### PR TITLE
fix(contracts): decouple SearchStrategyInterface from AbstractColumn

### DIFF
--- a/src/Contracts/ColumnInterface.php
+++ b/src/Contracts/ColumnInterface.php
@@ -21,4 +21,8 @@ interface ColumnInterface extends \JsonSerializable
     public function getData(): ?string;
 
     public function getTitle(): ?string;
+
+    public function isNumber(): bool;
+
+    public function isDate(): bool;
 }

--- a/src/Contracts/SearchStrategyInterface.php
+++ b/src/Contracts/SearchStrategyInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Pentiminax\UX\DataTables\Contracts;
 
 use Doctrine\ORM\QueryBuilder;
-use Pentiminax\UX\DataTables\Column\AbstractColumn;
+use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
 use Pentiminax\UX\DataTables\DataTableRequest\ColumnControlSearch;
 
 interface SearchStrategyInterface
@@ -13,7 +13,7 @@ interface SearchStrategyInterface
     /**
      * Apply search logic to the QueryBuilder for a specific column.
      */
-    public function apply(QueryBuilder $qb, AbstractColumn $column, ColumnControlSearch $search, int $paramIndex, string $alias): void;
+    public function apply(QueryBuilder $qb, ColumnInterface $column, ColumnControlSearch $search, int $paramIndex, string $alias): void;
 
     public function getLogic(): string;
 }

--- a/src/Query/Strategy/ComparisonSearchStrategy.php
+++ b/src/Query/Strategy/ComparisonSearchStrategy.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Pentiminax\UX\DataTables\Query\Strategy;
 
 use Doctrine\ORM\QueryBuilder;
-use Pentiminax\UX\DataTables\Column\AbstractColumn;
+use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
 use Pentiminax\UX\DataTables\Contracts\SearchStrategyInterface;
 use Pentiminax\UX\DataTables\DataTableRequest\ColumnControlSearch;
 use Pentiminax\UX\DataTables\Enum\ColumnControlLogic;
@@ -27,7 +27,7 @@ final class ComparisonSearchStrategy implements SearchStrategyInterface
         }
     }
 
-    public function apply(QueryBuilder $qb, AbstractColumn $column, ColumnControlSearch $search, int $paramIndex, string $alias): void
+    public function apply(QueryBuilder $qb, ColumnInterface $column, ColumnControlSearch $search, int $paramIndex, string $alias): void
     {
         if ('' === trim($search->value)) {
             return;

--- a/src/Query/Strategy/ContainsSearchStrategy.php
+++ b/src/Query/Strategy/ContainsSearchStrategy.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Pentiminax\UX\DataTables\Query\Strategy;
 
 use Doctrine\ORM\QueryBuilder;
-use Pentiminax\UX\DataTables\Column\AbstractColumn;
+use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
 use Pentiminax\UX\DataTables\Contracts\SearchStrategyInterface;
 use Pentiminax\UX\DataTables\DataTableRequest\ColumnControlSearch;
 use Pentiminax\UX\DataTables\Query\SearchConditionBuilder;
@@ -18,7 +18,7 @@ use Pentiminax\UX\DataTables\Query\SearchConditionBuilder;
  */
 final class ContainsSearchStrategy implements SearchStrategyInterface
 {
-    public function apply(QueryBuilder $qb, AbstractColumn $column, ColumnControlSearch $search, int $paramIndex, string $alias): void
+    public function apply(QueryBuilder $qb, ColumnInterface $column, ColumnControlSearch $search, int $paramIndex, string $alias): void
     {
         if ('' === trim($search->value)) {
             return;

--- a/src/Query/Strategy/InListSearchStrategy.php
+++ b/src/Query/Strategy/InListSearchStrategy.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Pentiminax\UX\DataTables\Query\Strategy;
 
 use Doctrine\ORM\QueryBuilder;
-use Pentiminax\UX\DataTables\Column\AbstractColumn;
+use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
 use Pentiminax\UX\DataTables\Contracts\SearchStrategyInterface;
 use Pentiminax\UX\DataTables\DataTableRequest\ColumnControlSearch;
 use Pentiminax\UX\DataTables\Query\RelationFieldResolver;
@@ -17,7 +17,7 @@ use Pentiminax\UX\DataTables\Query\RelationFieldResolver;
  */
 final class InListSearchStrategy implements SearchStrategyInterface
 {
-    public function apply(QueryBuilder $qb, AbstractColumn $column, ColumnControlSearch $search, int $paramIndex, string $alias): void
+    public function apply(QueryBuilder $qb, ColumnInterface $column, ColumnControlSearch $search, int $paramIndex, string $alias): void
     {
         // This strategy is used differently - it's called from ColumnControlSearchFilter
         // when list values are present, not through the standard search flow

--- a/src/Query/Strategy/NullnessSearchStrategy.php
+++ b/src/Query/Strategy/NullnessSearchStrategy.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Pentiminax\UX\DataTables\Query\Strategy;
 
 use Doctrine\ORM\QueryBuilder;
-use Pentiminax\UX\DataTables\Column\AbstractColumn;
+use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
 use Pentiminax\UX\DataTables\Contracts\SearchStrategyInterface;
 use Pentiminax\UX\DataTables\DataTableRequest\ColumnControlSearch;
 use Pentiminax\UX\DataTables\Query\RelationFieldResolver;
@@ -25,7 +25,7 @@ final class NullnessSearchStrategy implements SearchStrategyInterface
     ) {
     }
 
-    public function apply(QueryBuilder $qb, AbstractColumn $column, ColumnControlSearch $search, int $paramIndex, string $alias): void
+    public function apply(QueryBuilder $qb, ColumnInterface $column, ColumnControlSearch $search, int $paramIndex, string $alias): void
     {
         $field      = RelationFieldResolver::resolve($qb, $alias, $column->getField());
         $expr       = $qb->expr();


### PR DESCRIPTION
## Summary

- Add `isNumber()` and `isDate()` to `ColumnInterface`
- Type `SearchStrategyInterface::apply()` on `ColumnInterface` instead of `AbstractColumn`
- Update `ContainsSearchStrategy`, `ComparisonSearchStrategy`, `NullnessSearchStrategy`, `InListSearchStrategy`

Breaking change — custom strategies must now implement `ColumnInterface`, not depend on `AbstractColumn`.

Closes #165

## Test plan

- [x] All 476 existing tests pass
- [x] No regressions in query strategy behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)