### PR TITLE
Move DataTables controller to wrapper target

### DIFF
--- a/assets/src/controller.ts
+++ b/assets/src/controller.ts
@@ -11,20 +11,23 @@ import {deleteRow} from "./functions/delete";
 
 export default class extends Controller {
     declare readonly viewValue: any;
+    declare readonly tableTarget: HTMLTableElement;
 
     static readonly values = {
         view: Object,
     };
 
+    static readonly targets = ['table'];
+
     private table: DataTable | null = null;
     private isDataTableInitialized = false;
 
     async connect() {
-        if (this.isDataTableInitialized) {
+        if (this.isDataTableInitialized || this.element.dataset.datatablesInitialized === 'true') {
             return;
         }
 
-        if (!(this.element instanceof HTMLTableElement)) {
+        if (!(this.tableTarget instanceof HTMLTableElement)) {
             throw new Error('Invalid element');
         }
 
@@ -89,7 +92,7 @@ export default class extends Controller {
             }
         });
 
-        this.table = new DataTable(this.element as HTMLElement, payload);
+        this.table = new DataTable(this.tableTarget as HTMLElement, payload);
 
         this.dispatchEvent('connect', {table: this.table});
 
@@ -113,6 +116,7 @@ export default class extends Controller {
         });
 
         this.isDataTableInitialized = true;
+        this.element.dataset.datatablesInitialized = 'true';
     }
 
     private dispatchEvent(name: string, payload: any) {

--- a/docs/src/content/docs/guide/extensions.mdx
+++ b/docs/src/content/docs/guide/extensions.mdx
@@ -166,6 +166,11 @@ $dataTable->scrollY('400px');
   Scroller is ideal for tables with thousands of rows. It only renders visible rows, dramatically improving performance.
 </Aside>
 
+<Aside type="note">
+  When using the Scroller extension, attach the DataTables Stimulus controller to a wrapper element and keep the
+  actual <table> as a target. This avoids duplicate Stimulus connections when Scroller clones the table.
+</Aside>
+
 ## Combining Extensions
 
 Use multiple extensions together:

--- a/src/Twig/DataTablesExtension.php
+++ b/src/Twig/DataTablesExtension.php
@@ -45,18 +45,26 @@ class DataTablesExtension extends AbstractExtension
             $stimulusAttributes->addController($name, $controllerValues);
         }
 
+        $tableAttributes = [];
         foreach ($table->getAttributes() as $name => $value) {
             if ('data-controller' === $name) {
                 continue;
             }
 
             if (true === $value) {
-                $stimulusAttributes->addAttribute($name, $name);
+                $tableAttributes[] = \sprintf('%s="%s"', $name, $name);
             } elseif (false !== $value) {
-                $stimulusAttributes->addAttribute($name, $value);
+                $tableAttributes[] = \sprintf('%s="%s"', $name, $value);
             }
         }
 
-        return \sprintf('<table id="%s" %s></table>', $table->getId(), $stimulusAttributes);
+        $tableAttributesString = $tableAttributes ? ' ' . \implode(' ', $tableAttributes) : '';
+
+        return \sprintf(
+            '<div %s><table id="%s" data-datatables-target="table"%s></table></div>',
+            $stimulusAttributes,
+            $table->getId(),
+            $tableAttributesString
+        );
     }
 }


### PR DESCRIPTION
### Motivation

- Prevent duplicate Stimulus controller initializations when DataTables Scroller clones the `<table>` by moving the controller off the table element and into a wrapper.  
- Initialize the DataTable from an explicit target so the controller is not attached to cloned table nodes.  
- Add a secondary guard to avoid re-initialization if the controller remains on a table in some templates.  

### Description

- Add a `table` Stimulus target (`static targets = ['table']`) and a `tableTarget` declaration in `assets/src/controller.ts`, and initialize `DataTable` using `this.tableTarget` instead of `this.element`.  
- Add an initialization guard that checks `this.element.dataset.datatablesInitialized === 'true'` and set `this.element.dataset.datatablesInitialized = 'true'` after successful initialization.  
- Change the Twig helper (`src/Twig/DataTablesExtension.php`) to render the Stimulus controller on a wrapper `<div>` and mark the actual table with `data-datatables-target="table"`, while preserving other table attributes on the `<table>`.  
- Document the recommended placement in `docs/src/content/docs/guide/extensions.mdx` to advise attaching the controller to a wrapper when using the Scroller extension.  

### Testing

- No automated tests were run for these changes.  
- Static/type checks or build were not executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69650eadb310832abe696166854b5cfe)