### PR TITLE
Refactor `AbstractDataTable` initialization logic

### DIFF
--- a/src/Model/AbstractDataTable.php
+++ b/src/Model/AbstractDataTable.php
@@ -62,17 +62,26 @@ abstract class AbstractDataTable
         protected ?TemplateColumnRenderer $templateColumnRenderer = null,
         protected ?ActionRowDataResolver $actionRowDataResolver = null,
     ) {
+        $this->initializeTable();
+        $this->initializeColumns();
+        $this->initializeExtensions();
+    }
+
+    private function initializeTable(): void
+    {
         $this->table = $this->configureDataTable(
             new DataTable($this->getClassName())
         );
+    }
 
+    private function initializeColumns(): void
+    {
         $this->columns = iterator_to_array($this->configureColumns());
 
         $this->configureBooleanColumns();
         $this->configureUrlColumns();
 
         $actions = $this->configureActions(new Actions());
-
         $this->configureActionEntityClass($actions);
 
         if (!$actions->isEmpty()) {
@@ -84,7 +93,10 @@ abstract class AbstractDataTable
         }
 
         $this->table->columns($this->columns);
+    }
 
+    private function initializeExtensions(): void
+    {
         $this->table->setExtensions(
             $this->configureExtensions(new DataTableExtensions())
         );

--- a/tests/Unit/Column/AbstractColumnTest.php
+++ b/tests/Unit/Column/AbstractColumnTest.php
@@ -11,6 +11,9 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @internal
+ */
 #[CoversClass(AbstractColumn::class)]
 final class AbstractColumnTest extends TestCase
 {

--- a/tests/Unit/Model/AbstractDataTableExtensionsTest.php
+++ b/tests/Unit/Model/AbstractDataTableExtensionsTest.php
@@ -57,9 +57,9 @@ final class AbstractDataTableExtensionsTest extends TestCase
                     ],
                 ],
             ],
-            'topEnd' => 'search',
+            'topEnd'      => 'search',
             'bottomStart' => 'info',
-            'bottomEnd' => [
+            'bottomEnd'   => [
                 'paging' => true,
             ],
         ], $table->getDataTable()->getOptions()['layout']);


### PR DESCRIPTION
Introduce private methods to streamline table, columns, and extension initialization. Add internal annotation for `AbstractColumnTest` and fix formatting in test layout assertions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization and structure for better maintainability.

* **Tests**
  * Enhanced test annotations and formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->