### PR TITLE
Fix DataTable builder id nullability

### DIFF
--- a/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/docs/src/content/docs/getting-started/quick-start.mdx
@@ -66,7 +66,7 @@ Let's create a simple users table in under 5 minutes.
            {{ render_datatable(table) }}
 
            {# Or with custom attributes #}
-           {{ render_datatable(table, {'class': 'table table-striped', 'id': 'my-users-table'}) }}
+           {{ render_datatable(table, {'class': 'table table-striped'}) }}
        </div>
    {% endblock %}
    ```

--- a/docs/src/content/docs/guide/usage.mdx
+++ b/docs/src/content/docs/guide/usage.mdx
@@ -62,10 +62,12 @@ Pass HTML attributes as a second argument:
 
 {{ render_datatable(table, {
     'class': 'table table-bordered',
-    'id': 'custom-id',
     'data-custom': 'value'
 }) }}
 ```
+
+The table `id` attribute always comes from `createDataTable('...')`. Do not pass a separate `id`
+through `render_datatable()`.
 
 ## Extending the Default Behavior
 

--- a/src/Builder/DataTableBuilder.php
+++ b/src/Builder/DataTableBuilder.php
@@ -15,7 +15,7 @@ class DataTableBuilder implements DataTableBuilderInterface
     ) {
     }
 
-    public function createDataTable(?string $id = null): DataTable
+    public function createDataTable(string $id): DataTable
     {
         return new DataTable(
             id: $id,

--- a/src/Builder/DataTableBuilderInterface.php
+++ b/src/Builder/DataTableBuilderInterface.php
@@ -8,5 +8,5 @@ use Pentiminax\UX\DataTables\Model\DataTable;
 
 interface DataTableBuilderInterface
 {
-    public function createDataTable(?string $id = null): DataTable;
+    public function createDataTable(string $id): DataTable;
 }

--- a/src/Model/DataTable.php
+++ b/src/Model/DataTable.php
@@ -37,7 +37,7 @@ class DataTable
         $this->extensions = new DataTableExtensions($extensions);
     }
 
-    public function getId(): ?string
+    public function getId(): string
     {
         return $this->id;
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Table ID is now required when creating data tables; the parameter is no longer optional.

* **Documentation**
  * Updated guides to clarify the correct method for specifying table identifiers during creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->