### PR TITLE
Update pdfmake and select libraries

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -27,12 +27,12 @@
             "datatables.net-buttons/js/buttons.html5": "^3.2.3",
             "datatables.net-buttons/js/buttons.print": "^3.2.3",
             "datatables.net-dt": "^2.3.1",
-            "datatables.net-select-bs5": "^3.0.0",
-            "datatables.net-select-dt": "^3.0.0",
+            "datatables.net-select-bs5": "^3.0.1",
+            "datatables.net-select-dt": "^3.0.1",
             "datatables.net-responsive-bs5": "^3.0.4",
             "datatables.net-responsive-dt": "^3.0.4",
             "jszip": "^3.10.1",
-            "pdfmake": "^0.2.19",
+            "pdfmake": "^0.2.20",
             "pdfmake/build/vfs_fonts": "^0.2.18"
         }
     },
@@ -45,12 +45,12 @@
         "datatables.net-buttons/js/buttons.html5": "^3.2.3",
         "datatables.net-buttons/js/buttons.print": "^3.2.3",
         "datatables.net-dt": "^2.3.1",
-        "datatables.net-select-bs5": "^3.0.0",
-        "datatables.net-select-dt": "^3.0.0",
+        "datatables.net-select-bs5": "^3.0.1",
+        "datatables.net-select-dt": "^3.0.1",
         "datatables.net-responsive-bs5": "^3.0.4",
         "datatables.net-responsive-dt": "^3.0.4",
         "jszip": "^3.10.1",
-        "pdfmake": "^0.2.19",
+        "pdfmake": "^0.2.20",
         "pdfmake/build/vfs_fonts": "^0.2.18"
     },
     "devDependencies": {
@@ -62,12 +62,12 @@
         "datatables.net-buttons/js/buttons.html5": "^3.2.3",
         "datatables.net-buttons/js/buttons.print": "^3.2.3",
         "datatables.net-dt": "^2.3.1",
-        "datatables.net-select-bs5": "^3.0.0",
-        "datatables.net-select-dt": "^3.0.0",
+        "datatables.net-select-bs5": "^3.0.1",
+        "datatables.net-select-dt": "^3.0.1",
         "datatables.net-responsive-bs5": "^3.0.4",
         "datatables.net-responsive-dt": "^3.0.4",
         "jszip": "^3.10.1",
-        "pdfmake": "^0.2.19",
+        "pdfmake": "^0.2.20",
         "pdfmake/build/vfs_fonts": "^0.2.18"
     }
 }


### PR DESCRIPTION
## Summary
- bump `pdfmake` to `0.2.20`
- bump `datatables.net-select-dt` and `datatables.net-select-bs5` to `3.0.1`

## Testing
- `npm install` *(fails: EINVALIDPACKAGENAME)*

------
https://chatgpt.com/codex/tasks/task_e_684195efa540832aafd4593ccfce6278