### PR TITLE
Add select extension

### DIFF
--- a/assets/dist/controller.js
+++ b/assets/dist/controller.js
@@ -1,5 +1,7 @@
 import { Controller } from '@hotwired/stimulus';
 import { getLoadedDataTablesStyleSheet } from "./functions/getLoadedDataTablesStyleSheet.js";
+import { loadDataTableLibrary } from "./functions/loadDataTableLibrary.js";
+import { loadSelectLibrary } from "./functions/loadSelectLibrary.js";
 class default_1 extends Controller {
     constructor() {
         super(...arguments);
@@ -18,21 +20,22 @@ class default_1 extends Controller {
             config: payload,
         });
         const stylesheet = getLoadedDataTablesStyleSheet();
-        const DataTable = await this.loadDataTableLibrary(stylesheet);
+        const DataTable = await loadDataTableLibrary(stylesheet);
+        if (this.isSelectExtensionEnabled(payload)) {
+            await loadSelectLibrary();
+        }
         this.table = new DataTable(this.element, payload);
         this.dispatchEvent('connect', { table: this.table });
         this.isDataTableInitialized = true;
     }
-    async loadDataTableLibrary(stylesheet) {
-        if (stylesheet?.href?.includes('dataTables.bootstrap5')) {
-            return (await import('datatables.net-bs5')).default;
-        }
-        else {
-            return (await import('datatables.net-dt')).default;
-        }
-    }
     dispatchEvent(name, payload) {
-        this.dispatch(name, { detail: payload, prefix: 'datatables' });
+        this.dispatch(name, {
+            detail: payload,
+            prefix: 'datatables'
+        });
+    }
+    isSelectExtensionEnabled(payload) {
+        return !!payload['select'];
     }
 }
 default_1.values = {

--- a/assets/dist/functions/loadDataTableLibrary.js
+++ b/assets/dist/functions/loadDataTableLibrary.js
@@ -1,0 +1,8 @@
+export async function loadDataTableLibrary(stylesheet) {
+    if (stylesheet?.href?.includes('dataTables.bootstrap5')) {
+        return (await import('datatables.net-bs5')).default;
+    }
+    else {
+        return (await import('datatables.net-dt')).default;
+    }
+}

--- a/assets/dist/functions/loadSelectLibrary.js
+++ b/assets/dist/functions/loadSelectLibrary.js
@@ -1,0 +1,8 @@
+export async function loadSelectLibrary(stylesheet) {
+    if (stylesheet?.href?.includes('dataTables.bootstrap5')) {
+        return (await import('datatables.net-select-bs5')).default;
+    }
+    else {
+        return (await import('datatables.net-select-dt')).default;
+    }
+}

--- a/assets/package.json
+++ b/assets/package.json
@@ -21,17 +21,23 @@
         "importmap": {
             "@hotwired/stimulus": "^3.0.0",
             "datatables.net-dt": "^2.2.2",
-            "datatables.net-bs5": "^2.2.2"
+            "datatables.net-bs5": "^2.2.2",
+            "datatables.net-select-dt": "^3.0.0",
+            "datatables.net-select-bs5": "^3.0.0"
         }
     },
     "peerDependencies": {
         "@hotwired/stimulus": "^3.0.0",
         "datatables.net-dt": "^2.2.2",
-        "datatables.net-bs5": "^2.2.2"
+        "datatables.net-bs5": "^2.2.2",
+        "datatables.net-select-dt": "^3.0.0",
+        "datatables.net-select-bs5": "^3.0.0"
     },
     "devDependencies": {
         "@hotwired/stimulus": "^3.0.0",
         "datatables.net-dt": "^2.2.2",
-        "datatables.net-bs5": "^2.2.2"
+        "datatables.net-bs5": "^2.2.2",
+        "datatables.net-select-dt": "^3.0.0",
+        "datatables.net-select-bs5": "^3.0.0"
     }
 }

--- a/assets/src/controller.ts
+++ b/assets/src/controller.ts
@@ -1,5 +1,7 @@
 import { Controller } from '@hotwired/stimulus';
 import {getLoadedDataTablesStyleSheet} from "./functions/getLoadedDataTablesStyleSheet";
+import {loadDataTableLibrary} from "./functions/loadDataTableLibrary";
+import {loadSelectLibrary} from "./functions/loadSelectLibrary";
 
 export default class extends Controller {
     declare readonly viewValue: any;
@@ -28,7 +30,11 @@ export default class extends Controller {
 
         const stylesheet = getLoadedDataTablesStyleSheet();
 
-        const DataTable = await this.loadDataTableLibrary(stylesheet);
+        const DataTable = await loadDataTableLibrary(stylesheet);
+
+        if (this.isSelectExtensionEnabled(payload)) {
+            await loadSelectLibrary();
+        }
 
         this.table = new DataTable(this.element as HTMLElement, payload);
 
@@ -37,15 +43,14 @@ export default class extends Controller {
         this.isDataTableInitialized = true;
     }
 
-    async loadDataTableLibrary(stylesheet?: CSSStyleSheet) {
-        if (stylesheet?.href?.includes('dataTables.bootstrap5')) {
-            return (await import('datatables.net-bs5')).default;
-        } else {
-            return (await import('datatables.net-dt')).default;
-        }
+    private dispatchEvent(name: string, payload: any) {
+        this.dispatch(name, {
+            detail: payload,
+            prefix: 'datatables'
+        });
     }
 
-    private dispatchEvent(name: string, payload: any) {
-        this.dispatch(name, { detail: payload, prefix: 'datatables' });
+    private isSelectExtensionEnabled(payload: Record<string, any>): boolean {
+        return !!payload['select'];
     }
 }

--- a/assets/src/functions/loadDataTableLibrary.ts
+++ b/assets/src/functions/loadDataTableLibrary.ts
@@ -1,0 +1,7 @@
+export async function loadDataTableLibrary(stylesheet?: CSSStyleSheet | null) {
+    if (stylesheet?.href?.includes('dataTables.bootstrap5')) {
+        return (await import('datatables.net-bs5')).default;
+    } else {
+        return (await import('datatables.net-dt')).default;
+    }
+}

--- a/assets/src/functions/loadSelectLibrary.ts
+++ b/assets/src/functions/loadSelectLibrary.ts
@@ -1,0 +1,7 @@
+export async function loadSelectLibrary(stylesheet?: CSSStyleSheet) {
+    if (stylesheet?.href?.includes('dataTables.bootstrap5')) {
+        return (await import('datatables.net-select-bs5')).default;
+    } else {
+        return (await import('datatables.net-select-dt')).default;
+    }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,15 +8,26 @@ data_tables:
     lengthMenu: [10, 25, 50]
     pageLength: 10
   template_parameters:
-    class: 'table table-bordered'
+    class: 'table'
+  extensions:
+    select:
+      style: single
 ```
+
 # Explanation of the options:
+
 **lengthMenu**: An array of values representing the number of rows to display per page. In this example, users can choose from 10, 25, or 50 rows per page.
 
 **pageLength**: The initial number of rows to display per page. In the example above, it is set to 10.
 
-**template_parameters**: An array of parameters to pass to the DataTables template. In this example, the class attribute is set to "table table-bordered".
+**template_parameters**: An array of parameters to pass to the DataTables template. In this example, the class attribute is set to "table".
 
 - **class**: The CSS class to apply to the generated DataTables table.
 
+**extensions**: An array defining additional extensions for DataTables.
+
+- **select**: Configuration for the select extension.
+    - **style**: Defines the selection style. In this case, it is set to "single". Can be "single" or "multi".
+
 These options allow you to customize the DataTables behavior directly from your configuration file.
+

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,0 +1,26 @@
+# Extensions
+
+## Select
+
+Select adds item selection capabilities to a DataTable. Items can be rows, columns, or cells, which can be selected independently or together.
+
+You can have more information about the Select extension [here](https://datatables.net/extensions/select/).
+
+### Usage
+
+To enable the Select extension, instantiate `SelectExtension` and add it to your DataTable:
+
+```php
+$selectExtension = new SelectExtension();
+$datatable = new DataTable('example');
+
+$datatable->extensions([$selectExtension]);
+```
+
+You can also specify a selection style:
+
+```php
+$selectExtension = new SelectExtension(SelectStyle::MULTI);
+$datatable = new DataTable('example');
+$datatable->extensions([$selectExtension]);
+```

--- a/src/Builder/DataTableBuilder.php
+++ b/src/Builder/DataTableBuilder.php
@@ -10,7 +10,8 @@ class DataTableBuilder implements DataTableBuilderInterface
 {
     public function __construct(
         public array $options = [],
-        public array $attributes = []
+        public array $attributes = [],
+        public array $extensions = [],
     ) {
     }
 
@@ -19,7 +20,8 @@ class DataTableBuilder implements DataTableBuilderInterface
         return new DataTable(
             id: $id,
             options: $this->options,
-            attributes: $this->attributes
+            attributes: $this->attributes,
+            extensions: $this->extensions
         );
     }
 }

--- a/src/DataTablesBundle.php
+++ b/src/DataTablesBundle.php
@@ -32,6 +32,14 @@ class DataTablesBundle extends AbstractBundle
                         ->scalarNode('class')->defaultValue('table')->end()
                     ->end()
                 ->end()
+                ->arrayNode('extensions')
+                    ->children()
+                        ->arrayNode('select')
+                            ->children()
+                                ->scalarNode('style')->defaultValue('single')->end()
+                             ->end()
+                         ->end()
+                    ->end()
             ->end()
         ;
     }
@@ -42,6 +50,7 @@ class DataTablesBundle extends AbstractBundle
             ->set('datatables.builder', DataTableBuilder::class)
             ->arg(0, $config['options'] ?? [])
             ->arg(1, $config['template_parameters'] ?? [])
+            ->arg(2, $config['extensions'] ?? [])
             ->private();
 
         $container->services()

--- a/src/Enum/SelectStyle.php
+++ b/src/Enum/SelectStyle.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Pentiminax\UX\DataTables\Enum;
+
+enum SelectStyle: string
+{
+    case SINGLE = 'single';
+    case MULTI = 'multi';
+}

--- a/src/Model/DataTable.php
+++ b/src/Model/DataTable.php
@@ -2,13 +2,19 @@
 
 namespace Pentiminax\UX\DataTables\Model;
 
+use Pentiminax\UX\DataTables\Model\Extensions\ExtensionInterface;
+
 class DataTable
 {
+    private DataTableExtensions $extensions;
+
     public function __construct(
         private readonly string $id,
         private array $options = [],
-        private array $attributes = []
-    ){
+        private array $attributes = [],
+        array $extensions = [],
+    ) {
+        $this->extensions = new DataTableExtensions($extensions);
     }
 
     public function getId(): ?string
@@ -258,5 +264,22 @@ class DataTable
         $this->options['pageLength'] = $pageLength;
 
         return $this;
+    }
+
+    /**
+     * @param ExtensionInterface[] $extensions
+     */
+    public function extensions(array $extensions): static
+    {
+        foreach ($extensions as $extension) {
+            $this->extensions->addExtension($extension);
+        }
+
+        return $this;
+    }
+
+    public function getExtensions(): array
+    {
+        return $this->extensions->toArray();
     }
 }

--- a/src/Model/DataTableExtensions.php
+++ b/src/Model/DataTableExtensions.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Pentiminax\UX\DataTables\Model;
+
+use Pentiminax\UX\DataTables\Model\Extensions\ExtensionInterface;
+
+class DataTableExtensions
+{
+    private array $extensions;
+
+    public function __construct(array $extensions = [])
+    {
+        $this->extensions = $extensions;
+
+    }
+
+    public function addExtension(ExtensionInterface $extension): void
+    {
+        $this->extensions['select'] = $extension->toArray();
+
+    }
+
+    public function toArray(): array
+    {
+        return $this->extensions;
+    }
+}

--- a/src/Model/Extensions/ExtensionInterface.php
+++ b/src/Model/Extensions/ExtensionInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Pentiminax\UX\DataTables\Model\Extensions;
+
+interface ExtensionInterface
+{
+    public function toArray(): array;
+}

--- a/src/Model/Extensions/SelectExtension.php
+++ b/src/Model/Extensions/SelectExtension.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Pentiminax\UX\DataTables\Model\Extensions;
+
+use Pentiminax\UX\DataTables\Enum\SelectStyle;
+
+class SelectExtension implements ExtensionInterface
+{
+    public function __construct(
+        private SelectStyle $style = SelectStyle::SINGLE
+    ) {
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'style' => $this->style->value
+        ];
+    }
+}

--- a/src/Twig/DataTablesExtension.php
+++ b/src/Twig/DataTablesExtension.php
@@ -33,7 +33,9 @@ class DataTablesExtension extends AbstractExtension
             $controllers[$table->getDataController()] = [];
         }
 
-        $controllers['@pentiminax/ux-datatables/datatable'] = ['view' => $table->getOptions()];
+        $controllers['@pentiminax/ux-datatables/datatable'] = [
+            'view' => array_merge($table->getOptions(), $table->getExtensions())
+        ];
 
         $stimulusAttributes = $this->stimulus->createStimulusAttributes();
         foreach ($controllers as $name => $controllerValues) {

--- a/tests/Model/DataTableTest.php
+++ b/tests/Model/DataTableTest.php
@@ -3,33 +3,40 @@
 namespace Pentiminax\UX\DataTables\Tests\Model;
 
 use Pentiminax\UX\DataTables\Model\DataTable;
+use Pentiminax\UX\DataTables\Model\Extensions\SelectExtension;
 use PHPUnit\Framework\TestCase;
 
 class DataTableTest extends TestCase
 {
     public function testDataTable(): void
     {
-        $table = new DataTable('tableId');
+        $selectExtension = new SelectExtension();
 
-        $table
-            ->autoWidth(true)
-            ->caption('Table caption')
-            ->deferRender(true)
-            ->info(true)
-            ->lengthChange(true)
-            ->ordering(true)
-            ->paging(true)
-            ->processing(true)
-            ->scrollX(true)
-            ->scrollY('200px')
-            ->searching(true)
-            ->serverSide(true)
-            ->stateSave(true)
-            ->pageLength(10)
-            ->lengthMenu([10, 25, 50])
-        ;
+        $table =
+            (new DataTable('tableId'))
+                ->autoWidth(true)
+                ->caption('Table caption')
+                ->deferRender(true)
+                ->info(true)
+                ->lengthChange(true)
+                ->ordering(true)
+                ->paging(true)
+                ->processing(true)
+                ->scrollX(true)
+                ->scrollY('200px')
+                ->searching(true)
+                ->serverSide(true)
+                ->stateSave(true)
+                ->pageLength(10)
+                ->lengthMenu([10, 25, 50])
+                ->extensions([$selectExtension]);
 
         $this->assertEquals('tableId', $table->getId());
 
+        $expectedExtensions = [
+            'select' => $selectExtension->toArray()
+        ];
+
+        $this->assertEquals($expectedExtensions, $table->getExtensions());
     }
 }

--- a/tests/Model/Extensions/SelectExtensionTest.php
+++ b/tests/Model/Extensions/SelectExtensionTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Pentiminax\UX\DataTables\Tests\Model\Extensions;
+
+use Pentiminax\UX\DataTables\Enum\SelectStyle;
+use Pentiminax\UX\DataTables\Model\Extensions\SelectExtension;
+use PHPUnit\Framework\TestCase;
+
+class SelectExtensionTest extends TestCase
+{
+    public function testToArray(): void
+    {
+        $extension = new SelectExtension();
+
+        $this->assertEquals(['style' => 'single'], $extension->toArray());
+    }
+
+    public function testStyle(): void
+    {
+        $extension = new SelectExtension(SelectStyle::MULTI);
+
+        $this->assertEquals(['style' => 'multi'], $extension->toArray());
+    }
+}


### PR DESCRIPTION
This PR updates the bundle to include support for DataTables extensions (https://datatables.net/extensions/index)

Specifically:

- Added support for the select extension with the style configuration (single or multi).