### PR TITLE
Fix dark theme palette in docs

### DIFF
--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -18,14 +18,14 @@
   --sl-color-accent-low: #1a365d;
   --sl-color-accent: #4299e1;
   --sl-color-accent-high: #90cdf4;
-  --sl-color-white: #17202a;
-  --sl-color-gray-1: #232d38;
-  --sl-color-gray-2: #3a4a5a;
-  --sl-color-gray-3: #5a6f84;
-  --sl-color-gray-4: #8fa2b7;
-  --sl-color-gray-5: #c3ceda;
-  --sl-color-gray-6: #eef2f6;
-  --sl-color-black: #fff;
+  --sl-color-white: #f8fafc;
+  --sl-color-gray-1: #e2e8f0;
+  --sl-color-gray-2: #cbd5e1;
+  --sl-color-gray-3: #94a3b8;
+  --sl-color-gray-4: #64748b;
+  --sl-color-gray-5: #334155;
+  --sl-color-gray-6: #0f172a;
+  --sl-color-black: #0b141d;
 }
 
 /* Hero section styling */


### PR DESCRIPTION
### Motivation

- Restore readable contrast in the Astro/Starlight dark theme used by the documentation.
- Fix inverted/incorrect color token values that produced poor background/text contrast.
- Keep the docs theme color tokens consistent between light and dark variants.

### Description

- Updated the color token values in `docs/src/styles/custom.css` under `:root[data-theme='dark']` to a proper dark palette.
- Replaced the previous inverted tokens with darker background values (`--sl-color-gray-6`, `--sl-color-black`) and lighter text tokens (`--sl-color-white`, `--sl-color-gray-1`).
- No other source files were modified.

### Testing

- Ran `npm install` in the `docs` folder successfully.
- Launched the dev server with `npm run dev` and confirmed the site served without errors.
- Executed an automated Playwright step that set `localStorage` to `starlight-theme = dark` and captured a screenshot to verify the visual fix (artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69640449d6a0832a88a1c1eb10f82dcc)