### PR TITLE
Add styling option

### DIFF
--- a/assets/dist/controller.js
+++ b/assets/dist/controller.js
@@ -1,13 +1,12 @@
 import { Controller } from '@hotwired/stimulus';
-import DataTable from 'datatables.net-dt';
-
+import { getLoadedDataTablesStyleSheet } from "./functions/getLoadedDataTablesStyleSheet.js";
 class default_1 extends Controller {
     constructor() {
         super(...arguments);
         this.table = null;
         this.isDataTableInitialized = false;
     }
-    connect() {
+    async connect() {
         if (this.isDataTableInitialized) {
             return;
         }
@@ -18,9 +17,19 @@ class default_1 extends Controller {
         this.dispatchEvent('pre-connect', {
             config: payload,
         });
+        const stylesheet = getLoadedDataTablesStyleSheet();
+        const DataTable = await this.loadDataTableLibrary(stylesheet);
         this.table = new DataTable(this.element, payload);
         this.dispatchEvent('connect', { table: this.table });
         this.isDataTableInitialized = true;
+    }
+    async loadDataTableLibrary(stylesheet) {
+        if (stylesheet?.href?.includes('dataTables.bootstrap5')) {
+            return (await import('datatables.net-bs5')).default;
+        }
+        else {
+            return (await import('datatables.net-dt')).default;
+        }
     }
     dispatchEvent(name, payload) {
         this.dispatch(name, { detail: payload, prefix: 'datatables' });
@@ -29,5 +38,4 @@ class default_1 extends Controller {
 default_1.values = {
     view: Object,
 };
-
-export { default_1 as default };
+export default default_1;

--- a/assets/dist/functions/getLoadedDataTablesStyleSheet.js
+++ b/assets/dist/functions/getLoadedDataTablesStyleSheet.js
@@ -1,0 +1,12 @@
+export function getLoadedDataTablesStyleSheet() {
+    const cssFiles = [
+        'dataTables.dataTables',
+        'dataTables.bootstrap5',
+    ];
+    const loadedCSS = [...document.styleSheets].find(sheet => sheet.href && cssFiles.some(cssFile => sheet.href.includes(cssFile)));
+    if (!loadedCSS) {
+        console.warn('Warning: Required DataTables CSS file is not loaded.');
+        return null;
+    }
+    return loadedCSS;
+}

--- a/assets/package.json
+++ b/assets/package.json
@@ -13,21 +13,25 @@
                 "fetch": "eager",
                 "enabled": true,
                 "autoimport": {
-                    "datatables.net-dt/css/dataTables.dataTables.min.css": true
+                    "datatables.net-dt/css/dataTables.dataTables.min.css": true,
+                    "datatables.net-bs5/css/dataTables.bootstrap5.min.css": false
                 }
             }
         },
         "importmap": {
             "@hotwired/stimulus": "^3.0.0",
-            "datatables.net-dt": "^2.1.5"
+            "datatables.net-dt": "^2.1.5",
+            "datatables.net-bs5": "^2.1.5"
         }
     },
     "peerDependencies": {
         "@hotwired/stimulus": "^3.0.0",
-        "datatables.net-dt": "^2.1.5"
+        "datatables.net-dt": "^2.1.5",
+        "datatables.net-bs5": "^2.1.5"
     },
     "devDependencies": {
         "@hotwired/stimulus": "^3.0.0",
-        "datatables.net-dt": "^2.1.5"
+        "datatables.net-dt": "^2.1.5",
+        "datatables.net-bs5": "^2.1.5"
     }
 }

--- a/assets/src/controller.ts
+++ b/assets/src/controller.ts
@@ -1,5 +1,5 @@
 import { Controller } from '@hotwired/stimulus';
-import DataTable from 'datatables.net-dt';
+import {getLoadedDataTablesStyleSheet} from "./functions/getLoadedDataTablesStyleSheet";
 
 export default class extends Controller {
     declare readonly viewValue: any;
@@ -11,7 +11,7 @@ export default class extends Controller {
     private table: DataTable | null = null;
     private isDataTableInitialized = false;
 
-    connect() {
+    async connect() {
         if (this.isDataTableInitialized) {
             return;
         }
@@ -26,11 +26,23 @@ export default class extends Controller {
             config: payload,
         });
 
+        const stylesheet = getLoadedDataTablesStyleSheet();
+
+        const DataTable = await this.loadDataTableLibrary(stylesheet);
+
         this.table = new DataTable(this.element as HTMLElement, payload);
 
         this.dispatchEvent('connect', { table: this.table });
 
         this.isDataTableInitialized = true;
+    }
+
+    async loadDataTableLibrary(stylesheet?: CSSStyleSheet) {
+        if (stylesheet?.href?.includes('dataTables.bootstrap5')) {
+            return (await import('datatables.net-bs5')).default;
+        } else {
+            return (await import('datatables.net-dt')).default;
+        }
     }
 
     private dispatchEvent(name: string, payload: any) {

--- a/assets/src/functions/getLoadedDataTablesStyleSheet.ts
+++ b/assets/src/functions/getLoadedDataTablesStyleSheet.ts
@@ -1,0 +1,18 @@
+export function getLoadedDataTablesStyleSheet(): CSSStyleSheet | null {
+    const cssFiles = [
+        'dataTables.dataTables',
+        'dataTables.bootstrap5',
+    ];
+
+    const loadedCSS = [...document.styleSheets].find(sheet =>
+        sheet.href && cssFiles.some(cssFile => sheet.href.includes(cssFile))
+    );
+
+    if (!loadedCSS) {
+        console.warn('Warning: Required DataTables CSS file is not loaded.');
+
+        return null;
+    }
+
+    return loadedCSS;
+}

--- a/docs/options.md
+++ b/docs/options.md
@@ -142,3 +142,20 @@ $dataTable
 ```
 
 This example creates a DataTable with common options configured, including Ajax data loading, scrolling, and basic features enabled.
+
+## Styling DataTables
+
+In your ``assets/controllers.json`` file, you should see a line that automatically 
+includes a CSS file for DataTables which will give you basic styles.
+
+If you're using Bootstrap, set ``datatables.net-dt/css/dataTables.dataTables.min.css`` to false 
+and ``datatables.net-bs5/css/dataTables.bootstrap5.min.css`` to true:
+
+```json
+{
+    "autoimport": {
+        "datatables.net-dt/css/dataTables.dataTables.min.css": false,
+        "datatables.net-bs5/css/dataTables.bootstrap5.min.css": true
+    }
+}
+```

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "lib": ["dom", "es2015", "ESNext"],
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "noUnusedLocals": true,
+    "rootDir": "assets",
+    "strict": true,
+    "strictPropertyInitialization": false,
+    "target": "ES2021",
+    "removeComments": true,
+    "outDir": "assets/dist",
+    "baseUrl": ".",
+    "noEmit": false,
+    "declaration": false,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "jsx": "react",
+    "skipLibCheck": true
+  },
+  "exclude": ["assets/dist"]
+}


### PR DESCRIPTION
This PR introduces a new feature that adds a styling option.

The styling option allows the user to choose between different styling approaches, such as the default DataTables style or a Bootstrap 5-specific style.

```json
{
    "autoimport": {
        "datatables.net-dt/css/dataTables.dataTables.min.css": false,
        "datatables.net-bs5/css/dataTables.bootstrap5.min.css": true
    }
}
```