### PR TITLE
Remove unreachable else branch in DefaultRowMapper date formatting

### DIFF
--- a/src/RowMapper/DefaultRowMapper.php
+++ b/src/RowMapper/DefaultRowMapper.php
@@ -49,11 +49,7 @@ final class DefaultRowMapper implements RowMapperInterface
 
             $value = PropertyReader::readPath($row, $key);
             if ($column instanceof DateColumn && $value instanceof \DateTimeInterface) {
-                if ($column->getFormat()) {
-                    $value = $value->format($column->getFormat());
-                } else {
-                    $value = $value->format('Y-m-d');
-                }
+                $value = $value->format($column->getFormat());
             }
 
             $mapped[$key] = $value;


### PR DESCRIPTION
DateColumn::getFormat() always returns a non-null string (falls back to DEFAULT_DATE_FORMAT 'Y-m-d'), making the else branch dead code.