### PR TITLE
Add support for accessing the current Symfony HTTP request

### DIFF
--- a/docs/src/content/docs/reference/abstract-datatable.mdx
+++ b/docs/src/content/docs/reference/abstract-datatable.mdx
@@ -168,8 +168,8 @@ Use request parameters for dynamic filters:
 ```php
 public function queryBuilderConfigurator(QueryBuilder $qb, DataTableRequest $request): QueryBuilder
 {
-    // Access custom parameters
-    if ($roleId = $request->getCustomParameter('role')) {
+    // Access the current Symfony HTTP request for custom parameters
+    if ($roleId = $this->getHttpRequest()?->query->get('role')) {
         $qb->andWhere('e.role = :role')
            ->setParameter('role', $roleId);
     }
@@ -274,6 +274,8 @@ into each action. See the [Action Columns](../action-columns/) reference for the
     ['`createDataProvider()`', 'Protected hook for manual DataProvider instances'],
     ['`getDataProvider()`', 'Public façade returning the resolved provider'],
     ['`fetchData(DataTableRequest $request)`', 'Fetch data using the provider'],
+    ['`getRequest()`', 'Get the parsed DataTables request'],
+    ['`getHttpRequest()`', 'Get the current Symfony HTTP request after `handleRequest()`'],
     ['`mapRow(mixed $item)`', 'Map a single entity to array'],
     ['`createRowMapper()`', 'Protected helper returning the internal row-processing mapper'],
     ['`queryBuilderConfigurator(QueryBuilder $qb, ...)`', 'Modify Doctrine query'],

--- a/src/Model/AbstractDataTable.php
+++ b/src/Model/AbstractDataTable.php
@@ -103,6 +103,11 @@ abstract class AbstractDataTable
         return $this->runtime()->getRequest();
     }
 
+    protected function getHttpRequest(): ?Request
+    {
+        return $this->runtime()->getHttpRequest();
+    }
+
     public function handleRequest(Request $request): static
     {
         $this->runtime()->handleRequest($request);

--- a/src/Runtime/DataTableRuntime.php
+++ b/src/Runtime/DataTableRuntime.php
@@ -13,6 +13,8 @@ use Symfony\Component\HttpFoundation\Request;
 
 final class DataTableRuntime
 {
+    private ?Request $httpRequest = null;
+
     private ?DataTableRequest $request = null;
 
     private ?DataProviderInterface $dataProvider = null;
@@ -30,9 +32,15 @@ final class DataTableRuntime
         return $this->request;
     }
 
+    public function getHttpRequest(): ?Request
+    {
+        return $this->httpRequest;
+    }
+
     public function handleRequest(Request $request): void
     {
-        $this->request = DataTableRequest::fromRequest($request);
+        $this->httpRequest = $request;
+        $this->request     = DataTableRequest::fromRequest($request);
     }
 
     public function isRequestHandled(): bool

--- a/tests/Unit/Model/AbstractDataTableHttpRequestTest.php
+++ b/tests/Unit/Model/AbstractDataTableHttpRequestTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Unit\Model;
+
+use Doctrine\ORM\QueryBuilder;
+use Pentiminax\UX\DataTables\Column\TextColumn;
+use Pentiminax\UX\DataTables\DataTableRequest\Columns;
+use Pentiminax\UX\DataTables\DataTableRequest\DataTableRequest;
+use Pentiminax\UX\DataTables\Model\AbstractDataTable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+#[CoversClass(AbstractDataTable::class)]
+final class AbstractDataTableHttpRequestTest extends TestCase
+{
+    #[Test]
+    public function test_give_n_no_handled_request_whe_n_get_http_request_is_accessed_the_n_null_is_returned(): void
+    {
+        $table = new HttpRequestAwareTable();
+
+        $this->assertNull($table->exposedHttpRequest());
+    }
+
+    #[Test]
+    public function test_give_n_handled_request_whe_n_get_http_request_is_accessed_the_n_same_request_is_returned(): void
+    {
+        $table   = new HttpRequestAwareTable();
+        $request = new Request(query: ['draw' => 3, 'genre' => 'sci-fi']);
+
+        $table->handleRequest($request);
+
+        $this->assertSame($request, $table->exposedHttpRequest());
+    }
+
+    #[Test]
+    public function test_give_n_custom_http_filter_whe_n_query_builder_configurator_runs_the_n_it_reads_the_current_http_request(): void
+    {
+        $table = new HttpRequestAwareTable();
+        $table->handleRequest(new Request(query: ['draw' => 3, 'genre' => 'sci-fi']));
+
+        $qb = $this->createMock(QueryBuilder::class);
+        $qb->expects($this->once())
+            ->method('andWhere')
+            ->with('e.genre = :genre')
+            ->willReturn($qb);
+        $qb->expects($this->once())
+            ->method('setParameter')
+            ->with('genre', 'sci-fi')
+            ->willReturn($qb);
+
+        $request = new DataTableRequest(draw: 3, columns: new Columns([]));
+
+        $result = $table->queryBuilderConfigurator($qb, $request);
+
+        $this->assertSame($qb, $result);
+    }
+}
+
+final class HttpRequestAwareTable extends AbstractDataTable
+{
+    public function configureColumns(): iterable
+    {
+        yield TextColumn::new('id');
+    }
+
+    public function exposedHttpRequest(): ?Request
+    {
+        return $this->getHttpRequest();
+    }
+
+    public function queryBuilderConfigurator(QueryBuilder $qb, DataTableRequest $request): QueryBuilder
+    {
+        $genre = $this->getHttpRequest()?->query->get('genre');
+        if (null === $genre) {
+            return $qb;
+        }
+
+        return $qb
+            ->andWhere('e.genre = :genre')
+            ->setParameter('genre', $genre);
+    }
+}

--- a/tests/Unit/Runtime/DataTableRuntimeTest.php
+++ b/tests/Unit/Runtime/DataTableRuntimeTest.php
@@ -21,6 +21,31 @@ use Symfony\Component\HttpFoundation\Request;
 final class DataTableRuntimeTest extends TestCase
 {
     #[Test]
+    public function test_give_n_no_handled_request_whe_n_get_http_request_the_n_null_is_returned(): void
+    {
+        $runtime = new DataTableRuntime(
+            table: new DataTable('movies'),
+            dataProviderFactory: static fn (): ?DataProviderInterface => null,
+        );
+
+        $this->assertNull($runtime->getHttpRequest());
+    }
+
+    #[Test]
+    public function test_give_n_handled_request_whe_n_get_http_request_the_n_same_request_is_returned(): void
+    {
+        $runtime = new DataTableRuntime(
+            table: new DataTable('movies'),
+            dataProviderFactory: static fn (): ?DataProviderInterface => null,
+        );
+        $request = new Request(query: ['draw' => 7, 'genre' => 'sci-fi']);
+
+        $runtime->handleRequest($request);
+
+        $this->assertSame($request, $runtime->getHttpRequest());
+    }
+
+    #[Test]
     public function it_returns_an_empty_response_when_no_request_has_been_handled(): void
     {
         $runtime = new DataTableRuntime(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added accessor methods to retrieve the current HTTP request and parsed DataTables request within data table configurations.

* **Documentation**
  * Updated dynamic filtering examples to demonstrate reading custom filters from HTTP request parameters.
  * Added method documentation for newly available accessor methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->