### PR TITLE
Unify extension configuration in `AbstractDataTable`

### DIFF
--- a/docs/src/content/docs/reference/abstract-datatable.mdx
+++ b/docs/src/content/docs/reference/abstract-datatable.mdx
@@ -207,33 +207,19 @@ final class UsersDataTable extends AbstractDataTable
 ### Extensions
 
 ```php
-use Pentiminax\UX\DataTables\Model\Extensions\ButtonsExtension;
-use Pentiminax\UX\DataTables\Model\Extensions\SelectExtension;
+use Pentiminax\UX\DataTables\Enum\ButtonType;
+use Pentiminax\UX\DataTables\Enum\SelectStyle;
 use Pentiminax\UX\DataTables\Model\DataTableExtensions;
+use Pentiminax\UX\DataTables\Model\Extensions\ButtonsExtension;
+use Pentiminax\UX\DataTables\Model\Extensions\ColumnControlExtension;
+use Pentiminax\UX\DataTables\Model\Extensions\SelectExtension;
 
 public function configureExtensions(DataTableExtensions $extensions): DataTableExtensions
 {
     return $extensions
-        ->add(new ButtonsExtension([ButtonType::CSV, ButtonType::EXCEL]))
-        ->add(new SelectExtension(SelectStyle::MULTI));
-}
-```
-
-Or configure individual extensions:
-
-```php
-public function configureButtonsExtension(ButtonsExtension $ext): ButtonsExtension
-{
-    return $ext->buttons([
-        ButtonType::COPY,
-        ButtonType::CSV,
-        ButtonType::PDF,
-    ]);
-}
-
-public function configureSelectExtension(SelectExtension $ext): SelectExtension
-{
-    return $ext->style(SelectStyle::SINGLE);
+        ->addExtension(new ButtonsExtension([ButtonType::CSV, ButtonType::EXCEL]))
+        ->addExtension(new SelectExtension(SelectStyle::MULTI))
+        ->addExtension(new ColumnControlExtension());
 }
 ```
 
@@ -269,10 +255,7 @@ into each action. See the [Action Columns](../action-columns/) reference for the
     ['`configureActions(Actions $actions)`', 'Configure built-in row actions'],
     ['`configureDataTable(DataTable $table)`', 'Configure table options'],
     ['`configureColumns()`', 'Define columns (required)'],
-    ['`configureExtensions(DataTableExtensions $ext)`', 'Add extensions'],
-    ['`configureButtonsExtension(ButtonsExtension $ext)`', 'Configure Buttons extension'],
-    ['`configureSelectExtension(SelectExtension $ext)`', 'Configure Select extension'],
-    ['`configureColumnControlExtension(...)`', 'Configure ColumnControl extension'],
+    ['`configureExtensions(DataTableExtensions $ext)`', 'Configure all extensions'],
   ]}
 />
 

--- a/docs/src/content/docs/reference/maker.mdx
+++ b/docs/src/content/docs/reference/maker.mdx
@@ -157,16 +157,17 @@ public function queryBuilderConfigurator(QueryBuilder $qb, DataTableRequest $req
 ### Add Extensions
 
 ```php
-use Pentiminax\UX\DataTables\Model\Extensions\ButtonsExtension;
 use Pentiminax\UX\DataTables\Enum\ButtonType;
+use Pentiminax\UX\DataTables\Model\DataTableExtensions;
+use Pentiminax\UX\DataTables\Model\Extensions\ButtonsExtension;
 
-public function configureButtonsExtension(ButtonsExtension $ext): ButtonsExtension
+public function configureExtensions(DataTableExtensions $extensions): DataTableExtensions
 {
-    return $ext->buttons([
+    return $extensions->addExtension(new ButtonsExtension([
         ButtonType::CSV,
         ButtonType::EXCEL,
         ButtonType::PDF,
-    ]);
+    ]));
 }
 ```
 

--- a/src/Model/AbstractDataTable.php
+++ b/src/Model/AbstractDataTable.php
@@ -22,9 +22,6 @@ use Pentiminax\UX\DataTables\Contracts\MercureConfigResolverInterface;
 use Pentiminax\UX\DataTables\Contracts\RowMapperInterface;
 use Pentiminax\UX\DataTables\DataProvider\DoctrineDataProvider;
 use Pentiminax\UX\DataTables\DataTableRequest\DataTableRequest;
-use Pentiminax\UX\DataTables\Model\Extensions\ButtonsExtension;
-use Pentiminax\UX\DataTables\Model\Extensions\ColumnControlExtension;
-use Pentiminax\UX\DataTables\Model\Extensions\SelectExtension;
 use Pentiminax\UX\DataTables\Query\Builder\QueryFilterChain;
 use Pentiminax\UX\DataTables\Query\QueryFilterContext;
 use Pentiminax\UX\DataTables\Query\Strategy\DefaultSearchStrategyRegistry;
@@ -91,21 +88,6 @@ abstract class AbstractDataTable
         $this->table->setExtensions(
             $this->configureExtensions(new DataTableExtensions())
         );
-
-        $buttonsExtension = $this->configureButtonsExtension(new ButtonsExtension([]));
-        if ($buttonsExtension->isEnabled()) {
-            $this->table->addExtension($buttonsExtension);
-        }
-
-        $columnControlExtension = $this->configureColumnControlExtension(new ColumnControlExtension());
-        if ($columnControlExtension->isEnabled()) {
-            $this->table->addExtension($columnControlExtension);
-        }
-
-        $selectExtension = $this->configureSelectExtension(new SelectExtension());
-        if ($selectExtension->isEnabled()) {
-            $this->table->addExtension($selectExtension);
-        }
     }
 
     public function getRequest(): ?DataTableRequest
@@ -225,21 +207,6 @@ abstract class AbstractDataTable
     public function configureExtensions(DataTableExtensions $extensions): DataTableExtensions
     {
         return $extensions;
-    }
-
-    public function configureButtonsExtension(ButtonsExtension $extension): ButtonsExtension
-    {
-        return $extension;
-    }
-
-    public function configureColumnControlExtension(ColumnControlExtension $extension): ColumnControlExtension
-    {
-        return $extension;
-    }
-
-    public function configureSelectExtension(SelectExtension $extension): SelectExtension
-    {
-        return $extension;
     }
 
     public function fetchData(DataTableRequest $request): DataTableResult

--- a/tests/Unit/Model/AbstractDataTableExtensionsTest.php
+++ b/tests/Unit/Model/AbstractDataTableExtensionsTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Unit\Model;
+
+use Pentiminax\UX\DataTables\Column\TextColumn;
+use Pentiminax\UX\DataTables\Enum\ButtonType;
+use Pentiminax\UX\DataTables\Enum\Feature;
+use Pentiminax\UX\DataTables\Model\AbstractDataTable;
+use Pentiminax\UX\DataTables\Model\DataTable;
+use Pentiminax\UX\DataTables\Model\DataTableExtensions;
+use Pentiminax\UX\DataTables\Model\Extensions\ButtonsExtension;
+use Pentiminax\UX\DataTables\Model\Extensions\ColumnControlExtension;
+use Pentiminax\UX\DataTables\Model\Extensions\SelectExtension;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+#[CoversClass(AbstractDataTable::class)]
+final class AbstractDataTableExtensionsTest extends TestCase
+{
+    #[Test]
+    public function it_configures_all_extensions_through_configure_extensions(): void
+    {
+        $table = new class extends AbstractDataTable {
+            public function configureDataTable(DataTable $table): DataTable
+            {
+                return $table->layout(Feature::BUTTONS);
+            }
+
+            public function configureColumns(): iterable
+            {
+                yield TextColumn::new('id');
+            }
+
+            public function configureExtensions(DataTableExtensions $extensions): DataTableExtensions
+            {
+                return $extensions
+                    ->addExtension(new ButtonsExtension([ButtonType::CSV]))
+                    ->addExtension(new ColumnControlExtension())
+                    ->addExtension(new SelectExtension());
+            }
+        };
+
+        $this->assertSame([
+            'topStart' => [
+                'buttons' => [
+                    [
+                        'extend'        => 'csv',
+                        'exportOptions' => [
+                            'columns' => ':visible:not(.not-exportable)',
+                        ],
+                    ],
+                ],
+            ],
+            'topEnd' => 'search',
+            'bottomStart' => 'info',
+            'bottomEnd' => [
+                'paging' => true,
+            ],
+        ], $table->getDataTable()->getOptions()['layout']);
+
+        $this->assertSame([
+            'columnControl' => [
+                [
+                    'target'  => 0,
+                    'content' => [
+                        'order',
+                        [
+                            'orderAsc',
+                            'orderDesc',
+                            'spacer',
+                            'orderAddAsc',
+                            'orderAddDesc',
+                            'spacer',
+                            'orderRemove',
+                        ],
+                    ],
+                ],
+                [
+                    'target'  => 1,
+                    'content' => ['search'],
+                ],
+            ],
+            'select' => [
+                'blurable'       => false,
+                'className'      => 'selected',
+                'info'           => true,
+                'items'          => 'row',
+                'keys'           => false,
+                'style'          => 'single',
+                'toggleable'     => true,
+                'headerCheckbox' => false,
+                'withCheckbox'   => false,
+            ],
+        ], $table->getDataTable()->getExtensions());
+    }
+}


### PR DESCRIPTION
Replaced individual extension configuration methods with a single `configureExtensions()` method. Updated tests, documentation, and removed redundant methods from `AbstractDataTable`.