### PR TITLE
Add support for custom template parameters in `TemplateColumn`

### DIFF
--- a/src/Column/TemplateColumn.php
+++ b/src/Column/TemplateColumn.php
@@ -6,14 +6,15 @@ use Pentiminax\UX\DataTables\Enum\ColumnType;
 
 class TemplateColumn extends AbstractColumn
 {
-    public const OPTION_TEMPLATE_PATH = 'templatePath';
+    public const string OPTION_TEMPLATE_PATH       = 'templatePath';
+    public const string OPTION_TEMPLATE_PARAMETERS = 'templateParameters';
 
     public static function new(string $name, string $title = ''): static
     {
         return static::createWithType($name, $title, ColumnType::HTML);
     }
 
-    public function setTemplate(string $template): static
+    public function setTemplate(string $template, array $parameters = []): static
     {
         $template = trim($template);
         if ('' === $template) {
@@ -21,6 +22,7 @@ class TemplateColumn extends AbstractColumn
         }
 
         $this->setCustomOption(self::OPTION_TEMPLATE_PATH, $template);
+        $this->setCustomOption(self::OPTION_TEMPLATE_PARAMETERS, $parameters);
 
         return $this;
     }
@@ -33,6 +35,11 @@ class TemplateColumn extends AbstractColumn
         }
 
         return $template;
+    }
+
+    public function getTemplateParameters(): array
+    {
+        return $this->getCustomOption(self::OPTION_TEMPLATE_PARAMETERS) ?? [];
     }
 
     public function jsonSerialize(): array

--- a/src/Column/TemplateColumnRenderer.php
+++ b/src/Column/TemplateColumnRenderer.php
@@ -29,12 +29,18 @@ final class TemplateColumnRenderer
             $field = $column->getField();
             $data  = $this->resolveData(mappedRow: $mappedRow, row: $contextRow, field: $field);
 
-            $renderedRow[$field] = $this->renderTemplate($column->getTemplate(), [
+            $context = [
                 'entity' => $mappedRow,
                 'data'   => $data,
                 'column' => $column->jsonSerialize(),
                 'row'    => $contextRow,
-            ]);
+            ];
+
+            foreach ($column->getTemplateParameters() as $key => $value) {
+                $context[$key] = $value;
+            }
+
+            $renderedRow[$field] = $this->renderTemplate($column->getTemplate(), $context);
         }
 
         return $renderedRow;

--- a/tests/Unit/Column/TemplateColumnRendererTest.php
+++ b/tests/Unit/Column/TemplateColumnRendererTest.php
@@ -66,6 +66,93 @@ final class TemplateColumnRendererTest extends TestCase
             columns: $columns
         );
     }
+
+    public function testItPrefersRowArrayValueOverMappedRow(): void
+    {
+        $twig = new Environment(new ArrayLoader([
+            'column.html.twig' => '{{ data }}',
+        ]));
+
+        $renderer = new TemplateColumnRenderer($twig);
+        $columns  = [
+            TemplateColumn::new('status_display')->setField('status')->setTemplate('column.html.twig'),
+        ];
+
+        $row = $renderer->renderRow(
+            row: ['status' => 'from_row'],
+            mappedRow: new TemplateEntity(id: 1, status: 'from_entity'),
+            columns: $columns
+        );
+
+        $this->assertSame('from_row', $row['status']);
+    }
+
+    public function testItPassesCustomTemplateParametersToTwig(): void
+    {
+        $twig = new Environment(new ArrayLoader([
+            'column.html.twig' => '{{ badge_class }}: {{ data }}',
+        ]));
+
+        $renderer = new TemplateColumnRenderer($twig);
+        $columns  = [
+            TemplateColumn::new('status_display')
+                ->setField('status')
+                ->setTemplate('column.html.twig', ['badge_class' => 'badge-success']),
+        ];
+
+        $row = $renderer->renderRow(
+            row: ['status' => 'active'],
+            mappedRow: [],
+            columns: $columns
+        );
+
+        $this->assertSame('badge-success: active', $row['status']);
+    }
+
+    public function testItRendersMultipleTemplateColumnsInSameRow(): void
+    {
+        $twig = new Environment(new ArrayLoader([
+            'status.html.twig' => 'Status: {{ data }}',
+            'type.html.twig'   => 'Type: {{ data }}',
+        ]));
+
+        $renderer = new TemplateColumnRenderer($twig);
+        $columns  = [
+            TemplateColumn::new('status_display')->setField('status')->setTemplate('status.html.twig'),
+            TemplateColumn::new('type_display')->setField('type')->setTemplate('type.html.twig'),
+        ];
+
+        $row = $renderer->renderRow(
+            row: ['status' => 'active', 'type' => 'admin'],
+            mappedRow: [],
+            columns: $columns
+        );
+
+        $this->assertSame('Status: active', $row['status']);
+        $this->assertSame('Type: admin', $row['type']);
+    }
+
+    public function testItExposesEntityRowAndColumnInTwigContext(): void
+    {
+        $twig = new Environment(new ArrayLoader([
+            'column.html.twig' => '{{ entity.getStatus() }}-{{ row.id }}-{{ column.name }}',
+        ]));
+
+        $renderer = new TemplateColumnRenderer($twig);
+        $columns  = [
+            TemplateColumn::new('status_display')->setField('status')->setTemplate('column.html.twig'),
+        ];
+
+        $entity = new TemplateEntity(id: 42, status: 'verified');
+
+        $row = $renderer->renderRow(
+            row: ['id' => 42],
+            mappedRow: $entity,
+            columns: $columns
+        );
+
+        $this->assertSame('verified-42-status_display', $row['status']);
+    }
 }
 
 final readonly class TemplateEntity

--- a/tests/Unit/Column/TemplateColumnTest.php
+++ b/tests/Unit/Column/TemplateColumnTest.php
@@ -37,4 +37,37 @@ final class TemplateColumnTest extends TestCase
 
         TemplateColumn::new('status_display')->getTemplate();
     }
+
+    public function testGetTemplateParametersDefaultsToEmptyArray(): void
+    {
+        $column = TemplateColumn::new('status_display');
+
+        $this->assertSame([], $column->getTemplateParameters());
+    }
+
+    public function testSetTemplateStoresParameters(): void
+    {
+        $column = TemplateColumn::new('status_display')
+            ->setTemplate('some/template.html.twig', ['badge_class' => 'badge-success', 'show_icon' => true]);
+
+        $this->assertSame(['badge_class' => 'badge-success', 'show_icon' => true], $column->getTemplateParameters());
+    }
+
+    public function testJsonSerializeDoesNotIncludeTemplateParameters(): void
+    {
+        $column = TemplateColumn::new('status_display')
+            ->setTemplate('some/template.html.twig', ['secret' => 'server-side-only']);
+
+        $data = $column->jsonSerialize();
+
+        $this->assertArrayNotHasKey('templateParameters', $data);
+        $this->assertArrayNotHasKey(TemplateColumn::OPTION_TEMPLATE_PARAMETERS, $data);
+    }
+
+    public function testSetTemplateIsFluent(): void
+    {
+        $column = TemplateColumn::new('status_display');
+
+        $this->assertSame($column, $column->setTemplate('some/template.html.twig'));
+    }
 }

--- a/tests/Unit/Twig/DataTablesExtensionTest.php
+++ b/tests/Unit/Twig/DataTablesExtensionTest.php
@@ -142,4 +142,69 @@ class DataTablesExtensionTest extends TestCase
 
         $this->assertSame('<span class="badge">5-active</span>', trim($actual['data'][0]['status']));
     }
+
+    public function testRenderDataTableSkipsTemplateRenderingWhenAlreadyMarked(): void
+    {
+        $kernel = new TwigAppKernel('test', true);
+        $kernel->boot();
+        $container = $kernel->getContainer()->get('test.service_container');
+
+        /** @var DataTableBuilderInterface $builder */
+        $builder = $container->get('test.datatables.builder');
+
+        $table = $builder->createDataTable('template_table');
+        $table->columns([
+            TextColumn::new('id'),
+            TemplateColumn::new('status_display')
+                ->setField('status')
+                ->setTemplate('datatable/columns/status_badge.html.twig'),
+        ]);
+        $table->data([
+            ['id' => 5, 'status' => 'active'],
+        ]);
+
+        $table->markTemplateColumnsRendered();
+
+        $rendered = $container->get('test.datatables.twig_extension')->renderDataTable($table);
+
+        $dom = new \DOMDocument();
+        $dom->loadHTML($rendered);
+        $tableEl = $dom->getElementsByTagName('table')->item(0);
+
+        $jsonAttr = html_entity_decode($tableEl->getAttribute('data-pentiminax--ux-datatables--datatable-view-value'));
+        $actual   = json_decode($jsonAttr, true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('active', $actual['data'][0]['status']);
+    }
+
+    public function testRenderDataTableSkipsTemplateRenderingWhenNoInlineData(): void
+    {
+        $kernel = new TwigAppKernel('test', true);
+        $kernel->boot();
+        $container = $kernel->getContainer()->get('test.service_container');
+
+        /** @var DataTableBuilderInterface $builder */
+        $builder = $container->get('test.datatables.builder');
+
+        $table = $builder->createDataTable('ajax_table');
+        $table->columns([
+            TextColumn::new('id'),
+            TemplateColumn::new('status_display')
+                ->setField('status')
+                ->setTemplate('datatable/columns/status_badge.html.twig'),
+        ]);
+        $table->ajax('/api/items');
+
+        $rendered = $container->get('test.datatables.twig_extension')->renderDataTable($table);
+
+        $dom = new \DOMDocument();
+        $dom->loadHTML($rendered);
+        $tableEl = $dom->getElementsByTagName('table')->item(0);
+
+        $jsonAttr = html_entity_decode($tableEl->getAttribute('data-pentiminax--ux-datatables--datatable-view-value'));
+        $actual   = json_decode($jsonAttr, true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertArrayNotHasKey('data', $actual);
+        $this->assertFalse($table->areTemplateColumnsRendered());
+    }
 }


### PR DESCRIPTION
Fix #86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Template columns now support custom parameters passed during template setup
  * Custom parameters are accessible within Twig templates for enhanced flexibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->