### PR TITLE
Add TemplateColumn for Twig-based cell rendering

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   "require-dev": {
     "api-platform/core": "^3.0 || ^4.0",
     "doctrine/orm": "^3.0",
-    "friendsofphp/php-cs-fixer": "^3.89",
+    "friendsofphp/php-cs-fixer": "^3.94",
     "phpunit/phpunit": "^11.5",
     "symfony/framework-bundle": "^7.0 || ^8.0",
     "symfony/phpunit-bridge": "^7.0 || ^8.0",

--- a/docs/src/content/docs/guide/columns.mdx
+++ b/docs/src/content/docs/guide/columns.mdx
@@ -131,6 +131,36 @@ $column = TextColumn::new('email', 'Email')
     }');
 ```
 
+### TemplateColumn (Twig)
+
+Use `TemplateColumn` when you want to render server-side HTML with Twig:
+
+```php
+use Pentiminax\UX\DataTables\Column\TemplateColumn;
+
+TemplateColumn::new('status_display', 'Status')
+    ->setField('status')
+    ->setTemplate('datatable/columns/user_status.html.twig');
+```
+
+Template context:
+
+- `entity`: original row object/array
+- `value`: value resolved from `field`
+- `column`: serialized column configuration
+- `row`: mapped row before template substitution
+
+Example template:
+
+```twig
+{# templates/datatable/columns/user_status.html.twig #}
+<span class="badge bg-{{ value == 'active' ? 'success' : 'danger' }}">
+    {{ value|capitalize }}
+</span>
+```
+
+`TemplateColumn` works with both server-side responses and client-side inline data (`->data([...])`).
+
 ### Export Control
 
 ```php

--- a/docs/src/content/docs/guide/columns.mdx
+++ b/docs/src/content/docs/guide/columns.mdx
@@ -145,10 +145,10 @@ TemplateColumn::new('status_display', 'Status')
 
 Template context:
 
-- `entity`: original row object/array
-- `value`: value resolved from `field`
+- `entity`: the mapped row/entity object
+- `data`: the resolved field value
 - `column`: serialized column configuration
-- `row`: mapped row before template substitution
+- `row`: the original row array
 
 Example template:
 

--- a/src/Column/TemplateColumn.php
+++ b/src/Column/TemplateColumn.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Pentiminax\UX\DataTables\Column;
+
+use Pentiminax\UX\DataTables\Enum\ColumnType;
+
+class TemplateColumn extends AbstractColumn
+{
+    public const OPTION_TEMPLATE_PATH = 'templatePath';
+
+    public static function new(string $name, string $title = ''): static
+    {
+        return static::createWithType($name, $title, ColumnType::HTML);
+    }
+
+    public function setTemplate(string $template): static
+    {
+        $template = trim($template);
+        if ('' === $template) {
+            throw new \InvalidArgumentException('Template path cannot be empty.');
+        }
+
+        $this->setCustomOption(self::OPTION_TEMPLATE_PATH, $template);
+
+        return $this;
+    }
+
+    public function getTemplate(): string
+    {
+        $template = $this->getCustomOption(self::OPTION_TEMPLATE_PATH);
+        if (!\is_string($template) || '' === trim($template)) {
+            throw new \LogicException(\sprintf('Template path is not configured for column "%s".', $this->getName()));
+        }
+
+        return $template;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return array_merge(
+            parent::jsonSerialize(),
+            [self::OPTION_TEMPLATE_PATH => $this->getTemplate()]
+        );
+    }
+}

--- a/src/Column/TemplateColumnRenderer.php
+++ b/src/Column/TemplateColumnRenderer.php
@@ -1,0 +1,277 @@
+<?php
+
+namespace Pentiminax\UX\DataTables\Column;
+
+use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
+use Twig\Environment;
+
+final class TemplateColumnRenderer
+{
+    public function __construct(
+        private readonly ?Environment $twig = null,
+    ) {
+    }
+
+    /**
+     * @param iterable<ColumnInterface> $columns
+     */
+    public function renderRow(array $row, mixed $entity, iterable $columns): array
+    {
+        $renderedRow = $row;
+        $contextRow  = $row;
+
+        foreach ($columns as $column) {
+            if (!$column instanceof TemplateColumn) {
+                continue;
+            }
+
+            $outputKey = $this->resolveOutputKey($column->getData(), $column->getName());
+            if (null === $outputKey) {
+                continue;
+            }
+
+            $field = $this->resolveOutputKey($column->getField(), $outputKey) ?? $outputKey;
+            $value = $this->resolveValue(entity: $entity, row: $contextRow, field: $field, outputKey: $outputKey);
+
+            $renderedRow[$outputKey] = $this->renderTemplate($column->getTemplate(), [
+                'entity' => $entity,
+                'value'  => $value,
+                'column' => $column->jsonSerialize(),
+                'row'    => $contextRow,
+            ]);
+        }
+
+        return $renderedRow;
+    }
+
+    /**
+     * @param array<int, mixed> $rows
+     * @param array<int, mixed> $columns
+     *
+     * @return array<int, mixed>
+     */
+    public function renderInlineData(array $rows, array $columns): array
+    {
+        $templateColumns = $this->resolveTemplateColumns($columns);
+        if ([] === $templateColumns) {
+            return $rows;
+        }
+
+        foreach ($rows as $index => $row) {
+            $arrayRow = $this->normalizeRow($row);
+            if (null === $arrayRow) {
+                continue;
+            }
+
+            $rows[$index] = $this->renderInlineRow($arrayRow, $row, $templateColumns);
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param array<int, array{template:string, field:string, outputKey:string, column:array<string, mixed>}> $templateColumns
+     */
+    private function renderInlineRow(array $row, mixed $entity, array $templateColumns): array
+    {
+        $renderedRow = $row;
+        $contextRow  = $row;
+
+        foreach ($templateColumns as $templateColumn) {
+            $value = $this->resolveValue(
+                entity: $entity,
+                row: $contextRow,
+                field: $templateColumn['field'],
+                outputKey: $templateColumn['outputKey']
+            );
+
+            $renderedRow[$templateColumn['outputKey']] = $this->renderTemplate($templateColumn['template'], [
+                'entity' => $entity,
+                'value'  => $value,
+                'column' => $templateColumn['column'],
+                'row'    => $contextRow,
+            ]);
+        }
+
+        return $renderedRow;
+    }
+
+    /**
+     * @param array<int, mixed> $columns
+     *
+     * @return array<int, array{template:string, field:string, outputKey:string, column:array<string, mixed>}>
+     */
+    private function resolveTemplateColumns(array $columns): array
+    {
+        $templateColumns = [];
+
+        foreach ($columns as $column) {
+            if (!\is_array($column)) {
+                continue;
+            }
+
+            $template = $column[TemplateColumn::OPTION_TEMPLATE_PATH] ?? null;
+            if (!\is_string($template)) {
+                continue;
+            }
+
+            $template = trim($template);
+            if ('' === $template) {
+                throw new \InvalidArgumentException('Template path cannot be empty.');
+            }
+
+            $outputKey = $this->resolveOutputKey(
+                \is_string($column['data'] ?? null) ? $column['data'] : null,
+                \is_string($column['name'] ?? null) ? $column['name'] : null
+            );
+            if (null === $outputKey) {
+                continue;
+            }
+
+            $field = $this->resolveOutputKey(
+                \is_string($column['field'] ?? null) ? $column['field'] : null,
+                $outputKey
+            ) ?? $outputKey;
+
+            $templateColumns[] = [
+                'template'  => $template,
+                'field'     => $field,
+                'outputKey' => $outputKey,
+                'column'    => $column,
+            ];
+        }
+
+        return $templateColumns;
+    }
+
+    private function renderTemplate(string $template, array $context): string
+    {
+        if (null === $this->twig) {
+            throw new \LogicException('Twig Environment is required to render TemplateColumn cells.');
+        }
+
+        return $this->twig->render($template, $context);
+    }
+
+    private function resolveValue(mixed $entity, array $row, string $field, string $outputKey): mixed
+    {
+        $value = $this->readPath($entity, $field);
+        if (null !== $value) {
+            return $value;
+        }
+
+        $value = $this->readPath($row, $field);
+        if (null !== $value) {
+            return $value;
+        }
+
+        $value = $this->readPath($row, $outputKey);
+        if (null !== $value) {
+            return $value;
+        }
+
+        return $this->readPath($entity, $outputKey);
+    }
+
+    private function resolveOutputKey(?string $preferred, ?string $fallback): ?string
+    {
+        foreach ([$preferred, $fallback] as $candidate) {
+            if (!\is_string($candidate)) {
+                continue;
+            }
+
+            $candidate = trim($candidate);
+            if ('' !== $candidate) {
+                return $candidate;
+            }
+        }
+
+        return null;
+    }
+
+    private function normalizeRow(mixed $row): ?array
+    {
+        if (\is_array($row)) {
+            return $row;
+        }
+
+        if ($row instanceof \JsonSerializable) {
+            $serialized = $row->jsonSerialize();
+            if (\is_array($serialized)) {
+                return $serialized;
+            }
+        }
+
+        if (\is_object($row)) {
+            return get_object_vars($row);
+        }
+
+        return null;
+    }
+
+    private function readPath(mixed $value, string $path): mixed
+    {
+        if ('' === $path) {
+            return null;
+        }
+
+        foreach (explode('.', $path) as $segment) {
+            if (\is_array($value)) {
+                if (!\array_key_exists($segment, $value)) {
+                    return null;
+                }
+
+                $value = $value[$segment];
+                continue;
+            }
+
+            if (\is_object($value)) {
+                $value = $this->readObjectValue($value, $segment);
+                continue;
+            }
+
+            return null;
+        }
+
+        return $value;
+    }
+
+    private function readObjectValue(object $object, string $property): mixed
+    {
+        if (\is_callable([$object, $property])) {
+            return $object->$property();
+        }
+
+        $accessor = $this->buildAccessorSuffix($property);
+        foreach (['get', 'is', 'has'] as $prefix) {
+            $method = $prefix.$accessor;
+            if (\is_callable([$object, $method])) {
+                $value = $object->$method();
+                if (\is_object($value) && $value instanceof \Stringable) {
+                    return (string) $value;
+                }
+
+                return $value;
+            }
+        }
+
+        if (property_exists($object, $property)) {
+            $reflection = new \ReflectionObject($object);
+            if (!$reflection->hasProperty($property) || $reflection->getProperty($property)->isPublic()) {
+                return $object->$property;
+            }
+        }
+
+        return null;
+    }
+
+    private function buildAccessorSuffix(string $property): string
+    {
+        if (str_contains($property, '_') || str_contains($property, '-')) {
+            $property = str_replace(['-', '_'], ' ', $property);
+            $property = str_replace(' ', '', ucwords($property));
+        }
+
+        return ucfirst($property);
+    }
+}

--- a/src/Column/TemplateColumnRenderer.php
+++ b/src/Column/TemplateColumnRenderer.php
@@ -3,7 +3,7 @@
 namespace Pentiminax\UX\DataTables\Column;
 
 use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
-use Pentiminax\UX\DataTables\PropertyReader;
+use Pentiminax\UX\DataTables\Util\PropertyReader;
 use Twig\Environment;
 
 final class TemplateColumnRenderer

--- a/src/Column/TemplateColumnRenderer.php
+++ b/src/Column/TemplateColumnRenderer.php
@@ -26,11 +26,11 @@ final class TemplateColumnRenderer
             }
 
             $field = $column->getField();
-            $value = $this->resolveValue(mappedRow: $mappedRow, row: $contextRow, field: $field);
+            $data  = $this->resolveData(mappedRow: $mappedRow, row: $contextRow, field: $field);
 
             $renderedRow[$field] = $this->renderTemplate($column->getTemplate(), [
                 'entity' => $mappedRow,
-                'data'   => $value,
+                'data'   => $data,
                 'column' => $column->jsonSerialize(),
                 'row'    => $contextRow,
             ]);
@@ -48,7 +48,7 @@ final class TemplateColumnRenderer
         return $this->twig->render($template, $context);
     }
 
-    private function resolveValue(mixed $mappedRow, array $row, string $field): mixed
+    private function resolveData(mixed $mappedRow, array $row, string $field): mixed
     {
         $value = $this->readPath($row, $field);
         if (null !== $value) {
@@ -66,7 +66,7 @@ final class TemplateColumnRenderer
 
         foreach (explode('.', $path) as $segment) {
             if (\is_array($value)) {
-                if (!\array_key_exists($segment, $value)) {
+                if (!isset($value[$segment])) {
                     return null;
                 }
 

--- a/src/Column/TemplateColumnRenderer.php
+++ b/src/Column/TemplateColumnRenderer.php
@@ -30,112 +30,13 @@ final class TemplateColumnRenderer
 
             $renderedRow[$outputKey] = $this->renderTemplate($column->getTemplate(), [
                 'entity' => $mappedRow,
-                'data'  => $value,
+                'data'   => $value,
                 'column' => $column->jsonSerialize(),
                 'row'    => $contextRow,
             ]);
         }
 
         return $renderedRow;
-    }
-
-    /**
-     * @param array<int, mixed> $rows
-     * @param array<int, mixed> $columns
-     *
-     * @return array<int, mixed>
-     */
-    public function renderInlineData(array $rows, array $columns): array
-    {
-        $templateColumns = $this->resolveTemplateColumns($columns);
-        if ([] === $templateColumns) {
-            return $rows;
-        }
-
-        foreach ($rows as $index => $row) {
-            $arrayRow = $this->normalizeRow($row);
-            if (null === $arrayRow) {
-                continue;
-            }
-
-            $rows[$index] = $this->renderInlineRow($arrayRow, $row, $templateColumns);
-        }
-
-        return $rows;
-    }
-
-    /**
-     * @param array<int, array{template:string, field:string, outputKey:string, column:array<string, mixed>}> $templateColumns
-     */
-    private function renderInlineRow(array $row, mixed $entity, array $templateColumns): array
-    {
-        $renderedRow = $row;
-        $contextRow  = $row;
-
-        foreach ($templateColumns as $templateColumn) {
-            $value = $this->resolveValue(
-                mappedRow: $entity,
-                row: $contextRow,
-                outputKey: $templateColumn['outputKey']
-            );
-
-            $renderedRow[$templateColumn['outputKey']] = $this->renderTemplate($templateColumn['template'], [
-                'entity' => $entity,
-                'value'  => $value,
-                'column' => $templateColumn['column'],
-                'row'    => $contextRow,
-            ]);
-        }
-
-        return $renderedRow;
-    }
-
-    /**
-     * @param array<int, mixed> $columns
-     *
-     * @return array<int, array{template:string, field:string, outputKey:string, column:array<string, mixed>}>
-     */
-    private function resolveTemplateColumns(array $columns): array
-    {
-        $templateColumns = [];
-
-        foreach ($columns as $column) {
-            if (!\is_array($column)) {
-                continue;
-            }
-
-            $template = $column[TemplateColumn::OPTION_TEMPLATE_PATH] ?? null;
-            if (!\is_string($template)) {
-                continue;
-            }
-
-            $template = trim($template);
-            if ('' === $template) {
-                throw new \InvalidArgumentException('Template path cannot be empty.');
-            }
-
-            $outputKey = $this->resolveOutputKey(
-                \is_string($column['data'] ?? null) ? $column['data'] : null,
-                \is_string($column['name'] ?? null) ? $column['name'] : null
-            );
-            if (null === $outputKey) {
-                continue;
-            }
-
-            $field = $this->resolveOutputKey(
-                \is_string($column['field'] ?? null) ? $column['field'] : null,
-                $outputKey
-            ) ?? $outputKey;
-
-            $templateColumns[] = [
-                'template'  => $template,
-                'field'     => $field,
-                'outputKey' => $outputKey,
-                'column'    => $column,
-            ];
-        }
-
-        return $templateColumns;
     }
 
     private function renderTemplate(string $template, array $context): string
@@ -155,42 +56,6 @@ final class TemplateColumnRenderer
         }
 
         return $this->readPath($mappedRow, $outputKey);
-    }
-
-    private function resolveOutputKey(?string $preferred, ?string $fallback): ?string
-    {
-        foreach ([$preferred, $fallback] as $candidate) {
-            if (!\is_string($candidate)) {
-                continue;
-            }
-
-            $candidate = trim($candidate);
-            if ('' !== $candidate) {
-                return $candidate;
-            }
-        }
-
-        return null;
-    }
-
-    private function normalizeRow(mixed $row): ?array
-    {
-        if (\is_array($row)) {
-            return $row;
-        }
-
-        if ($row instanceof \JsonSerializable) {
-            $serialized = $row->jsonSerialize();
-            if (\is_array($serialized)) {
-                return $serialized;
-            }
-        }
-
-        if (\is_object($row)) {
-            return get_object_vars($row);
-        }
-
-        return null;
     }
 
     private function readPath(mixed $value, string $path): mixed

--- a/src/Column/TemplateColumnRenderer.php
+++ b/src/Column/TemplateColumnRenderer.php
@@ -25,10 +25,10 @@ final class TemplateColumnRenderer
                 continue;
             }
 
-            $outputKey = $column->getField();
-            $value     = $this->resolveValue(mappedRow: $mappedRow, row: $contextRow, outputKey: $outputKey);
+            $field = $column->getField();
+            $value = $this->resolveValue(mappedRow: $mappedRow, row: $contextRow, field: $field);
 
-            $renderedRow[$outputKey] = $this->renderTemplate($column->getTemplate(), [
+            $renderedRow[$field] = $this->renderTemplate($column->getTemplate(), [
                 'entity' => $mappedRow,
                 'data'   => $value,
                 'column' => $column->jsonSerialize(),
@@ -48,14 +48,14 @@ final class TemplateColumnRenderer
         return $this->twig->render($template, $context);
     }
 
-    private function resolveValue(mixed $mappedRow, array $row, string $outputKey): mixed
+    private function resolveValue(mixed $mappedRow, array $row, string $field): mixed
     {
-        $value = $this->readPath($row, $outputKey);
+        $value = $this->readPath($row, $field);
         if (null !== $value) {
             return $value;
         }
 
-        return $this->readPath($mappedRow, $outputKey);
+        return $this->readPath($mappedRow, $field);
     }
 
     private function readPath(mixed $value, string $path): mixed

--- a/src/DataTablesBundle.php
+++ b/src/DataTablesBundle.php
@@ -13,6 +13,7 @@ use Pentiminax\UX\DataTables\Builder\DataTableResponseBuilder;
 use Pentiminax\UX\DataTables\Builder\DataTableResponseBuilderInterface;
 use Pentiminax\UX\DataTables\Column\AttributeColumnReader;
 use Pentiminax\UX\DataTables\Column\PropertyTypeMapper;
+use Pentiminax\UX\DataTables\Column\TemplateColumnRenderer;
 use Pentiminax\UX\DataTables\Column\UrlColumnResolver;
 use Pentiminax\UX\DataTables\Contracts\ApiResourceCollectionUrlResolverInterface;
 use Pentiminax\UX\DataTables\Contracts\ColumnAutoDetectorInterface;
@@ -94,8 +95,18 @@ class DataTablesBundle extends AbstractBundle
             ->private();
 
         $container->services()
+            ->set('datatables.column.template_column_renderer', TemplateColumnRenderer::class)
+            ->arg(0, service('twig')->nullOnInvalid())
+            ->private();
+
+        $container->services()
+            ->alias(TemplateColumnRenderer::class, 'datatables.column.template_column_renderer')
+            ->private();
+
+        $container->services()
             ->set('datatables.twig_extension', Twig\DataTablesExtension::class)
             ->arg(0, new Reference('stimulus.helper'))
+            ->arg(1, service('datatables.column.template_column_renderer'))
             ->tag('twig.extension')
             ->private();
 

--- a/src/Model/AbstractDataTable.php
+++ b/src/Model/AbstractDataTable.php
@@ -350,7 +350,7 @@ abstract class AbstractDataTable implements DataTableInterface
 
                 return $this->templateColumnRenderer->renderRow(
                     row: $mappedRow,
-                    entity: $row,
+                    mappedRow: $row,
                     columns: $this->columns
                 );
             }

--- a/src/Model/AbstractDataTable.php
+++ b/src/Model/AbstractDataTable.php
@@ -9,6 +9,7 @@ use Pentiminax\UX\DataTables\Builder\DataTableResponseBuilder;
 use Pentiminax\UX\DataTables\Column\AbstractColumn;
 use Pentiminax\UX\DataTables\Column\AttributeColumnReader;
 use Pentiminax\UX\DataTables\Column\BooleanColumn;
+use Pentiminax\UX\DataTables\Column\TemplateColumnRenderer;
 use Pentiminax\UX\DataTables\Column\UrlColumnResolver;
 use Pentiminax\UX\DataTables\Contracts\ApiResourceCollectionUrlResolverInterface;
 use Pentiminax\UX\DataTables\Contracts\ColumnAutoDetectorInterface;
@@ -57,6 +58,7 @@ abstract class AbstractDataTable implements DataTableInterface
         protected ?ApiResourceCollectionUrlResolverInterface $apiResourceCollectionUrlResolver = null,
         protected ?AttributeColumnReader $attributeColumnReader = null,
         protected ?UrlColumnResolver $urlColumnResolver = null,
+        protected ?TemplateColumnRenderer $templateColumnRenderer = null,
     ) {
         $this->table = $this->configureDataTable(
             new DataTable($this->getClassName())
@@ -242,6 +244,7 @@ abstract class AbstractDataTable implements DataTableInterface
         $data   = iterator_to_array($result->data);
 
         $this->table->data($data);
+        $this->table->markTemplateColumnsRendered();
 
         return $result;
     }
@@ -339,7 +342,18 @@ abstract class AbstractDataTable implements DataTableInterface
     protected function rowMapper(): RowMapperInterface
     {
         return new ClosureRowMapper(
-            $this->mapRow(...)
+            function (mixed $row): array {
+                $mappedRow = $this->mapRow($row);
+                if (null === $this->templateColumnRenderer) {
+                    return $mappedRow;
+                }
+
+                return $this->templateColumnRenderer->renderRow(
+                    row: $mappedRow,
+                    entity: $row,
+                    columns: $this->columns
+                );
+            }
         );
     }
 

--- a/src/Model/DataTable.php
+++ b/src/Model/DataTable.php
@@ -426,6 +426,14 @@ class DataTable
         return $this->options['columns'] ?? [];
     }
 
+    /**
+     * @return ColumnInterface[]
+     */
+    public function getColumnObjects(): array
+    {
+        return $this->columns;
+    }
+
     public function markTemplateColumnsRendered(bool $rendered = true): static
     {
         $this->templateColumnsRendered = $rendered;

--- a/src/Model/DataTable.php
+++ b/src/Model/DataTable.php
@@ -20,6 +20,8 @@ class DataTable
 
     private DataTableExtensions $extensions;
 
+    private bool $templateColumnsRendered = false;
+
     public function __construct(
         private readonly string $id,
         array $options = [],
@@ -422,6 +424,18 @@ class DataTable
     public function getColumns(): array
     {
         return $this->options['columns'] ?? [];
+    }
+
+    public function markTemplateColumnsRendered(bool $rendered = true): static
+    {
+        $this->templateColumnsRendered = $rendered;
+
+        return $this;
+    }
+
+    public function areTemplateColumnsRendered(): bool
+    {
+        return $this->templateColumnsRendered;
     }
 
     public function isServerSide(): bool

--- a/src/PropertyReader.php
+++ b/src/PropertyReader.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Pentiminax\UX\DataTables;
+
+final class PropertyReader
+{
+    public static function readPath(mixed $value, string $path): mixed
+    {
+        if ('' === $path) {
+            return null;
+        }
+
+        foreach (explode('.', $path) as $segment) {
+            if (\is_array($value)) {
+                if (!isset($value[$segment])) {
+                    return null;
+                }
+
+                $value = $value[$segment];
+                continue;
+            }
+
+            if (\is_object($value)) {
+                $value = self::readObjectValue($value, $segment);
+                continue;
+            }
+
+            return null;
+        }
+
+        return $value;
+    }
+
+    public static function readObjectValue(object $object, string $property): mixed
+    {
+        if (\is_callable([$object, $property])) {
+            return $object->$property();
+        }
+
+        $accessor = self::buildAccessorSuffix($property);
+        foreach (['get', 'is', 'has'] as $prefix) {
+            $method = $prefix.$accessor;
+            if (\is_callable([$object, $method])) {
+                $value = $object->$method();
+                if ($value instanceof \Stringable) {
+                    return (string) $value;
+                }
+
+                return $value;
+            }
+        }
+
+        if (property_exists($object, $property)) {
+            $reflection = new \ReflectionObject($object);
+            if (!$reflection->hasProperty($property) || $reflection->getProperty($property)->isPublic()) {
+                return $object->$property;
+            }
+        }
+
+        return null;
+    }
+
+    private static function buildAccessorSuffix(string $property): string
+    {
+        if (str_contains($property, '_') || str_contains($property, '-')) {
+            $property = str_replace(['-', '_'], ' ', $property);
+            $property = str_replace(' ', '', ucwords($property));
+        }
+
+        return ucfirst($property);
+    }
+}

--- a/src/RowMapper/DefaultRowMapper.php
+++ b/src/RowMapper/DefaultRowMapper.php
@@ -6,7 +6,7 @@ use Pentiminax\UX\DataTables\Column\AbstractColumn;
 use Pentiminax\UX\DataTables\Column\DateColumn;
 use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
 use Pentiminax\UX\DataTables\Contracts\RowMapperInterface;
-use Pentiminax\UX\DataTables\PropertyReader;
+use Pentiminax\UX\DataTables\Util\PropertyReader;
 
 final class DefaultRowMapper implements RowMapperInterface
 {

--- a/src/RowMapper/DefaultRowMapper.php
+++ b/src/RowMapper/DefaultRowMapper.php
@@ -6,6 +6,7 @@ use Pentiminax\UX\DataTables\Column\AbstractColumn;
 use Pentiminax\UX\DataTables\Column\DateColumn;
 use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
 use Pentiminax\UX\DataTables\Contracts\RowMapperInterface;
+use Pentiminax\UX\DataTables\PropertyReader;
 
 final class DefaultRowMapper implements RowMapperInterface
 {
@@ -44,7 +45,7 @@ final class DefaultRowMapper implements RowMapperInterface
                 continue;
             }
 
-            $value = $this->readValueFromRow($row, $key);
+            $value = PropertyReader::readPath($row, $key);
             if ($column instanceof DateColumn && $value instanceof \DateTimeInterface) {
                 if ($column->getFormat()) {
                     $value = $value->format($column->getFormat());
@@ -64,68 +65,5 @@ final class DefaultRowMapper implements RowMapperInterface
         $key = $column->getData() ?? $column->getName();
 
         return null === $key || '' === $key ? null : $key;
-    }
-
-    private function readValueFromRow(mixed $row, string $path): mixed
-    {
-        $value = $row;
-        foreach (explode('.', $path) as $segment) {
-            if (\is_array($value)) {
-                if (!isset($value[$segment])) {
-                    return null;
-                }
-
-                $value = $value[$segment];
-                continue;
-            }
-
-            if (\is_object($value)) {
-                $value = $this->readObjectValue($value, $segment);
-                continue;
-            }
-
-            return null;
-        }
-
-        return $value;
-    }
-
-    private function readObjectValue(object $object, string $property): mixed
-    {
-        if (\is_callable([$object, $property])) {
-            return $object->$property();
-        }
-
-        $accessor = $this->buildAccessorSuffix($property);
-        foreach (['get', 'is', 'has'] as $prefix) {
-            $method = $prefix.$accessor;
-            if (\is_callable([$object, $method])) {
-                $value = $object->$method();
-                if (\is_object($value) && $value instanceof \Stringable) {
-                    return (string) $value;
-                }
-
-                return $value;
-            }
-        }
-
-        if (property_exists($object, $property)) {
-            $reflection = new \ReflectionObject($object);
-            if (!$reflection->hasProperty($property) || $reflection->getProperty($property)->isPublic()) {
-                return $object->$property;
-            }
-        }
-
-        return null;
-    }
-
-    private function buildAccessorSuffix(string $property): string
-    {
-        if (str_contains($property, '_') || str_contains($property, '-')) {
-            $property = str_replace(['-', '_'], ' ', $property);
-            $property = str_replace(' ', '', ucwords($property));
-        }
-
-        return ucfirst($property);
     }
 }

--- a/src/Twig/DataTablesExtension.php
+++ b/src/Twig/DataTablesExtension.php
@@ -2,7 +2,6 @@
 
 namespace Pentiminax\UX\DataTables\Twig;
 
-use Pentiminax\UX\DataTables\Column\TemplateColumnRenderer;
 use Pentiminax\UX\DataTables\Model\AbstractDataTable;
 use Pentiminax\UX\DataTables\Model\DataTable;
 use Symfony\UX\StimulusBundle\Helper\StimulusHelper;
@@ -13,7 +12,6 @@ class DataTablesExtension extends AbstractExtension
 {
     public function __construct(
         private StimulusHelper $stimulus,
-        private ?TemplateColumnRenderer $templateColumnRenderer = null,
     ) {
     }
 
@@ -40,16 +38,6 @@ class DataTablesExtension extends AbstractExtension
         }
 
         $options = $table->getOptions();
-        if (
-            null !== $this->templateColumnRenderer
-            && !$table->areTemplateColumnsRendered()
-            && \is_array($options['data'] ?? null)
-            && \is_array($options['columns'] ?? null)
-        ) {
-            $options['data'] = $this->templateColumnRenderer->renderInlineData($options['data'], $options['columns']);
-            $table->data($options['data']);
-            $table->markTemplateColumnsRendered();
-        }
 
         $controllers['@pentiminax/ux-datatables/datatable'] = [
             'view' => array_merge($options, $table->getExtensions()),

--- a/src/Twig/DataTablesExtension.php
+++ b/src/Twig/DataTablesExtension.php
@@ -2,6 +2,7 @@
 
 namespace Pentiminax\UX\DataTables\Twig;
 
+use Pentiminax\UX\DataTables\Column\TemplateColumnRenderer;
 use Pentiminax\UX\DataTables\Model\AbstractDataTable;
 use Pentiminax\UX\DataTables\Model\DataTable;
 use Symfony\UX\StimulusBundle\Helper\StimulusHelper;
@@ -12,6 +13,7 @@ class DataTablesExtension extends AbstractExtension
 {
     public function __construct(
         private StimulusHelper $stimulus,
+        private TemplateColumnRenderer $templateColumnRenderer,
     ) {
     }
 
@@ -38,6 +40,15 @@ class DataTablesExtension extends AbstractExtension
         }
 
         $options = $table->getOptions();
+
+        if (!empty($options['data']) && !$table->areTemplateColumnsRendered()) {
+            $columns = $table->getColumnObjects();
+            $options['data'] = array_map(
+                fn (array $row) => $this->templateColumnRenderer->renderRow($row, $row, $columns),
+                $options['data']
+            );
+            $table->markTemplateColumnsRendered();
+        }
 
         $controllers['@pentiminax/ux-datatables/datatable'] = [
             'view' => array_merge($options, $table->getExtensions()),

--- a/src/Util/PropertyReader.php
+++ b/src/Util/PropertyReader.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pentiminax\UX\DataTables;
+namespace Pentiminax\UX\DataTables\Util;
 
 final class PropertyReader
 {

--- a/tests/Kernel/templates/datatable/columns/status_badge.html.twig
+++ b/tests/Kernel/templates/datatable/columns/status_badge.html.twig
@@ -1,0 +1,1 @@
+<span class="badge">{{ row.id }}-{{ value }}</span>

--- a/tests/Kernel/templates/datatable/columns/status_badge.html.twig
+++ b/tests/Kernel/templates/datatable/columns/status_badge.html.twig
@@ -1,1 +1,1 @@
-<span class="badge">{{ row.id }}-{{ value }}</span>
+<span class="badge">{{ row.id }}-{{ data }}</span>

--- a/tests/Unit/Column/ColumnTypesTest.php
+++ b/tests/Unit/Column/ColumnTypesTest.php
@@ -11,6 +11,7 @@ use Pentiminax\UX\DataTables\Column\HtmlNumberFormatColumn;
 use Pentiminax\UX\DataTables\Column\HtmlUtf8Column;
 use Pentiminax\UX\DataTables\Column\NumberColumn;
 use Pentiminax\UX\DataTables\Column\NumberFormatColumn;
+use Pentiminax\UX\DataTables\Column\TemplateColumn;
 use Pentiminax\UX\DataTables\Column\TextColumn;
 use Pentiminax\UX\DataTables\Column\UrlColumn;
 use Pentiminax\UX\DataTables\Column\Utf8TextColumn;
@@ -76,6 +77,7 @@ class ColumnTypesTest extends TestCase
         yield 'html-number-formatted' => [HtmlNumberFormatColumn::new('col_html_num_fmt'), ColumnType::HTML_NUM_FMT];
         yield 'html' => [HtmlColumn::new('col_html'), ColumnType::HTML];
         yield 'html-utf8' => [HtmlUtf8Column::new('col_html_utf8'), ColumnType::HTML_UTF8];
+        yield 'template' => [TemplateColumn::new('col_template')->setTemplate('datatable/columns/cell.html.twig'), ColumnType::HTML];
         yield 'url' => [UrlColumn::new('col_url'), ColumnType::HTML];
     }
 }

--- a/tests/Unit/Column/ConcreteColumnFactoryTest.php
+++ b/tests/Unit/Column/ConcreteColumnFactoryTest.php
@@ -10,6 +10,7 @@ use Pentiminax\UX\DataTables\Column\HtmlNumberFormatColumn;
 use Pentiminax\UX\DataTables\Column\HtmlUtf8Column;
 use Pentiminax\UX\DataTables\Column\NumberColumn;
 use Pentiminax\UX\DataTables\Column\NumberFormatColumn;
+use Pentiminax\UX\DataTables\Column\TemplateColumn;
 use Pentiminax\UX\DataTables\Column\TextColumn;
 use Pentiminax\UX\DataTables\Column\UrlColumn;
 use Pentiminax\UX\DataTables\Column\Utf8TextColumn;
@@ -23,7 +24,11 @@ class ConcreteColumnFactoryTest extends TestCase
     public function testFactorySetsNameDataTitleAndType(string $columnClass, ColumnType $expectedType): void
     {
         $column = $columnClass::new('field_name', 'Field label');
-        $data   = $column->jsonSerialize();
+        if ($column instanceof TemplateColumn) {
+            $column->setTemplate('datatable/columns/cell.html.twig');
+        }
+
+        $data = $column->jsonSerialize();
 
         $this->assertSame('field_name', $data['data']);
         $this->assertSame('field_name', $data['name']);
@@ -35,7 +40,11 @@ class ConcreteColumnFactoryTest extends TestCase
     public function testFactoryDefaultsTitleToName(string $columnClass): void
     {
         $column = $columnClass::new('field_name');
-        $data   = $column->jsonSerialize();
+        if ($column instanceof TemplateColumn) {
+            $column->setTemplate('datatable/columns/cell.html.twig');
+        }
+
+        $data = $column->jsonSerialize();
 
         $this->assertSame('field_name', $data['title']);
     }
@@ -55,6 +64,7 @@ class ConcreteColumnFactoryTest extends TestCase
         yield 'html-number-formatted' => [HtmlNumberFormatColumn::class, ColumnType::HTML_NUM_FMT];
         yield 'html' => [HtmlColumn::class, ColumnType::HTML];
         yield 'html-utf8' => [HtmlUtf8Column::class, ColumnType::HTML_UTF8];
+        yield 'template' => [TemplateColumn::class, ColumnType::HTML];
         yield 'url' => [UrlColumn::class, ColumnType::HTML];
     }
 }

--- a/tests/Unit/Column/TemplateColumnRendererTest.php
+++ b/tests/Unit/Column/TemplateColumnRendererTest.php
@@ -34,31 +34,6 @@ final class TemplateColumnRendererTest extends TestCase
         $this->assertSame('<span data-field="status">active</span>', $row['status_display']);
     }
 
-    public function testItPassesExpectedContextInInlineRendering(): void
-    {
-        $twig = new Environment(new ArrayLoader([
-            'datatable/columns/status_badge.html.twig' => '<span>{{ row.id }}-{{ entity.id }}-{{ column.name }}-{{ value }}</span>',
-        ]));
-
-        $renderer = new TemplateColumnRenderer($twig);
-        $rows     = $renderer->renderInlineData(
-            rows: [
-                ['id' => 42, 'status' => 'inactive'],
-            ],
-            columns: [
-                ['name' => 'id', 'data' => 'id'],
-                [
-                    'name'         => 'status_display',
-                    'data'         => 'status_display',
-                    'field'        => 'status',
-                    'templatePath' => 'datatable/columns/status_badge.html.twig',
-                ],
-            ]
-        );
-
-        $this->assertSame('<span>42-42-status_display-inactive</span>', $rows[0]['status_display']);
-    }
-
     public function testItFailsFastWhenTwigIsMissing(): void
     {
         $renderer = new TemplateColumnRenderer();

--- a/tests/Unit/Column/TemplateColumnRendererTest.php
+++ b/tests/Unit/Column/TemplateColumnRendererTest.php
@@ -26,7 +26,7 @@ final class TemplateColumnRendererTest extends TestCase
 
         $row = $renderer->renderRow(
             row: ['id' => 7],
-            entity: new TemplateEntity(id: 7, status: 'active'),
+            mappedRow: new TemplateEntity(id: 7, status: 'active'),
             columns: $columns
         );
 
@@ -71,7 +71,7 @@ final class TemplateColumnRendererTest extends TestCase
 
         $renderer->renderRow(
             row: ['status_display' => 'active'],
-            entity: ['status_display' => 'active'],
+            mappedRow: ['status_display' => 'active'],
             columns: $columns
         );
     }
@@ -87,7 +87,7 @@ final class TemplateColumnRendererTest extends TestCase
 
         $renderer->renderRow(
             row: ['status_display' => 'active'],
-            entity: ['status_display' => 'active'],
+            mappedRow: ['status_display' => 'active'],
             columns: $columns
         );
     }

--- a/tests/Unit/Column/TemplateColumnRendererTest.php
+++ b/tests/Unit/Column/TemplateColumnRendererTest.php
@@ -15,7 +15,7 @@ final class TemplateColumnRendererTest extends TestCase
     public function testItRendersTemplateColumnFromEntityField(): void
     {
         $twig = new Environment(new ArrayLoader([
-            'datatable/columns/status_badge.html.twig' => '<span data-field="{{ column.field }}">{{ value }}</span>',
+            'datatable/columns/status_badge.html.twig' => '<span data-field="{{ column.field }}">{{ data }}</span>',
         ]));
 
         $renderer = new TemplateColumnRenderer($twig);
@@ -31,7 +31,7 @@ final class TemplateColumnRendererTest extends TestCase
         );
 
         $this->assertSame(7, $row['id']);
-        $this->assertSame('<span data-field="status">active</span>', $row['status_display']);
+        $this->assertSame('<span data-field="status">active</span>', $row['status']);
     }
 
     public function testItFailsFastWhenTwigIsMissing(): void

--- a/tests/Unit/Column/TemplateColumnRendererTest.php
+++ b/tests/Unit/Column/TemplateColumnRendererTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Pentiminax\UX\DataTables\Tests\Unit\Column;
+
+use Pentiminax\UX\DataTables\Column\TemplateColumn;
+use Pentiminax\UX\DataTables\Column\TemplateColumnRenderer;
+use Pentiminax\UX\DataTables\Column\TextColumn;
+use PHPUnit\Framework\TestCase;
+use Twig\Environment;
+use Twig\Error\LoaderError;
+use Twig\Loader\ArrayLoader;
+
+final class TemplateColumnRendererTest extends TestCase
+{
+    public function testItRendersTemplateColumnFromEntityField(): void
+    {
+        $twig = new Environment(new ArrayLoader([
+            'datatable/columns/status_badge.html.twig' => '<span data-field="{{ column.field }}">{{ value }}</span>',
+        ]));
+
+        $renderer = new TemplateColumnRenderer($twig);
+        $columns  = [
+            TextColumn::new('id'),
+            TemplateColumn::new('status_display')->setField('status')->setTemplate('datatable/columns/status_badge.html.twig'),
+        ];
+
+        $row = $renderer->renderRow(
+            row: ['id' => 7],
+            entity: new TemplateEntity(id: 7, status: 'active'),
+            columns: $columns
+        );
+
+        $this->assertSame(7, $row['id']);
+        $this->assertSame('<span data-field="status">active</span>', $row['status_display']);
+    }
+
+    public function testItPassesExpectedContextInInlineRendering(): void
+    {
+        $twig = new Environment(new ArrayLoader([
+            'datatable/columns/status_badge.html.twig' => '<span>{{ row.id }}-{{ entity.id }}-{{ column.name }}-{{ value }}</span>',
+        ]));
+
+        $renderer = new TemplateColumnRenderer($twig);
+        $rows     = $renderer->renderInlineData(
+            rows: [
+                ['id' => 42, 'status' => 'inactive'],
+            ],
+            columns: [
+                ['name' => 'id', 'data' => 'id'],
+                [
+                    'name'         => 'status_display',
+                    'data'         => 'status_display',
+                    'field'        => 'status',
+                    'templatePath' => 'datatable/columns/status_badge.html.twig',
+                ],
+            ]
+        );
+
+        $this->assertSame('<span>42-42-status_display-inactive</span>', $rows[0]['status_display']);
+    }
+
+    public function testItFailsFastWhenTwigIsMissing(): void
+    {
+        $renderer = new TemplateColumnRenderer();
+        $columns  = [
+            TemplateColumn::new('status_display')->setTemplate('datatable/columns/status_badge.html.twig'),
+        ];
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Twig Environment is required to render TemplateColumn cells.');
+
+        $renderer->renderRow(
+            row: ['status_display' => 'active'],
+            entity: ['status_display' => 'active'],
+            columns: $columns
+        );
+    }
+
+    public function testItFailsFastWhenTemplateDoesNotExist(): void
+    {
+        $renderer = new TemplateColumnRenderer(new Environment(new ArrayLoader([])));
+        $columns  = [
+            TemplateColumn::new('status_display')->setTemplate('datatable/columns/missing.html.twig'),
+        ];
+
+        $this->expectException(LoaderError::class);
+
+        $renderer->renderRow(
+            row: ['status_display' => 'active'],
+            entity: ['status_display' => 'active'],
+            columns: $columns
+        );
+    }
+}
+
+final readonly class TemplateEntity
+{
+    public function __construct(
+        private int $id,
+        private string $status,
+    ) {
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+}

--- a/tests/Unit/Column/TemplateColumnTest.php
+++ b/tests/Unit/Column/TemplateColumnTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Pentiminax\UX\DataTables\Tests\Unit\Column;
+
+use Pentiminax\UX\DataTables\Column\TemplateColumn;
+use PHPUnit\Framework\TestCase;
+
+final class TemplateColumnTest extends TestCase
+{
+    public function testItSerializesTemplatePath(): void
+    {
+        $column = TemplateColumn::new('status_display')
+            ->setField('status')
+            ->setTemplate('datatable/columns/status_badge.html.twig');
+
+        $data = $column->jsonSerialize();
+
+        $this->assertSame('status_display', $data['name']);
+        $this->assertSame('status_display', $data['data']);
+        $this->assertSame('status', $data['field']);
+        $this->assertSame('html', $data['type']);
+        $this->assertSame('datatable/columns/status_badge.html.twig', $data['templatePath']);
+    }
+
+    public function testSetTemplateRejectsEmptyPath(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Template path cannot be empty.');
+
+        TemplateColumn::new('status_display')->setTemplate('   ');
+    }
+
+    public function testGetTemplateFailsWhenMissing(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Template path is not configured for column');
+
+        TemplateColumn::new('status_display')->getTemplate();
+    }
+}

--- a/tests/Unit/Model/AbstractDataTableTemplateColumnTest.php
+++ b/tests/Unit/Model/AbstractDataTableTemplateColumnTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Pentiminax\UX\DataTables\Tests\Unit\Model;
+
+use Pentiminax\UX\DataTables\Column\TemplateColumn;
+use Pentiminax\UX\DataTables\Column\TemplateColumnRenderer;
+use Pentiminax\UX\DataTables\Column\TextColumn;
+use Pentiminax\UX\DataTables\Model\AbstractDataTable;
+use PHPUnit\Framework\TestCase;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+
+final class AbstractDataTableTemplateColumnTest extends TestCase
+{
+    public function testRowMapperPipelineRendersTemplateColumnWhenMapRowIsOverridden(): void
+    {
+        $renderer = new TemplateColumnRenderer(new Environment(new ArrayLoader([
+            'datatable/columns/status_badge.html.twig' => '<span>{{ row.id }}-{{ value }}</span>',
+        ])));
+
+        $table = new TemplatePipelineTable($renderer);
+
+        $row = $table->mapViaPipeline(new TemplatePipelineEntity(id: 9, status: 'active'));
+
+        $this->assertSame([
+            'id'             => 9,
+            'status_display' => '<span>9-active</span>',
+        ], $row);
+    }
+}
+
+final class TemplatePipelineTable extends AbstractDataTable
+{
+    public function __construct(TemplateColumnRenderer $renderer)
+    {
+        parent::__construct(templateColumnRenderer: $renderer);
+    }
+
+    public function configureColumns(): iterable
+    {
+        yield TextColumn::new('id');
+        yield TemplateColumn::new('status_display')
+            ->setField('status')
+            ->setTemplate('datatable/columns/status_badge.html.twig');
+    }
+
+    protected function mapRow(mixed $row): array
+    {
+        return ['id' => $row->getId()];
+    }
+
+    public function mapViaPipeline(mixed $row): array
+    {
+        return $this->rowMapper()->map($row);
+    }
+}
+
+final readonly class TemplatePipelineEntity
+{
+    public function __construct(
+        private int $id,
+        private string $status,
+    ) {
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+}

--- a/tests/Unit/Model/AbstractDataTableTemplateColumnTest.php
+++ b/tests/Unit/Model/AbstractDataTableTemplateColumnTest.php
@@ -15,7 +15,7 @@ final class AbstractDataTableTemplateColumnTest extends TestCase
     public function testRowMapperPipelineRendersTemplateColumnWhenMapRowIsOverridden(): void
     {
         $renderer = new TemplateColumnRenderer(new Environment(new ArrayLoader([
-            'datatable/columns/status_badge.html.twig' => '<span>{{ row.id }}-{{ value }}</span>',
+            'datatable/columns/status_badge.html.twig' => '<span>{{ row.id }}-{{ data }}</span>',
         ])));
 
         $table = new TemplatePipelineTable($renderer);
@@ -33,7 +33,9 @@ final class TemplatePipelineTable extends AbstractDataTable
 {
     public function __construct(TemplateColumnRenderer $renderer)
     {
-        parent::__construct(templateColumnRenderer: $renderer);
+        parent::__construct(
+            templateColumnRenderer: $renderer
+        );
     }
 
     public function configureColumns(): iterable

--- a/tests/Unit/Model/AbstractDataTableTemplateColumnTest.php
+++ b/tests/Unit/Model/AbstractDataTableTemplateColumnTest.php
@@ -23,8 +23,8 @@ final class AbstractDataTableTemplateColumnTest extends TestCase
         $row = $table->mapViaPipeline(new TemplatePipelineEntity(id: 9, status: 'active'));
 
         $this->assertSame([
-            'id'             => 9,
-            'status_display' => '<span>9-active</span>',
+            'id'     => 9,
+            'status' => '<span>9-active</span>',
         ], $row);
     }
 }

--- a/tests/Unit/PropertyReaderTest.php
+++ b/tests/Unit/PropertyReaderTest.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace Pentiminax\UX\DataTables\Tests\Unit;
+
+use Pentiminax\UX\DataTables\PropertyReader;
+use PHPUnit\Framework\TestCase;
+
+final class PropertyReaderTest extends TestCase
+{
+    public function testReadPathReturnsNullForEmptyPath(): void
+    {
+        $this->assertNull(PropertyReader::readPath(['foo' => 'bar'], ''));
+    }
+
+    public function testReadPathFromArray(): void
+    {
+        $data = ['user' => ['name' => 'Alice']];
+
+        $this->assertSame('Alice', PropertyReader::readPath($data, 'user.name'));
+    }
+
+    public function testReadPathFromArrayReturnsNullForMissingKey(): void
+    {
+        $this->assertNull(PropertyReader::readPath(['a' => 1], 'b'));
+    }
+
+    public function testReadPathFromObjectViaGetter(): void
+    {
+        $object = new PropertyReaderStub(name: 'Bob', active: true, role: 'admin');
+
+        $this->assertSame('Bob', PropertyReader::readPath($object, 'name'));
+    }
+
+    public function testReadPathFromObjectViaIsPrefix(): void
+    {
+        $object = new PropertyReaderStub(name: 'Bob', active: true, role: 'admin');
+
+        $this->assertTrue(PropertyReader::readPath($object, 'active'));
+    }
+
+    public function testReadPathFromObjectViaHasPrefix(): void
+    {
+        $object = new PropertyReaderStub(name: 'Bob', active: true, role: 'admin');
+
+        $this->assertTrue(PropertyReader::readPath($object, 'role'));
+    }
+
+    public function testReadPathFromObjectViaDirectCallable(): void
+    {
+        $object = new PropertyReaderStub(name: 'Bob', active: true, role: 'admin');
+
+        $this->assertSame(42, PropertyReader::readPath($object, 'score'));
+    }
+
+    public function testReadPathFromPublicProperty(): void
+    {
+        $object = new PropertyReaderPublicFieldStub();
+
+        $this->assertSame('public_value', PropertyReader::readPath($object, 'field'));
+    }
+
+    public function testReadPathReturnsNullForUnknownProperty(): void
+    {
+        $object = new PropertyReaderStub(name: 'Bob', active: true, role: 'admin');
+
+        $this->assertNull(PropertyReader::readPath($object, 'nonexistent'));
+    }
+
+    public function testReadPathHandlesSnakeCaseAccessor(): void
+    {
+        $object = new PropertyReaderSnakeCaseStub();
+
+        $this->assertSame('snake_value', PropertyReader::readPath($object, 'first_name'));
+    }
+
+    public function testReadPathHandlesKebabCaseAccessor(): void
+    {
+        $object = new PropertyReaderKebabCaseStub();
+
+        $this->assertSame('kebab_value', PropertyReader::readPath($object, 'last-name'));
+    }
+
+    public function testReadPathHandlesStringableReturnValue(): void
+    {
+        $object = new PropertyReaderStringableStub();
+
+        $this->assertSame('stringified', PropertyReader::readPath($object, 'label'));
+    }
+
+    public function testReadPathTraversesDotNotationOnNestedObjects(): void
+    {
+        $address = new PropertyReaderAddressStub('Paris');
+        $user    = new PropertyReaderUserStub($address);
+
+        $this->assertSame('Paris', PropertyReader::readPath($user, 'address.city'));
+    }
+
+    public function testReadPathReturnsNullForScalarSegment(): void
+    {
+        $this->assertNull(PropertyReader::readPath('scalar', 'foo'));
+    }
+
+    public function testReadObjectValueReturnsNullForPrivateProperty(): void
+    {
+        $object = new PropertyReaderPrivateFieldStub();
+
+        $this->assertNull(PropertyReader::readObjectValue($object, 'secret'));
+    }
+}
+
+final readonly class PropertyReaderStub
+{
+    public function __construct(
+        private string $name,
+        private bool $active,
+        private string $role,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->active;
+    }
+
+    public function hasRole(): bool
+    {
+        return true;
+    }
+
+    public function score(): int
+    {
+        return 42;
+    }
+}
+
+final class PropertyReaderPublicFieldStub
+{
+    public string $field = 'public_value';
+}
+
+final class PropertyReaderSnakeCaseStub
+{
+    public function getFirstName(): string
+    {
+        return 'snake_value';
+    }
+}
+
+final class PropertyReaderKebabCaseStub
+{
+    public function getLastName(): string
+    {
+        return 'kebab_value';
+    }
+}
+
+final class PropertyReaderStringableStub
+{
+    public function getLabel(): \Stringable
+    {
+        return new class implements \Stringable {
+            public function __toString(): string
+            {
+                return 'stringified';
+            }
+        };
+    }
+}
+
+final readonly class PropertyReaderAddressStub
+{
+    public function __construct(private string $city)
+    {
+    }
+
+    public function getCity(): string
+    {
+        return $this->city;
+    }
+}
+
+final readonly class PropertyReaderUserStub
+{
+    public function __construct(private PropertyReaderAddressStub $address)
+    {
+    }
+
+    public function getAddress(): PropertyReaderAddressStub
+    {
+        return $this->address;
+    }
+}
+
+final class PropertyReaderPrivateFieldStub
+{
+    private string $secret = 'hidden';
+}

--- a/tests/Unit/PropertyReaderTest.php
+++ b/tests/Unit/PropertyReaderTest.php
@@ -2,7 +2,7 @@
 
 namespace Pentiminax\UX\DataTables\Tests\Unit;
 
-use Pentiminax\UX\DataTables\PropertyReader;
+use Pentiminax\UX\DataTables\Util\PropertyReader;
 use PHPUnit\Framework\TestCase;
 
 final class PropertyReaderTest extends TestCase

--- a/tests/Unit/Twig/DataTablesExtensionTest.php
+++ b/tests/Unit/Twig/DataTablesExtensionTest.php
@@ -140,6 +140,6 @@ class DataTablesExtensionTest extends TestCase
         $jsonAttr = html_entity_decode($tableEl->getAttribute('data-pentiminax--ux-datatables--datatable-view-value'));
         $actual   = json_decode($jsonAttr, true, 512, JSON_THROW_ON_ERROR);
 
-        $this->assertSame('<span class="badge">5-active</span>', trim($actual['data'][0]['status_display']));
+        $this->assertSame('<span class="badge">5-active</span>', trim($actual['data'][0]['status']));
     }
 }


### PR DESCRIPTION
Fix issue #86 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Template-based column rendering using Twig for custom cell output, plus runtime support to pre-render template columns.
  * Utility for robust dotted-path property reading to access nested data in rows.

* **Documentation**
  * Expanded Columns guide with TemplateColumn usage, examples, context details, and template samples.

* **Tests**
  * Added unit and integration tests covering template columns, renderer behavior, property reader, and rendering pipeline.

* **Chores**
  * Bumped PHP CS Fixer dev dependency from ^3.89 to ^3.94.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->