### PR TITLE
fix(row-mapper): normalize relation objects in pipeline for custom mapRow()

### DIFF
--- a/src/RowMapper/DefaultRowMapper.php
+++ b/src/RowMapper/DefaultRowMapper.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Pentiminax\UX\DataTables\RowMapper;
 
-use Pentiminax\UX\DataTables\Column\DateColumn;
 use Pentiminax\UX\DataTables\Column\Rendering\PropertyReader;
 use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
 use Pentiminax\UX\DataTables\Contracts\RowMapperInterface;
@@ -46,8 +45,7 @@ final class DefaultRowMapper implements RowMapperInterface
                 continue;
             }
 
-            $value        = PropertyReader::readPath($row, $this->resolveReadPath($column, $key));
-            $mapped[$key] = $this->normalizeValue($column, $value);
+            $mapped[$key] = PropertyReader::readPath($row, $this->resolveReadPath($column, $key));
         }
 
         return $mapped ?: get_object_vars($row);
@@ -65,18 +63,5 @@ final class DefaultRowMapper implements RowMapperInterface
         $field = $column->getField();
 
         return (null !== $field && $field !== $column->getName()) ? $field : $key;
-    }
-
-    private function normalizeValue(ColumnInterface $column, mixed $value): mixed
-    {
-        if ($column instanceof DateColumn && $value instanceof \DateTimeInterface) {
-            return $value->format($column->getFormat());
-        }
-
-        if ($value instanceof \Stringable) {
-            return (string) $value;
-        }
-
-        return \is_object($value) ? null : $value;
     }
 }

--- a/src/RowMapper/RowProcessingPipeline.php
+++ b/src/RowMapper/RowProcessingPipeline.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Pentiminax\UX\DataTables\RowMapper;
 
+use Pentiminax\UX\DataTables\Column\DateColumn;
 use Pentiminax\UX\DataTables\Column\Rendering\ActionRowDataResolver;
+use Pentiminax\UX\DataTables\Column\Rendering\PropertyReader;
 use Pentiminax\UX\DataTables\Column\Rendering\TemplateColumnRenderer;
 use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
 use Pentiminax\UX\DataTables\Contracts\RowMapperInterface;
@@ -27,6 +29,8 @@ final class RowProcessingPipeline implements RowMapperInterface
     {
         $mappedRow = ($this->baseMapper)($row);
 
+        $mappedRow = $this->normalizeRow($mappedRow);
+
         if (null !== $this->templateColumnRenderer) {
             $mappedRow = $this->templateColumnRenderer->renderRow(
                 row: $mappedRow,
@@ -37,6 +41,40 @@ final class RowProcessingPipeline implements RowMapperInterface
 
         if (null !== $this->actionRowDataResolver) {
             $mappedRow = $this->actionRowDataResolver->resolveRow($mappedRow, $row, $this->columns);
+        }
+
+        return $mappedRow;
+    }
+
+    private function normalizeRow(array $mappedRow): array
+    {
+        foreach ($this->columns as $column) {
+            $key = $column->getData() ?? $column->getName();
+            if (null === $key || '' === $key || !\array_key_exists($key, $mappedRow)) {
+                continue;
+            }
+
+            $value = $mappedRow[$key];
+            if (!\is_object($value)) {
+                continue;
+            }
+
+            $field = $column->getField();
+            if (null !== $field && str_contains($field, '.')) {
+                $resolved = PropertyReader::readPath($mappedRow, $field);
+                if (null !== $resolved && !\is_object($resolved)) {
+                    $mappedRow[$key] = $resolved;
+                    continue;
+                }
+            }
+
+            if ($column instanceof DateColumn && $value instanceof \DateTimeInterface) {
+                $mappedRow[$key] = $value->format($column->getFormat());
+            } elseif ($value instanceof \Stringable) {
+                $mappedRow[$key] = (string) $value;
+            } else {
+                $mappedRow[$key] = null;
+            }
         }
 
         return $mappedRow;

--- a/tests/Unit/Model/AbstractDataTableMapRowTest.php
+++ b/tests/Unit/Model/AbstractDataTableMapRowTest.php
@@ -197,7 +197,7 @@ final class MapRowTestTable extends AbstractDataTable
 
     public function mapRowPublic(mixed $row): array
     {
-        return $this->mapRow($row);
+        return $this->createRowMapper()->map($row);
     }
 }
 

--- a/tests/Unit/RowMapper/DefaultRowMapperTest.php
+++ b/tests/Unit/RowMapper/DefaultRowMapperTest.php
@@ -65,7 +65,7 @@ final class DefaultRowMapperTest extends TestCase
     }
 
     #[Test]
-    public function it_returns_null_when_field_resolves_to_non_stringable_object(): void
+    public function it_returns_raw_object_when_field_resolves_to_non_stringable_object(): void
     {
         $column = TextColumn::new('client', 'Client');
         $mapper = new DefaultRowMapper([$column]);
@@ -85,11 +85,11 @@ final class DefaultRowMapperTest extends TestCase
 
         $result = $mapper->map($row);
 
-        $this->assertNull($result['client']);
+        $this->assertInstanceOf(\stdClass::class, $result['client']);
     }
 
     #[Test]
-    public function it_converts_stringable_object_to_string(): void
+    public function it_converts_stringable_returned_by_getter_to_string(): void
     {
         $column = TextColumn::new('client', 'Client');
         $mapper = new DefaultRowMapper([$column]);
@@ -114,36 +114,12 @@ final class DefaultRowMapperTest extends TestCase
 
         $result = $mapper->map($row);
 
+        // PropertyReader already converts Stringable to string when reading via getter
         $this->assertSame('Stringable Corp', $result['client']);
     }
 
     #[Test]
-    public function it_converts_public_stringable_property_to_string(): void
-    {
-        $column = TextColumn::new('label', 'Label');
-        $mapper = new DefaultRowMapper([$column]);
-
-        $row = new class {
-            public \Stringable $label;
-
-            public function __construct()
-            {
-                $this->label = new class implements \Stringable {
-                    public function __toString(): string
-                    {
-                        return 'Public Label';
-                    }
-                };
-            }
-        };
-
-        $result = $mapper->map($row);
-
-        $this->assertSame('Public Label', $result['label']);
-    }
-
-    #[Test]
-    public function it_formats_date_columns_using_the_configured_format(): void
+    public function it_returns_raw_datetime_without_formatting(): void
     {
         $column = DateColumn::new('createdAt', 'Created At')->setFormat('d/m/Y');
         $mapper = new DefaultRowMapper([$column]);
@@ -157,7 +133,7 @@ final class DefaultRowMapperTest extends TestCase
 
         $result = $mapper->map($row);
 
-        $this->assertSame('15/01/2024', $result['createdAt']);
+        $this->assertInstanceOf(\DateTimeImmutable::class, $result['createdAt']);
     }
 
     #[Test]

--- a/tests/Unit/RowMapper/RowProcessingPipelineTest.php
+++ b/tests/Unit/RowMapper/RowProcessingPipelineTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pentiminax\UX\DataTables\Tests\Unit\RowMapper;
 
 use Pentiminax\UX\DataTables\Column\ActionColumn;
+use Pentiminax\UX\DataTables\Column\DateColumn;
 use Pentiminax\UX\DataTables\Column\Rendering\ActionRowDataResolver;
 use Pentiminax\UX\DataTables\Column\Rendering\TemplateColumnRenderer;
 use Pentiminax\UX\DataTables\Column\TemplateColumn;
@@ -81,6 +82,87 @@ final class RowProcessingPipelineTest extends TestCase
         $mappedRow = $pipeline->map(['id' => 8]);
 
         $this->assertSame('/movies/8', $mappedRow['__ux_datatables_actions']['DETAIL']['url']);
+    }
+
+    #[Test]
+    public function it_resolves_relation_object_via_dotted_field_path(): void
+    {
+        $client = new class {
+            public function getName(): string
+            {
+                return 'Acme Corp';
+            }
+        };
+
+        $pipeline = new RowProcessingPipeline(
+            baseMapper: static fn (mixed $row): array => ['client' => $row],
+            columns: [TextColumn::new('client', 'Client')->setField('client.name')],
+        );
+
+        $mappedRow = $pipeline->map($client);
+
+        $this->assertSame(['client' => 'Acme Corp'], $mappedRow);
+    }
+
+    #[Test]
+    public function it_converts_stringable_object_to_string(): void
+    {
+        $stringable = new class implements \Stringable {
+            public function __toString(): string
+            {
+                return 'My Label';
+            }
+        };
+
+        $pipeline = new RowProcessingPipeline(
+            baseMapper: static fn (mixed $row): array => ['label' => $row],
+            columns: [TextColumn::new('label', 'Label')],
+        );
+
+        $mappedRow = $pipeline->map($stringable);
+
+        $this->assertSame(['label' => 'My Label'], $mappedRow);
+    }
+
+    #[Test]
+    public function it_converts_non_stringable_object_to_null(): void
+    {
+        $pipeline = new RowProcessingPipeline(
+            baseMapper: static fn (mixed $row): array => ['client' => $row],
+            columns: [TextColumn::new('client', 'Client')],
+        );
+
+        $mappedRow = $pipeline->map(new \stdClass());
+
+        $this->assertNull($mappedRow['client']);
+    }
+
+    #[Test]
+    public function it_formats_datetime_values_using_date_column(): void
+    {
+        $date = new \DateTimeImmutable('2024-03-15');
+
+        $pipeline = new RowProcessingPipeline(
+            baseMapper: static fn (mixed $row): array => ['createdAt' => $row],
+            columns: [DateColumn::new('createdAt', 'Date')->setFormat('d/m/Y')],
+        );
+
+        $mappedRow = $pipeline->map($date);
+
+        $this->assertSame(['createdAt' => '15/03/2024'], $mappedRow);
+    }
+
+    #[Test]
+    public function it_leaves_scalar_values_unchanged(): void
+    {
+        $pipeline = new RowProcessingPipeline(
+            baseMapper: static fn (array $row): array => $row,
+            columns: [TextColumn::new('title', 'Title')],
+        );
+
+        $mappedRow = $pipeline->map(['title' => 'Hello World']);
+
+        $this->assertSame(['title' => 'Hello World'], $mappedRow);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- Moves value normalization (dotted field path resolution, `DateTimeInterface` formatting, `Stringable` → string, unknown objects → `null`) from `DefaultRowMapper` into `RowProcessingPipeline`
- `DefaultRowMapper` becomes a pure value reader — single responsibility
- Fixes `[object Object]` rendering when `mapRow()` returns an entity object for a relation column with `->setField('client.name')`

## Root cause

`DefaultRowMapper::normalizeValue()` only ran when using the **default** mapper. Any custom `mapRow()` override bypassed it entirely, leaving raw entity objects in the JSON response (`"client": {}`).

## Usage (now works)

```php
yield TextColumn::new('client', 'Client')->setField('client.name');

protected function mapRow(mixed $row): array
{
    return [
        'id'     => $row->getId(),
        'client' => $row->getClient(), // ✅ auto-resolved via setField
    ];
}
```

## Test plan

- [ ] `vendor/bin/phpunit tests/Unit/RowMapper/RowProcessingPipelineTest.php` — 5 new tests for pipeline normalization
- [ ] `vendor/bin/phpunit tests/Unit/RowMapper/DefaultRowMapperTest.php` — updated for pure reader behavior
- [ ] `vendor/bin/phpunit` — full suite (461 tests)

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized row value normalization to occur at a different stage in the data mapping pipeline, improving code organization and separation of concerns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->