### PR TITLE
refactor(options)!: drop ArrayAccess from DataTableOptions

### DIFF
--- a/src/Model/DataTable.php
+++ b/src/Model/DataTable.php
@@ -47,7 +47,7 @@ class DataTable
             return $this->getColumnDefinitions();
         }
 
-        return $this->options[$name] ?? null;
+        return $this->options->get($name);
     }
 
     public function getOptions(): array
@@ -86,7 +86,7 @@ class DataTable
      */
     public function autoWidth(bool $autoWidth = true): static
     {
-        $this->options['autoWidth'] = $autoWidth;
+        $this->options->set('autoWidth', $autoWidth);
 
         return $this;
     }
@@ -101,7 +101,7 @@ class DataTable
      */
     public function order(array $order): static
     {
-        $this->options['order'] = $order;
+        $this->options->set('order', $order);
 
         return $this;
     }
@@ -111,15 +111,15 @@ class DataTable
      */
     public function caption(string $caption): static
     {
-        $this->options['caption'] = $caption;
+        $this->options->set('caption', $caption);
 
         return $this;
     }
 
     public function add(ColumnInterface $column): static
     {
-        if (!isset($this->options['columns'])) {
-            $this->options['columns'] = [];
+        if (!$this->options->has('columns')) {
+            $this->options->set('columns', []);
         }
 
         $this->columns[$column->getName()] = $column;
@@ -132,8 +132,8 @@ class DataTable
      */
     public function columns(array $columns): static
     {
-        if (!isset($this->options['columns'])) {
-            $this->options['columns'] = [];
+        if (!$this->options->has('columns')) {
+            $this->options->set('columns', []);
         }
 
         $this->columns = [];
@@ -155,7 +155,7 @@ class DataTable
      */
     public function deferRender(bool $deferRender): static
     {
-        $this->options['deferRender'] = $deferRender;
+        $this->options->set('deferRender', $deferRender);
 
         return $this;
     }
@@ -165,7 +165,7 @@ class DataTable
      */
     public function info(bool $info): static
     {
-        $this->options['info'] = $info;
+        $this->options->set('info', $info);
 
         return $this;
     }
@@ -175,7 +175,7 @@ class DataTable
      */
     public function lengthChange(bool $lengthChange): static
     {
-        $this->options['lengthChange'] = $lengthChange;
+        $this->options->set('lengthChange', $lengthChange);
 
         return $this;
     }
@@ -185,17 +185,17 @@ class DataTable
      */
     public function ordering(bool $handler = true, bool $indicators = true): static
     {
-        $this->options['ordering'] = [
+        $this->options->set('ordering', [
             'handler'    => $handler,
             'indicators' => $indicators,
-        ];
+        ]);
 
         return $this;
     }
 
     public function withoutOrdering(): static
     {
-        $this->options['ordering'] = false;
+        $this->options->set('ordering', false);
 
         return $this;
     }
@@ -207,13 +207,13 @@ class DataTable
         bool $numbers = true,
         bool $previousNext = true,
     ): static {
-        $this->options['paging'] = [
+        $this->options->set('paging', [
             'boundaryNumbers' => $boundaryNumbers,
             'buttons'         => $buttons,
             'firstLast'       => $firstLast,
             'numbers'         => $numbers,
             'previousNext'    => $previousNext,
-        ];
+        ]);
 
         return $this;
     }
@@ -223,7 +223,7 @@ class DataTable
      */
     public function withoutPaging(): static
     {
-        $this->options['paging'] = false;
+        $this->options->set('paging', false);
 
         return $this;
     }
@@ -233,7 +233,7 @@ class DataTable
      */
     public function processing(bool $processing = true): static
     {
-        $this->options['processing'] = $processing;
+        $this->options->set('processing', $processing);
 
         return $this;
     }
@@ -243,7 +243,7 @@ class DataTable
      */
     public function scrollX(bool $scrollX): static
     {
-        $this->options['scrollX'] = $scrollX;
+        $this->options->set('scrollX', $scrollX);
 
         return $this;
     }
@@ -253,7 +253,7 @@ class DataTable
      */
     public function scrollY(string $scrollY): static
     {
-        $this->options['scrollY'] = $scrollY;
+        $this->options->set('scrollY', $scrollY);
 
         return $this;
     }
@@ -263,7 +263,7 @@ class DataTable
      */
     public function searching(bool $searching = true): static
     {
-        $this->options['searching'] = $searching;
+        $this->options->set('searching', $searching);
 
         return $this;
     }
@@ -273,7 +273,7 @@ class DataTable
      */
     public function serverSide(bool $serverSide = true): static
     {
-        $this->options['serverSide'] = $serverSide;
+        $this->options->set('serverSide', $serverSide);
 
         return $this;
     }
@@ -283,7 +283,7 @@ class DataTable
      */
     public function apiPlatform(bool $enabled = true): static
     {
-        $this->options['apiPlatform'] = $enabled;
+        $this->options->set('apiPlatform', $enabled);
 
         return $this;
     }
@@ -323,7 +323,7 @@ class DataTable
      */
     public function stateSave(bool $stateSave = true): static
     {
-        $this->options['stateSave'] = $stateSave;
+        $this->options->set('stateSave', $stateSave);
 
         return $this;
     }
@@ -333,7 +333,7 @@ class DataTable
      */
     public function displayStart(int $displayStart): static
     {
-        $this->options['displayStart'] = $displayStart;
+        $this->options->set('displayStart', $displayStart);
 
         return $this;
     }
@@ -352,7 +352,7 @@ class DataTable
             $ajax['dataSrc'] = $dataSrc;
         }
 
-        $this->options['ajax'] = $ajax;
+        $this->options->set('ajax', $ajax);
 
         return $this;
     }
@@ -362,7 +362,7 @@ class DataTable
      */
     public function data(array $data): static
     {
-        $this->options['data'] = $data;
+        $this->options->set('data', $data);
 
         return $this;
     }
@@ -372,7 +372,7 @@ class DataTable
      */
     public function lengthMenu(array $lengthMenu): static
     {
-        $this->options['lengthMenu'] = $lengthMenu;
+        $this->options->set('lengthMenu', $lengthMenu);
 
         return $this;
     }
@@ -382,7 +382,7 @@ class DataTable
      */
     public function pageLength(int $pageLength): static
     {
-        $this->options['pageLength'] = $pageLength;
+        $this->options->set('pageLength', $pageLength);
 
         return $this;
     }
@@ -449,7 +449,7 @@ class DataTable
      */
     public function layout(array $layout): static
     {
-        $this->options['layout'] = $layout;
+        $this->options->set('layout', $layout);
 
         return $this;
     }
@@ -470,7 +470,7 @@ class DataTable
 
     public function withSearchOption(SearchOption $searchOption): static
     {
-        $this->options['search'] = $searchOption->jsonSerialize();
+        $this->options->set('search', $searchOption->jsonSerialize());
 
         return $this;
     }
@@ -505,7 +505,7 @@ class DataTable
 
     public function isServerSide(): bool
     {
-        return $this->options['serverSide'] ?? false;
+        return $this->options->get('serverSide') ?? false;
     }
 
     private function addButtonsToLayout(array &$options): void

--- a/src/Model/DataTableOptions.php
+++ b/src/Model/DataTableOptions.php
@@ -7,7 +7,7 @@ namespace Pentiminax\UX\DataTables\Model;
 use Pentiminax\UX\DataTables\Enum\Feature;
 use Pentiminax\UX\DataTables\Enum\Language;
 
-class DataTableOptions implements \ArrayAccess
+class DataTableOptions
 {
     private array $options;
 
@@ -30,6 +30,44 @@ class DataTableOptions implements \ArrayAccess
         $this->options['search']['search'] = $search;
 
         return $this;
+    }
+
+    /**
+     * Set an arbitrary DataTables.net option.
+     *
+     * Escape hatch for options the bundle does not expose through a typed
+     * setter. Prefer the dedicated builder methods on {@see DataTable} when
+     * available.
+     */
+    public function set(string $name, mixed $value): static
+    {
+        $this->options[$name] = $value;
+
+        return $this;
+    }
+
+    public function get(string $name): mixed
+    {
+        return $this->options[$name] ?? null;
+    }
+
+    public function has(string $name): bool
+    {
+        return isset($this->options[$name]);
+    }
+
+    public function remove(string $name): static
+    {
+        unset($this->options[$name]);
+
+        return $this;
+    }
+
+    public function getOptions(): array
+    {
+        $this->handleLayoutOption();
+
+        return $this->options;
     }
 
     private function handleLanguageOption(array $options): array
@@ -70,32 +108,5 @@ class DataTableOptions implements \ArrayAccess
         }
 
         return $value;
-    }
-
-    public function getOptions(): array
-    {
-        $this->handleLayoutOption();
-
-        return $this->options;
-    }
-
-    public function offsetExists($offset): bool
-    {
-        return isset($this->options[$offset]);
-    }
-
-    public function offsetGet($offset): mixed
-    {
-        return $this->options[$offset] ?? null;
-    }
-
-    public function offsetSet($offset, $value): void
-    {
-        $this->options[$offset] = $value;
-    }
-
-    public function offsetUnset($offset): void
-    {
-        unset($this->options[$offset]);
     }
 }

--- a/tests/Unit/Model/DataTableOptionsTest.php
+++ b/tests/Unit/Model/DataTableOptionsTest.php
@@ -27,8 +27,8 @@ final class DataTableOptionsTest extends TestCase
             ],
         ]);
 
-        $this->assertEquals(Language::EN->getUrl(), $options['language']['url']);
-        $this->assertEquals('Alice', $options['search']['search']);
+        $this->assertEquals(Language::EN->getUrl(), $options->get('language')['url']);
+        $this->assertEquals('Alice', $options->get('search')['search']);
     }
 
     #[Test]
@@ -99,6 +99,32 @@ final class DataTableOptionsTest extends TestCase
             'top'      => '<h2>Title</h2>',
             'topStart' => 'customPlugin',
         ], $options->getOptions()['layout']);
+    }
+
+    #[Test]
+    public function it_exposes_typed_accessors_for_arbitrary_options(): void
+    {
+        $options = new DataTableOptions();
+
+        $this->assertFalse($options->has('foo'));
+        $this->assertNull($options->get('foo'));
+
+        $options->set('foo', 'bar');
+
+        $this->assertTrue($options->has('foo'));
+        $this->assertSame('bar', $options->get('foo'));
+        $this->assertSame('bar', $options->getOptions()['foo']);
+
+        $options->remove('foo');
+
+        $this->assertFalse($options->has('foo'));
+        $this->assertNull($options->get('foo'));
+    }
+
+    #[Test]
+    public function it_no_longer_implements_array_access(): void
+    {
+        $this->assertFalse(is_subclass_of(DataTableOptions::class, \ArrayAccess::class));
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- Remove `\ArrayAccess` from `DataTableOptions` and replace it with explicit `set` / `get` / `has` / `remove` methods.
- Update internal call sites in `DataTable` to use the new accessors. Public typed setters (`setLanguage`, `setSearch`) and the fluent builder API on `DataTable` are unchanged.
- Lays the groundwork for future validation, deprecation warnings, or call-site logging without further breaking changes.

Why option 1 (drop `ArrayAccess`) over option 2 (whitelist): DataTables.net option keys live upstream and drift each release, so a client-side whitelist would constantly lag. Routing every write through a single typed entry point gives us the validation hook without owning the schema.

## Breaking change
`DataTableOptions` no longer implements `\ArrayAccess`. Migration:

```php
// before
$options['serverSide'] = true;
$value = $options['serverSide'] ?? null;
isset($options['serverSide']);
unset($options['serverSide']);

// after
$options->set('serverSide', true);
$value = $options->get('serverSide');
$options->has('serverSide');
$options->remove('serverSide');
```

Closes #168

## Test plan
- [x] `vendor/bin/phpunit` (476 tests pass)
- [x] New unit tests cover `set` / `get` / `has` / `remove` and assert `\ArrayAccess` is no longer implemented