### PR TITLE
improve(doc): add missing data keys in usage doc

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -92,10 +92,10 @@ export default class extends Controller {
         // For instance you can listen to additional events
         event.detail.table.on('init', (event) => {
             /* ... */
-        };
+        });
         event.detail.table.on('draw', (event) => {
             /* ... */
-        };
+        });
     }
 }
 ```


### PR DESCRIPTION
When data keys are missing, the following error is present :

Using without keys : 

```php
// ...
use Pentiminax\UX\DataTables\Builder\DataTableBuilderInterface;
use Pentiminax\UX\DataTables\Model\DataTable;
use Pentiminax\UX\DataTables\Column\TextColumn;

class HomeController extends AbstractController
{
    #[Route('/', name: 'app_homepage')]
    public function index(DataTableBuilderInterface $builder): Response
    {
        $table = $builder
            ->createDataTable('usersTable')
            ->columns([
                TextColumn::new('firstName', 'First name'),
                TextColumn::new('lastName', 'Last name'),
            ])
            ->data([
                ['John', 'Doe'],
                ['Jane', 'Smith'],
            ]);

        return $this->render('home/index.html.twig', [
            'table' => $table,
        ]);
    }
}
```

Error in web browser :

```
DataTables warning: table id=usersTable - Requested unknown parameter 'firstName' for row 0, column 0. For more information about this error, please see https://datatables.net/tn/4
```