### PR TITLE
fix(datatable): preserve typed actions in setData

### DIFF
--- a/docs/src/content/docs/guide/data-loading.mdx
+++ b/docs/src/content/docs/guide/data-loading.mdx
@@ -66,6 +66,16 @@ $dataTable->data([
 ]);
 ```
 
+With `AbstractDataTable`, prefer `setData()` when your source rows are objects and you want the
+normal row-processing pipeline to run:
+
+```php
+$table->setData($products);
+```
+
+`setData()` applies `mapRow()`, template column rendering, and row action URL resolution before
+the inline rows are stored.
+
 ## Mapping Columns To Nested Keys
 
 ```php
@@ -81,6 +91,8 @@ TextColumn::new('amount', 'Amount')
 - Missing `recordsTotal` or `recordsFiltered` in server-side responses.
 - Forgetting `dataSrc` when your API does not return `data`.
 - Handling an Ajax request without resolving a data provider; the response will be empty.
+- Using `data([...])` with object rows while expecting typed action callables; use `setData()`
+  on `AbstractDataTable` instead.
 
 ## Cross Links
 

--- a/docs/src/content/docs/reference/abstract-datatable.mdx
+++ b/docs/src/content/docs/reference/abstract-datatable.mdx
@@ -277,6 +277,7 @@ into each action. See the [Action Columns](../action-columns/) reference for the
     ['`getRequest()`', 'Get the parsed DataTables request'],
     ['`getHttpRequest()`', 'Get the current Symfony HTTP request after `handleRequest()`'],
     ['`mapRow(mixed $item)`', 'Map a single entity to array'],
+    ['`setData(array $data)`', 'Set inline data through the same row-processing pipeline used by providers'],
     ['`createRowMapper()`', 'Protected helper returning the internal row-processing mapper'],
     ['`queryBuilderConfigurator(QueryBuilder $qb, ...)`', 'Modify Doctrine query'],
   ]}
@@ -323,6 +324,42 @@ final class CustomUsersDataTable extends AbstractDataTable
     }
 }
 ```
+
+`createRowMapper()` and `setData()` both run the built-in row-processing pipeline. That means
+template columns and action URLs are resolved before the rows are stored for inline rendering.
+
+## Inline Data with `setData()`
+
+When you already have rows in memory, `setData()` is the simplest way to populate an
+`AbstractDataTable` without building a custom provider:
+
+```php
+use App\Entity\User;
+
+#[AsDataTable(User::class)]
+final class UsersDataTable extends AbstractDataTable
+{
+    public function configureColumns(): iterable
+    {
+        yield NumberColumn::new('id', 'ID');
+        yield TextColumn::new('email', 'Email');
+    }
+
+    public function configureActions(Actions $actions): Actions
+    {
+        return $actions->add(
+            Action::detail()->linkToUrl(static fn (User $user): string => '/users/'.$user->getId())
+        );
+    }
+}
+```
+
+```php
+$table->setData($users);
+```
+
+Use `setData()` when your rows are domain objects or preloaded arrays and you still want
+`mapRow()`, template columns, and typed action callables to work consistently.
 
 If an Ajax request is handled and the resolved provider is `null`, `getResponse()` returns an
 empty DataTables payload using the current `draw` value:

--- a/docs/src/content/docs/reference/action-columns.mdx
+++ b/docs/src/content/docs/reference/action-columns.mdx
@@ -96,6 +96,14 @@ When `configureActions()` returns at least one action, `AbstractDataTable` autom
   ]}
 />
 
+When `linkToUrl()` receives a callable, the argument depends on how the row was produced:
+
+- `AbstractDataTable` + provider or `setData($objects)`:
+  the callable receives the original source object, so typed closures such as
+  `static fn (User $user): string => ...` work as expected
+- manual `DataTable::data([...])` inline rows:
+  the callable receives the row array, so use `static fn (array $row): string => ...`
+
 ## `Actions` API
 
 <Table

--- a/docs/src/content/docs/reference/data-providers-row-mappers.mdx
+++ b/docs/src/content/docs/reference/data-providers-row-mappers.mdx
@@ -82,6 +82,10 @@ protected function createDataProvider(): ?DataProviderInterface
 }
 ```
 
+`$this->createRowMapper()` is the important part: it preserves the same mapping, template
+rendering, and action-resolution behavior as the built-in Doctrine provider. `setData()` on
+`AbstractDataTable` uses that same pipeline for inline rows.
+
 ## Cross Links
 
 - [/ux-datatables/reference/abstract-datatable/](/ux-datatables/reference/abstract-datatable/)

--- a/src/Column/ActionRowDataResolver.php
+++ b/src/Column/ActionRowDataResolver.php
@@ -15,6 +15,10 @@ final class ActionRowDataResolver
      */
     public function resolveRow(array $row, mixed $sourceRow, iterable $columns): array
     {
+        if (\array_key_exists(self::ROW_ACTIONS_KEY, $row)) {
+            return $row;
+        }
+
         $actions = [];
 
         foreach ($columns as $column) {

--- a/src/Model/AbstractDataTable.php
+++ b/src/Model/AbstractDataTable.php
@@ -231,6 +231,20 @@ abstract class AbstractDataTable
         );
     }
 
+    public function setData(array $data): void
+    {
+        $rowMapper = $this->createRowMapper();
+
+        $rows = (static function () use ($data, $rowMapper) {
+            foreach ($data as $item) {
+                yield $rowMapper->map($item);
+            }
+        })();
+
+        $this->table->data(iterator_to_array($rows));
+        $this->table->markTemplateColumnsRendered();
+    }
+
     private function getDefaultRowMapper(): DefaultRowMapper
     {
         if (null === $this->defaultRowMapper) {

--- a/tests/Unit/Model/AbstractDataTableMapRowTest.php
+++ b/tests/Unit/Model/AbstractDataTableMapRowTest.php
@@ -127,6 +127,60 @@ final class AbstractDataTableMapRowTest extends TestCase
 
         $this->assertSame('/movies/8', $mappedRow['__ux_datatables_actions']['DETAIL']['url']);
     }
+
+    #[Test]
+    public function it_sets_inline_data_from_objects_with_typed_action_closure(): void
+    {
+        $table = new TypedDetailActionSetDataTable([
+            TextColumn::new('id'),
+            TextColumn::new('title'),
+        ]);
+
+        $table->setData([
+            new MovieRow(
+                id: 11,
+                title: 'Blade Runner',
+                releasedAt: new \DateTimeImmutable('1982-06-25')
+            ),
+        ]);
+
+        $data = $table->getDataTable()->getOption('data');
+
+        $this->assertSame([
+            [
+                'id'                     => 11,
+                'title'                  => 'Blade Runner',
+                'actions'                => null,
+                '__ux_datatables_actions' => [
+                    'DETAIL' => ['url' => '/movies/11'],
+                ],
+            ],
+        ], $data);
+        $this->assertTrue($table->getDataTable()->areTemplateColumnsRendered());
+    }
+
+    #[Test]
+    public function it_sets_inline_data_from_arrays_with_array_action_closure(): void
+    {
+        $table = new ArrayDetailActionSetDataTable([
+            TextColumn::new('id'),
+            TextColumn::new('title'),
+        ]);
+
+        $table->setData([
+            ['id' => 12, 'title' => 'Alien'],
+        ]);
+
+        $this->assertSame([
+            [
+                'id'                     => 12,
+                'title'                  => 'Alien',
+                '__ux_datatables_actions' => [
+                    'DETAIL' => ['url' => '/movies/12'],
+                ],
+            ],
+        ], $table->getDataTable()->getOption('data'));
+    }
 }
 
 final class MapRowTestTable extends AbstractDataTable
@@ -177,6 +231,54 @@ final class DetailActionMapRowTestTable extends AbstractDataTable
     public function renderRowPublic(mixed $row): array
     {
         return $this->createRowMapper()->map($row);
+    }
+}
+
+final class TypedDetailActionSetDataTable extends AbstractDataTable
+{
+    public function __construct(private readonly array $columnsConfig)
+    {
+        parent::__construct(
+            runtimeFactory: new DataTableRuntimeFactory(
+                actionRowDataResolver: new ActionRowDataResolver(),
+            ),
+        );
+    }
+
+    public function configureColumns(): iterable
+    {
+        return $this->columnsConfig;
+    }
+
+    public function configureActions(Actions $actions): Actions
+    {
+        return $actions->add(
+            Action::detail()->linkToUrl(static fn (MovieRow $row): string => '/movies/'.$row->getId())
+        );
+    }
+}
+
+final class ArrayDetailActionSetDataTable extends AbstractDataTable
+{
+    public function __construct(private readonly array $columnsConfig)
+    {
+        parent::__construct(
+            runtimeFactory: new DataTableRuntimeFactory(
+                actionRowDataResolver: new ActionRowDataResolver(),
+            ),
+        );
+    }
+
+    public function configureColumns(): iterable
+    {
+        return $this->columnsConfig;
+    }
+
+    public function configureActions(Actions $actions): Actions
+    {
+        return $actions->add(
+            Action::detail()->linkToUrl(static fn (array $row): string => '/movies/'.$row['id'])
+        );
     }
 }
 

--- a/tests/Unit/Twig/DataTablesExtensionTest.php
+++ b/tests/Unit/Twig/DataTablesExtensionTest.php
@@ -273,4 +273,94 @@ final class DataTablesExtensionTest extends TestCase
 
         $this->assertSame('/books/5', $actual['data'][0]['__ux_datatables_actions']['DETAIL']['url']);
     }
+
+    #[Test]
+    public function it_keeps_set_data_rows_prepared_during_rendering(): void
+    {
+        $kernel = new TwigAppKernel('test', true);
+        $kernel->boot();
+        $container = $kernel->getContainer()->get('test.service_container');
+
+        /** @var DataTablesExtension $twigExtension */
+        $twigExtension = $container->get('test.datatables.twig_extension');
+        $reflection    = new \ReflectionClass($twigExtension);
+
+        $templateRendererProperty = $reflection->getProperty('templateColumnRenderer');
+        $templateRendererProperty->setAccessible(true);
+
+        $actionResolverProperty = $reflection->getProperty('actionRowDataResolver');
+        $actionResolverProperty->setAccessible(true);
+
+        $table = new InlinePreparedDataTable(
+            $templateRendererProperty->getValue($twigExtension),
+            $actionResolverProperty->getValue($twigExtension),
+        );
+
+        $table->setData([
+            new InlineBookEntity(id: 5, status: 'active'),
+        ]);
+
+        $this->assertTrue($table->getDataTable()->areTemplateColumnsRendered());
+
+        $rendered = $container->get('test.datatables.twig_extension')->renderDataTable($table);
+
+        $dom = new \DOMDocument();
+        $dom->loadHTML($rendered);
+        $tableEl = $dom->getElementsByTagName('table')->item(0);
+
+        $jsonAttr = html_entity_decode($tableEl->getAttribute('data-pentiminax--ux-datatables--datatable-view-value'));
+        $actual   = json_decode($jsonAttr, true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('<span class="badge">5-active</span>', trim($actual['data'][0]['status']));
+        $this->assertSame('/books/5', $actual['data'][0]['__ux_datatables_actions']['DETAIL']['url']);
+    }
+}
+
+final readonly class InlineBookEntity
+{
+    public function __construct(
+        private int $id,
+        private string $status,
+    ) {
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+}
+
+final class InlinePreparedDataTable extends AbstractDataTable
+{
+    public function __construct(
+        \Pentiminax\UX\DataTables\Column\TemplateColumnRenderer $templateColumnRenderer,
+        \Pentiminax\UX\DataTables\Column\ActionRowDataResolver $actionRowDataResolver,
+    ) {
+        parent::__construct(
+            runtimeFactory: new \Pentiminax\UX\DataTables\Runtime\DataTableRuntimeFactory(
+                templateColumnRenderer: $templateColumnRenderer,
+                actionRowDataResolver: $actionRowDataResolver,
+            ),
+        );
+    }
+
+    public function configureColumns(): iterable
+    {
+        yield TextColumn::new('id');
+        yield TemplateColumn::new('status_display')
+            ->setField('status')
+            ->setTemplate('datatable/columns/status_badge.html.twig');
+    }
+
+    public function configureActions(Actions $actions): Actions
+    {
+        return $actions->add(
+            Action::detail()->linkToUrl(static fn (InlineBookEntity $book): string => '/books/'.$book->getId())
+        );
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `setData()` method for inline data that ensures proper template column rendering and action URL resolution.

* **Documentation**
  * Updated inline data handling guidance recommending `setData()` for object rows.
  * Clarified action callable signatures and behavior for different row sources.
  * Added usage examples demonstrating inline data configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->