### PR TITLE
Add `apiPlatform` opt-in for API Platform integration

### DIFF
--- a/docs/src/content/docs/integrations/api-platform.mdx
+++ b/docs/src/content/docs/integrations/api-platform.mdx
@@ -5,23 +5,67 @@ description: Use UX DataTables with API Platform collections and Hydra responses
 
 # API Platform Integration
 
-UX DataTables supports two integration paths with API Platform.
+API Platform integration is **opt-in**. The mere presence of `#[AsDataTable(Entity::class)]` does not activate any API Platform behavior. You must explicitly enable it with one of the two opt-in mechanisms below.
 
-## 1) Ajax Adapter Mode (`DataTable::apiPlatform()`)
+## Opt-in mechanisms
 
-Use this mode when DataTables runs in server-side mode and your endpoint is an API Platform collection.
+### 1) Attribute opt-in: `#[AsDataTable(..., apiPlatform: true)]`
+
+Add `apiPlatform: true` to the attribute on your DataTable class. This enables:
+
+- Automatic Ajax URL resolution from API Platform collection metadata
+- Auto-detection of columns from API Platform property metadata
+
+```php
+use Pentiminax\UX\DataTables\Attribute\AsDataTable;
+use Pentiminax\UX\DataTables\Model\AbstractDataTable;
+
+#[AsDataTable(entityClass: Book::class, apiPlatform: true)]
+class BookDataTable extends AbstractDataTable
+{
+}
+```
+
+### 2) Imperative opt-in: `DataTable::apiPlatform(true)` in `configureDataTable()`
+
+Use this mode when you need to point to an explicit Ajax URL (e.g. a custom endpoint) while still using the API Platform Hydra adapter on the frontend.
 
 ```php
 use Pentiminax\UX\DataTables\Model\DataTable;
 
-$dataTable = new DataTable('books');
-$dataTable
-    ->ajax('/api/books')
-    ->serverSide(true)
-    ->apiPlatform(true);
+public function configureDataTable(DataTable $table): DataTable
+{
+    return $table
+        ->ajax('/api/books')
+        ->serverSide(true)
+        ->apiPlatform(true);
+}
 ```
 
-The frontend adapter converts:
+When `apiPlatform(true)` is called in `configureDataTable()` but no explicit `ajax()` URL is set, the bundle will still attempt to resolve the collection URL automatically from API Platform metadata (provided `#[AsDataTable]` is present).
+
+## Ajax auto-wiring (attribute opt-in only)
+
+When `#[AsDataTable(entityClass: Book::class, apiPlatform: true)]` is present and no explicit `ajax()` or `data()` option has been set, the bundle resolves the API Platform collection URL and configures Ajax automatically.
+
+<Table
+  headers={['Option', 'Value']}
+  rows={[
+    ['`ajax.url`', 'Resolved from API Platform collection metadata (e.g. `/api/books`)'],
+    ['`ajax.type`', '`GET`'],
+    ['`apiPlatform`', '`true`'],
+  ]}
+/>
+
+Auto-wiring is skipped if:
+
+- `ajax()` is already set (explicit URL takes priority)
+- `data()` is already set (client-side mode)
+- No collection URL can be resolved from API Platform metadata
+
+## Frontend adapter (both opt-ins)
+
+When `apiPlatform` is enabled, the Stimulus controller activates a Hydra adapter that converts:
 
 <Table
   headers={['Input', 'Output']}
@@ -39,67 +83,26 @@ Notes:
 - Date formatting is handled by the backend payload. The adapter does not reformat date values on the client.
 - When API Platform adapter mode is enabled, `serverSide` is enforced so sorting and filtering stay consistent with API queries.
 
-## 2) AbstractDataTable Auto Ajax Wiring
+## Column auto-detection
 
-When rendering an `AbstractDataTable`, calling `getDataTable()` auto-configures Ajax for API resources when possible.
+Column auto-detection from API Platform property metadata is also gated behind the opt-in. Without `apiPlatform: true`, the auto-detector is never called even if API Platform is installed.
 
-<Table
-  headers={['Aspect', 'Value']}
-  rows={[
-    ['Trigger', '`getDataTable()` / Twig rendering of `AbstractDataTable`'],
-    ['Purpose', 'Auto-configure Ajax options for API Platform resources'],
-    ['Applied to', 'Tables with resolvable API Platform collection metadata'],
-  ]}
-/>
-
-Conditions:
-
-<Table
-  headers={['Condition', 'Required']}
-  rows={[
-    ['No explicit `ajax` option', 'Yes'],
-    ['No explicit `data` option', 'Yes'],
-    ['`#[AsDataTable(...)]` exists', 'Yes'],
-    ['A collection URL can be resolved from API Platform metadata', 'Yes'],
-  ]}
-/>
-
-If `#[AsDataTable(..., mercure: true)]` is also enabled and a Mercure hub is configured, the same preparation pass can auto-attach Mercure topics for live reload.
-
-<Aside type="note">
-  `prepareForRendering()` is still available and remains idempotent, but normal rendering no longer
-  needs to call it manually.
-</Aside>
-
-Example resolved output:
-
-<Table
-  headers={['Option', 'Value']}
-  rows={[
-    ['`ajax.url`', '`/api/books`'],
-    ['`ajax.type`', '`GET`'],
-    ['`apiPlatform`', '`true`'],
-  ]}
-/>
-
-## Column Auto Detection
-
-If API Platform metadata is available, columns can be auto-detected from readable properties.
-
-`#[AsDataTable]` supports serialization groups:
+`#[AsDataTable]` supports serialization groups to filter exposed properties:
 
 ```php
-#[AsDataTable(Book::class, serializationGroups: ['book:list'])]
+#[AsDataTable(Book::class, serializationGroups: ['book:list'], apiPlatform: true)]
 ```
 
-## Frequent Pitfalls
+## Frequent pitfalls
 
+- Using `#[AsDataTable(Entity::class)]` alone and expecting Ajax or columns to be auto-configured — add `apiPlatform: true`.
 - Enabling adapter mode without an Ajax endpoint.
-- Expecting auto Ajax wiring when `ajax` or `data` is already set.
+- Expecting auto Ajax wiring when `ajax()` or `data()` is already set.
 - Forgetting that non-readable resource properties are skipped in auto-detection.
 
 ## Cross Links
 
+- [/ux-datatables/reference/attributes/](/ux-datatables/reference/attributes/)
 - [/ux-datatables/reference/abstract-datatable/](/ux-datatables/reference/abstract-datatable/)
 - [/ux-datatables/guide/data-loading/](/ux-datatables/guide/data-loading/)
 - [/ux-datatables/guide/server-side-processing/](/ux-datatables/guide/server-side-processing/)

--- a/docs/src/content/docs/reference/attributes.mdx
+++ b/docs/src/content/docs/reference/attributes.mdx
@@ -10,7 +10,7 @@ description: Reference for AsDataTable and Column PHP attributes
 Target: class
 
 ```php
-#[AsDataTable(User::class, serializationGroups: ['user:list'], mercure: true)]
+#[AsDataTable(User::class, serializationGroups: ['user:list'], mercure: true, apiPlatform: true)]
 ```
 
 Arguments:
@@ -23,7 +23,7 @@ Arguments:
       '`serializationGroups`',
       '`string[]`',
       '`[]`',
-      'API Platform serialization groups for auto-detection',
+      'API Platform serialization groups used during column auto-detection (requires `apiPlatform: true`)',
     ],
     [
       '`mercure`',
@@ -31,14 +31,20 @@ Arguments:
       '`false`',
       'Enable automatic Mercure config resolution for the table',
     ],
+    [
+      '`apiPlatform`',
+      '`bool`',
+      '`false`',
+      'Opt-in to API Platform integration: auto Ajax URL wiring and column auto-detection from API Platform metadata',
+    ],
   ]}
 />
 
 Use this attribute to:
 
 - auto-configure the Doctrine data provider used internally by `AbstractDataTable`
-- enable API Platform-driven column auto-detection
-- resolve API collection URL for auto Ajax wiring
+- opt-in to API Platform-driven column auto-detection (`apiPlatform: true` required)
+- opt-in to automatic API collection URL resolution for Ajax wiring (`apiPlatform: true` required)
 - auto-attach a Mercure config when Mercure is enabled for the table
 
 ## `#[Column]`

--- a/src/Attribute/AsDataTable.php
+++ b/src/Attribute/AsDataTable.php
@@ -9,11 +9,13 @@ final class AsDataTable
 {
     /**
      * @param string[] $serializationGroups Groups used to filter exposed properties during column auto-detection
+     * @param bool     $apiPlatform         Opt-in to API Platform integration (auto Ajax wiring, URL resolution, column auto-detection)
      */
     public function __construct(
         public readonly string $entityClass,
         public readonly array $serializationGroups = [],
         public readonly bool $mercure = false,
+        public readonly bool $apiPlatform = false,
     ) {
     }
 }

--- a/src/Column/ColumnResolver.php
+++ b/src/Column/ColumnResolver.php
@@ -69,6 +69,10 @@ final class ColumnResolver
             return [];
         }
 
+        if (!$asDataTable->apiPlatform) {
+            return [];
+        }
+
         $resolvedGroups = $groups ?: $asDataTable->serializationGroups;
 
         if (!$this->columnAutoDetector->supports($asDataTable->entityClass)) {

--- a/src/Rendering/RenderingPreparer.php
+++ b/src/Rendering/RenderingPreparer.php
@@ -28,26 +28,25 @@ final class RenderingPreparer
 
     private function configureApiPlatform(DataTable $table, ?AsDataTable $asDataTable): void
     {
-        if (null !== $table->getOption('ajax') || null !== $table->getOption('data')) {
-            return;
-        }
-
-        if (null === $this->urlResolver) {
-            return;
-        }
-
-        if (null === $asDataTable) {
+        if (!$this->canAutoWireApiPlatform($table, $asDataTable)) {
             return;
         }
 
         $collectionUrl = $this->urlResolver->resolveCollectionUrl($asDataTable->entityClass);
 
-        if (null === $collectionUrl) {
-            return;
+        if (null !== $collectionUrl) {
+            $table->ajax($collectionUrl);
+            $table->apiPlatform();
         }
+    }
 
-        $table->ajax($collectionUrl);
-        $table->apiPlatform();
+    private function canAutoWireApiPlatform(DataTable $table, ?AsDataTable $asDataTable): bool
+    {
+        return null === $table->getOption('ajax')
+            && null === $table->getOption('data')
+            && null !== $this->urlResolver
+            && null !== $asDataTable
+            && ($asDataTable->apiPlatform || $table->getOption('apiPlatform'));
     }
 
     private function configureMercure(DataTable $table, ?AsDataTable $asDataTable): void

--- a/tests/Fixtures/DataTable/AutoDetectTestDataTable.php
+++ b/tests/Fixtures/DataTable/AutoDetectTestDataTable.php
@@ -9,7 +9,7 @@ use Pentiminax\UX\DataTables\Column\ColumnResolver;
 use Pentiminax\UX\DataTables\Contracts\ColumnAutoDetectorInterface;
 use Pentiminax\UX\DataTables\Model\AbstractDataTable;
 
-#[AsDataTable(entityClass: \stdClass::class)]
+#[AsDataTable(entityClass: \stdClass::class, apiPlatform: true)]
 class AutoDetectTestDataTable extends AbstractDataTable
 {
     public function __construct(?ColumnAutoDetectorInterface $columnAutoDetector = null)

--- a/tests/Fixtures/DataTable/AutoDetectWithoutApiPlatformOptInDataTable.php
+++ b/tests/Fixtures/DataTable/AutoDetectWithoutApiPlatformOptInDataTable.php
@@ -9,8 +9,8 @@ use Pentiminax\UX\DataTables\Column\ColumnResolver;
 use Pentiminax\UX\DataTables\Contracts\ColumnAutoDetectorInterface;
 use Pentiminax\UX\DataTables\Model\AbstractDataTable;
 
-#[AsDataTable(entityClass: \stdClass::class, serializationGroups: ['product:list'], apiPlatform: true)]
-class AutoDetectWithGroupsDataTable extends AbstractDataTable
+#[AsDataTable(entityClass: \stdClass::class)]
+class AutoDetectWithoutApiPlatformOptInDataTable extends AbstractDataTable
 {
     public function __construct(?ColumnAutoDetectorInterface $columnAutoDetector = null)
     {

--- a/tests/Fixtures/DataTable/TestDataTableWithAttribute.php
+++ b/tests/Fixtures/DataTable/TestDataTableWithAttribute.php
@@ -11,7 +11,7 @@ use Pentiminax\UX\DataTables\Contracts\MercureConfigResolverInterface;
 use Pentiminax\UX\DataTables\Model\AbstractDataTable;
 use Pentiminax\UX\DataTables\Rendering\RenderingPreparer;
 
-#[AsDataTable(entityClass: \stdClass::class)]
+#[AsDataTable(entityClass: \stdClass::class, apiPlatform: true)]
 class TestDataTableWithAttribute extends AbstractDataTable
 {
     public function __construct(

--- a/tests/Fixtures/DataTable/TestDataTableWithServerSide.php
+++ b/tests/Fixtures/DataTable/TestDataTableWithServerSide.php
@@ -12,7 +12,7 @@ use Pentiminax\UX\DataTables\Model\AbstractDataTable;
 use Pentiminax\UX\DataTables\Model\DataTable;
 use Pentiminax\UX\DataTables\Rendering\RenderingPreparer;
 
-#[AsDataTable(entityClass: \stdClass::class)]
+#[AsDataTable(entityClass: \stdClass::class, apiPlatform: true)]
 class TestDataTableWithServerSide extends AbstractDataTable
 {
     public function __construct(

--- a/tests/Unit/ApiPlatform/AbstractDataTableAutoDetectTest.php
+++ b/tests/Unit/ApiPlatform/AbstractDataTableAutoDetectTest.php
@@ -11,6 +11,7 @@ use Pentiminax\UX\DataTables\Model\AbstractDataTable;
 use Pentiminax\UX\DataTables\Tests\Fixtures\DataTable\AutoDetectNoAttributeDataTable;
 use Pentiminax\UX\DataTables\Tests\Fixtures\DataTable\AutoDetectTestDataTable;
 use Pentiminax\UX\DataTables\Tests\Fixtures\DataTable\AutoDetectWithGroupsDataTable;
+use Pentiminax\UX\DataTables\Tests\Fixtures\DataTable\AutoDetectWithoutApiPlatformOptInDataTable;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -37,6 +38,18 @@ final class AbstractDataTableAutoDetectTest extends TestCase
         $detector->expects($this->never())->method('detectColumns');
 
         $table = new AutoDetectNoAttributeDataTable(columnAutoDetector: $detector);
+
+        $this->assertSame([], $table->getDataTable()->getColumns());
+    }
+
+    #[Test]
+    public function it_returns_empty_columns_without_api_platform_opt_in(): void
+    {
+        $detector = $this->createMock(ColumnAutoDetectorInterface::class);
+        $detector->expects($this->never())->method('supports');
+        $detector->expects($this->never())->method('detectColumns');
+
+        $table = new AutoDetectWithoutApiPlatformOptInDataTable(columnAutoDetector: $detector);
 
         $this->assertSame([], $table->getDataTable()->getColumns());
     }

--- a/tests/Unit/Column/ColumnResolverTest.php
+++ b/tests/Unit/Column/ColumnResolverTest.php
@@ -49,6 +49,18 @@ final class ColumnResolverTest extends TestCase
     }
 
     #[Test]
+    public function auto_detect_returns_empty_without_api_platform_opt_in(): void
+    {
+        $detector = $this->createMock(ColumnAutoDetectorInterface::class);
+        $detector->expects($this->never())->method('supports');
+        $detector->expects($this->never())->method('detectColumns');
+
+        $resolver = new ColumnResolver(columnAutoDetector: $detector);
+
+        $this->assertSame([], $resolver->autoDetectColumns(new AsDataTable(entityClass: \stdClass::class)));
+    }
+
+    #[Test]
     public function auto_detect_returns_empty_when_not_supported(): void
     {
         $detector = $this->createMock(ColumnAutoDetectorInterface::class);
@@ -57,7 +69,7 @@ final class ColumnResolverTest extends TestCase
 
         $resolver = new ColumnResolver(columnAutoDetector: $detector);
 
-        $this->assertSame([], $resolver->autoDetectColumns(new AsDataTable(entityClass: \stdClass::class)));
+        $this->assertSame([], $resolver->autoDetectColumns(new AsDataTable(entityClass: \stdClass::class, apiPlatform: true)));
     }
 
     #[Test]
@@ -74,7 +86,7 @@ final class ColumnResolverTest extends TestCase
 
         $resolver = new ColumnResolver(columnAutoDetector: $detector);
 
-        $this->assertSame($expected, $resolver->autoDetectColumns(new AsDataTable(entityClass: \stdClass::class)));
+        $this->assertSame($expected, $resolver->autoDetectColumns(new AsDataTable(entityClass: \stdClass::class, apiPlatform: true)));
     }
 
     #[Test]
@@ -91,7 +103,7 @@ final class ColumnResolverTest extends TestCase
         $resolver = new ColumnResolver(columnAutoDetector: $detector);
 
         $resolver->autoDetectColumns(
-            new AsDataTable(entityClass: \stdClass::class, serializationGroups: ['product:list'])
+            new AsDataTable(entityClass: \stdClass::class, serializationGroups: ['product:list'], apiPlatform: true)
         );
     }
 
@@ -109,7 +121,7 @@ final class ColumnResolverTest extends TestCase
         $resolver = new ColumnResolver(columnAutoDetector: $detector);
 
         $resolver->autoDetectColumns(
-            new AsDataTable(entityClass: \stdClass::class, serializationGroups: ['product:list']),
+            new AsDataTable(entityClass: \stdClass::class, serializationGroups: ['product:list'], apiPlatform: true),
             ['custom:group']
         );
     }
@@ -228,7 +240,7 @@ final class ColumnResolverTest extends TestCase
 
         $this->assertSame(
             $expected,
-            $resolver->resolveColumns(new AsDataTable(entityClass: \stdClass::class))
+            $resolver->resolveColumns(new AsDataTable(entityClass: \stdClass::class, apiPlatform: true))
         );
     }
 }

--- a/tests/Unit/Rendering/RenderingPreparerTest.php
+++ b/tests/Unit/Rendering/RenderingPreparerTest.php
@@ -59,12 +59,46 @@ final class RenderingPreparerTest extends TestCase
         $preparer = new RenderingPreparer(urlResolver: $urlResolver);
         $table    = new DataTable('Test');
 
-        $preparer->prepare($table, new AsDataTable(entityClass: \stdClass::class));
+        $preparer->prepare($table, new AsDataTable(entityClass: \stdClass::class, apiPlatform: true));
 
         $ajax = $table->getOption('ajax');
         $this->assertIsArray($ajax);
         $this->assertSame('/api/products', $ajax['url']);
         $this->assertTrue($table->getOption('apiPlatform'));
+    }
+
+    #[Test]
+    public function it_skips_api_platform_without_opt_in(): void
+    {
+        $urlResolver = $this->createMock(ApiResourceCollectionUrlResolverInterface::class);
+        $urlResolver->expects($this->never())->method('resolveCollectionUrl');
+
+        $preparer = new RenderingPreparer(urlResolver: $urlResolver);
+        $table    = new DataTable('Test');
+
+        $preparer->prepare($table, new AsDataTable(entityClass: \stdClass::class));
+
+        $this->assertNull($table->getOption('ajax'));
+        $this->assertNull($table->getOption('apiPlatform'));
+    }
+
+    #[Test]
+    public function it_configures_api_platform_ajax_when_opted_in_via_configure_data_table(): void
+    {
+        $urlResolver = $this->createMock(ApiResourceCollectionUrlResolverInterface::class);
+        $urlResolver->method('resolveCollectionUrl')
+            ->with(\stdClass::class)
+            ->willReturn('/api/products');
+
+        $preparer = new RenderingPreparer(urlResolver: $urlResolver);
+        $table    = new DataTable('Test');
+        $table->apiPlatform(true);
+
+        $preparer->prepare($table, new AsDataTable(entityClass: \stdClass::class));
+
+        $ajax = $table->getOption('ajax');
+        $this->assertIsArray($ajax);
+        $this->assertSame('/api/products', $ajax['url']);
     }
 
     #[Test]
@@ -106,7 +140,7 @@ final class RenderingPreparerTest extends TestCase
         $preparer = new RenderingPreparer(urlResolver: $urlResolver);
         $table    = new DataTable('Test');
 
-        $preparer->prepare($table, new AsDataTable(entityClass: \stdClass::class));
+        $preparer->prepare($table, new AsDataTable(entityClass: \stdClass::class, apiPlatform: true));
 
         $this->assertNull($table->getOption('ajax'));
     }


### PR DESCRIPTION
Add `apiPlatform` opt-in for API Platform integration, enabling automatic column detection and Ajax URL resolution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API Platform integration documentation describing the transition to an explicit opt-in model. All API Platform features and related automatic functionality—including column auto-detection and AJAX collection URL configuration—now require explicit enablement. Previously enabled by default, these features are accessible only when explicitly activated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->