### PR TITLE
refactor(rendering): dispatch column renderers via capability interfaces

### DIFF
--- a/src/Column/ActionColumn.php
+++ b/src/Column/ActionColumn.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace Pentiminax\UX\DataTables\Column;
 
+use Pentiminax\UX\DataTables\Contracts\ActionsProvidingColumnInterface;
 use Pentiminax\UX\DataTables\Enum\ColumnType;
 use Pentiminax\UX\DataTables\Model\Actions;
 
-class ActionColumn extends AbstractColumn
+class ActionColumn extends AbstractColumn implements ActionsProvidingColumnInterface
 {
     private ?Actions $actions = null;
 

--- a/src/Column/Rendering/ActionRowDataResolver.php
+++ b/src/Column/Rendering/ActionRowDataResolver.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Pentiminax\UX\DataTables\Column\Rendering;
 
-use Pentiminax\UX\DataTables\Column\ActionColumn;
+use Pentiminax\UX\DataTables\Contracts\ActionsProvidingColumnInterface;
 use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
 
 final class ActionRowDataResolver
@@ -23,7 +23,7 @@ final class ActionRowDataResolver
         $actions = [];
 
         foreach ($columns as $column) {
-            if (!$column instanceof ActionColumn) {
+            if (!$column instanceof ActionsProvidingColumnInterface) {
                 continue;
             }
 

--- a/src/Column/Rendering/TemplateColumnRenderer.php
+++ b/src/Column/Rendering/TemplateColumnRenderer.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Pentiminax\UX\DataTables\Column\Rendering;
 
-use Pentiminax\UX\DataTables\Column\TemplateColumn;
 use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
+use Pentiminax\UX\DataTables\Contracts\TemplateAwareColumnInterface;
 use Twig\Environment;
 
 final class TemplateColumnRenderer
@@ -26,7 +26,7 @@ final class TemplateColumnRenderer
         $contextRow  = $row;
 
         foreach ($columns as $column) {
-            if (!$column instanceof TemplateColumn) {
+            if (!$column instanceof TemplateAwareColumnInterface) {
                 continue;
             }
 

--- a/src/Column/Rendering/UrlColumnResolver.php
+++ b/src/Column/Rendering/UrlColumnResolver.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Pentiminax\UX\DataTables\Column\Rendering;
 
-use Pentiminax\UX\DataTables\Column\UrlColumn;
 use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
+use Pentiminax\UX\DataTables\Contracts\RouteAwareColumnInterface;
 use Symfony\Component\Routing\RouterInterface;
 
 class UrlColumnResolver
@@ -21,7 +21,7 @@ class UrlColumnResolver
     public function resolveRoutes(array $columns): void
     {
         foreach ($columns as $column) {
-            if (!$column instanceof UrlColumn || null === $column->getRouteName()) {
+            if (!$column instanceof RouteAwareColumnInterface || null === $column->getRouteName()) {
                 continue;
             }
 

--- a/src/Column/TemplateColumn.php
+++ b/src/Column/TemplateColumn.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Pentiminax\UX\DataTables\Column;
 
+use Pentiminax\UX\DataTables\Contracts\TemplateAwareColumnInterface;
 use Pentiminax\UX\DataTables\Enum\ColumnType;
 
-class TemplateColumn extends AbstractColumn
+class TemplateColumn extends AbstractColumn implements TemplateAwareColumnInterface
 {
     public const string OPTION_TEMPLATE_PATH       = 'templatePath';
     public const string OPTION_TEMPLATE_PARAMETERS = 'templateParameters';

--- a/src/Column/UrlColumn.php
+++ b/src/Column/UrlColumn.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Pentiminax\UX\DataTables\Column;
 
+use Pentiminax\UX\DataTables\Contracts\RouteAwareColumnInterface;
 use Pentiminax\UX\DataTables\Enum\ColumnType;
 
-class UrlColumn extends AbstractColumn
+class UrlColumn extends AbstractColumn implements RouteAwareColumnInterface
 {
     public const string OPTION_TARGET             = 'target';
     public const string OPTION_DISPLAY_VALUE      = 'displayValue';

--- a/src/Contracts/ActionsProvidingColumnInterface.php
+++ b/src/Contracts/ActionsProvidingColumnInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Contracts;
+
+use Pentiminax\UX\DataTables\Model\Actions;
+
+/**
+ * Marker interface for columns that contribute per-row action metadata
+ * (URLs/labels) merged into the row payload by the action resolver.
+ */
+interface ActionsProvidingColumnInterface extends ColumnInterface
+{
+    /**
+     * Returns the actions exposed for each row, or null when none are configured.
+     */
+    public function getActions(): ?Actions;
+}

--- a/src/Contracts/RouteAwareColumnInterface.php
+++ b/src/Contracts/RouteAwareColumnInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Contracts;
+
+/**
+ * Marker interface for columns that resolve their value from a Symfony route.
+ *
+ * Implementations are picked up by the URL resolver at table-build time to
+ * inject a fully-qualified URL template based on the configured route name.
+ */
+interface RouteAwareColumnInterface extends ColumnInterface
+{
+    /**
+     * Returns the Symfony route name backing this column, or null when none is configured.
+     */
+    public function getRouteName(): ?string;
+
+    /**
+     * Stores the resolved URL template (e.g. "/users/{id}") on the column for client-side rendering.
+     */
+    public function setUrlTemplate(string $template): static;
+}

--- a/src/Contracts/TemplateAwareColumnInterface.php
+++ b/src/Contracts/TemplateAwareColumnInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Contracts;
+
+/**
+ * Marker interface for columns whose cell value is rendered by a Twig template.
+ *
+ * Implementations are picked up by the template renderer to render their cell
+ * value at row-mapping time, with the row data and any extra parameters as context.
+ */
+interface TemplateAwareColumnInterface extends ColumnInterface
+{
+    /**
+     * Returns the path to the Twig template used to render this column's cell.
+     */
+    public function getTemplate(): string;
+
+    /**
+     * Returns extra parameters merged into the Twig render context.
+     *
+     * @return array<string, mixed>
+     */
+    public function getTemplateParameters(): array;
+}

--- a/tests/Unit/Column/UrlColumnResolverTest.php
+++ b/tests/Unit/Column/UrlColumnResolverTest.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Pentiminax\UX\DataTables\Tests\Unit\Column;
 
+use Pentiminax\UX\DataTables\Column\AbstractColumn;
 use Pentiminax\UX\DataTables\Column\Rendering\UrlColumnResolver;
 use Pentiminax\UX\DataTables\Column\TextColumn;
 use Pentiminax\UX\DataTables\Column\UrlColumn;
+use Pentiminax\UX\DataTables\Contracts\RouteAwareColumnInterface;
+use Pentiminax\UX\DataTables\Enum\ColumnType;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -88,6 +91,44 @@ final class UrlColumnResolverTest extends TestCase
 
         $data = $column->jsonSerialize();
         $this->assertSame('/app/users/{id}', $data['customOptions']['template']);
+    }
+
+    #[Test]
+    public function it_resolves_routes_for_custom_route_aware_columns(): void
+    {
+        $column = new class extends AbstractColumn implements RouteAwareColumnInterface {
+            private ?string $routeName = 'app_user_show';
+            private ?string $template  = null;
+
+            public function __construct()
+            {
+                $this->setName('custom');
+                $this->setTitle('custom');
+                $this->setType(ColumnType::HTML);
+            }
+
+            public function getRouteName(): ?string
+            {
+                return $this->routeName;
+            }
+
+            public function setUrlTemplate(string $template): static
+            {
+                $this->template = $template;
+
+                return $this;
+            }
+
+            public function resolvedTemplate(): ?string
+            {
+                return $this->template;
+            }
+        };
+
+        $resolver = new UrlColumnResolver($this->createRouter('/custom/{id}'));
+        $resolver->resolveRoutes([$column]);
+
+        $this->assertSame('/custom/{id}', $column->resolvedTemplate());
     }
 
     private function createRouter(string $path, string $baseUrl = ''): RouterInterface


### PR DESCRIPTION
Closes #169

## Summary
- 3 row/column renderers (\`UrlColumnResolver\`, \`TemplateColumnRenderer\`, \`ActionRowDataResolver\`) used \`instanceof XxxColumn\` to find columns to process — OCP violation: custom column types couldn't participate.
- Introduces 3 narrow capability interfaces in \`src/Contracts/\`:
  - \`RouteAwareColumnInterface\` — \`getRouteName()\`, \`setUrlTemplate()\`
  - \`TemplateAwareColumnInterface\` — \`getTemplate()\`, \`getTemplateParameters()\`
  - \`ActionsProvidingColumnInterface\` — \`getActions()\`
- \`UrlColumn\`, \`TemplateColumn\`, \`ActionColumn\` declare the matching interface; the renderers dispatch on the interface, not the concrete class.
- Any user-defined column implementing one of these interfaces is now picked up automatically by the corresponding renderer.

## Approach
Picked the **capability-interface** option from #169 (rather than full Visitor) because:
- The 3 renderers do unrelated things (config-time URL resolution, per-row Twig render, per-row action assembly) — a single Visitor doesn't fit
- Capability interfaces stay narrow, decoupled, and don't force injecting Twig/Router into value objects
- Doesn't depend on #164 (the broader \`ColumnInterface\` enrichment): each interface extends \`ColumnInterface\` and adds only the methods needed for that capability

## BC
Fully backwards compatible. Existing user code keeps working. The 3 built-in columns still expose the same public methods, just now declared via interface.

## Test plan
- [x] \`vendor/bin/phpunit\` (482 tests, 1256 assertions, all green)
- [x] Added regression test \`UrlColumnResolverTest::it_resolves_routes_for_custom_route_aware_columns\` proving a custom column implementing \`RouteAwareColumnInterface\` is picked up
- [x] \`composer fix\` (no changes)