### PR TITLE
Refactor column serialization delegation

### DIFF
--- a/src/Column/AbstractColumn.php
+++ b/src/Column/AbstractColumn.php
@@ -222,33 +222,9 @@ abstract class AbstractColumn implements ColumnInterface
         return $this->dto->getCustomOption($optionName);
     }
 
-    /**
-     * Convert the column to a JSON-serializable array for DataTables initialization.
-     */
     public function jsonSerialize(): array
     {
-        $className = $this->dto->getClassName();
-
-        if (!$this->dto->isExportable()) {
-            $className = trim(\sprintf('%s not-exportable', $className ?? '')) ?: null;
-        }
-
-        return array_filter([
-            'cellType'       => $this->dto->getCellType(),
-            'className'      => $className,
-            'data'           => $this->dto->getData(),
-            'defaultContent' => $this->dto->getDefaultContent(),
-            'name'           => $this->dto->getName(),
-            'orderable'      => $this->dto->isOrderable(),
-            'render'         => $this->dto->getRender(),
-            'searchable'     => $this->dto->isSearchable(),
-            'title'          => $this->dto->getTitle(),
-            'type'           => $this->dto->getType()->value,
-            'visible'        => $this->dto->isVisible(),
-            'width'          => $this->dto->getWidth(),
-            'field'          => $this->dto->getField(),
-            'customOptions'  => $this->dto->getCustomOptions(),
-        ], static fn (mixed $value) => null !== $value && '' !== $value && [] !== $value);
+        return $this->dto->jsonSerialize();
     }
 
     /**

--- a/tests/Unit/Column/AbstractColumnTest.php
+++ b/tests/Unit/Column/AbstractColumnTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Unit\Column;
+
+use Pentiminax\UX\DataTables\Column\AbstractColumn;
+use Pentiminax\UX\DataTables\Dto\ColumnDto;
+use Pentiminax\UX\DataTables\Enum\ColumnType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AbstractColumn::class)]
+final class AbstractColumnTest extends TestCase
+{
+    #[Test]
+    public function it_delegates_json_serialization_to_the_dto(): void
+    {
+        $dto = (new ColumnDto())
+            ->setType(ColumnType::STRING)
+            ->setName('status')
+            ->setTitle('Status')
+            ->setActions([['type' => 'DETAIL', 'url' => '/books/42']]);
+
+        $column = new class($dto) extends AbstractColumn {};
+
+        $this->assertSame($dto->jsonSerialize(), $column->jsonSerialize());
+    }
+}


### PR DESCRIPTION
## Summary
- delegate \ directly to \
- remove the duplicated serialization logic from the abstract column base class
- add a regression test asserting column serialization matches the DTO output exactly

## Testing
- vendor/bin/phpunit tests/Unit/Column/AbstractColumnTest.php
- vendor/bin/phpunit tests/Unit/Column/ActionColumnTest.php tests/Unit/Column/ColumnTypesTest.php