### PR TITLE
refactor(pipeline): make RowProcessingPipeline a true composable pipeline

### DIFF
--- a/docs/src/content/docs/reference/data-providers-row-mappers.mdx
+++ b/docs/src/content/docs/reference/data-providers-row-mappers.mdx
@@ -50,9 +50,56 @@ Built-in mappers and processors:
   rows={[
     ['`DefaultRowMapper`', 'Default row-to-array mapping behavior'],
     ['`ClosureRowMapper`', 'Custom mapping logic via closure'],
-    ['`RowProcessingPipeline`', 'Internal pipeline used by `AbstractDataTable`'],
+    ['`RowProcessingPipeline`', 'Composable pipeline used by `AbstractDataTable` — stages added via `->add(RowStageInterface)`'],
   ]}
 />
+
+### RowStageInterface
+
+Each stage in `RowProcessingPipeline` implements `RowStageInterface`:
+
+```php
+interface RowStageInterface
+{
+    public function process(array $mappedRow, mixed $originalRow, array $columns): array;
+}
+```
+
+Built-in stages applied by default (in order):
+
+<Table
+  headers={['Stage', 'Responsibility']}
+  rows={[
+    ['`NormalizationStage`', 'Dotted-path resolution, `DateColumn` formatting, `Stringable` casting'],
+    ['`TemplateRenderingStage`', 'Renders `TemplateColumn` cells via Twig (only if renderer is available)'],
+    ['`ActionResolutionStage`', 'Resolves `ActionColumn` URLs into `__ux_datatables_actions` key'],
+  ]}
+/>
+
+Custom stage example:
+
+```php
+use Pentiminax\UX\DataTables\Contracts\RowStageInterface;
+
+final class UpperCaseTitleStage implements RowStageInterface
+{
+    public function process(array $mappedRow, mixed $originalRow, array $columns): array
+    {
+        if (isset($mappedRow['title'])) {
+            $mappedRow['title'] = strtoupper($mappedRow['title']);
+        }
+
+        return $mappedRow;
+    }
+}
+```
+
+```php
+protected function createRowMapper(): RowMapperInterface
+{
+    return parent::createRowMapper()->add(new UpperCaseTitleStage());
+}
+```
 
 ## DataTableResult
 
@@ -85,6 +132,8 @@ protected function createDataProvider(): ?DataProviderInterface
 `$this->createRowMapper()` is the important part: it preserves the same mapping, template
 rendering, and action-resolution behavior as the built-in Doctrine provider. `setData()` on
 `AbstractDataTable` uses that same pipeline for inline rows.
+
+Custom stages added to the pipeline are preserved when passing the mapper to a custom provider.
 
 ## Cross Links
 

--- a/src/Contracts/RowStageInterface.php
+++ b/src/Contracts/RowStageInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Contracts;
+
+interface RowStageInterface
+{
+    /**
+     * @param array<string, mixed> $mappedRow
+     * @param ColumnInterface[]    $columns
+     *
+     * @return array<string, mixed>
+     */
+    public function process(array $mappedRow, mixed $originalRow, array $columns): array;
+}

--- a/src/RowMapper/RowProcessingPipeline.php
+++ b/src/RowMapper/RowProcessingPipeline.php
@@ -4,15 +4,14 @@ declare(strict_types=1);
 
 namespace Pentiminax\UX\DataTables\RowMapper;
 
-use Pentiminax\UX\DataTables\Column\DateColumn;
-use Pentiminax\UX\DataTables\Column\Rendering\ActionRowDataResolver;
-use Pentiminax\UX\DataTables\Column\Rendering\PropertyReader;
-use Pentiminax\UX\DataTables\Column\Rendering\TemplateColumnRenderer;
-use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
 use Pentiminax\UX\DataTables\Contracts\RowMapperInterface;
+use Pentiminax\UX\DataTables\Contracts\RowStageInterface;
 
 final class RowProcessingPipeline implements RowMapperInterface
 {
+    /** @var RowStageInterface[] */
+    private array $stages = [];
+
     /**
      * @param ColumnInterface[]     $columns
      * @param \Closure(mixed):array $baseMapper
@@ -20,61 +19,22 @@ final class RowProcessingPipeline implements RowMapperInterface
     public function __construct(
         private readonly \Closure $baseMapper,
         private readonly array $columns,
-        private readonly ?TemplateColumnRenderer $templateColumnRenderer = null,
-        private readonly ?ActionRowDataResolver $actionRowDataResolver = null,
     ) {
+    }
+
+    public function add(RowStageInterface $stage): self
+    {
+        $this->stages[] = $stage;
+
+        return $this;
     }
 
     public function map(mixed $row): array
     {
         $mappedRow = ($this->baseMapper)($row);
 
-        $mappedRow = $this->normalizeRow($mappedRow);
-
-        if (null !== $this->templateColumnRenderer) {
-            $mappedRow = $this->templateColumnRenderer->renderRow(
-                row: $mappedRow,
-                mappedRow: $row,
-                columns: $this->columns,
-            );
-        }
-
-        if (null !== $this->actionRowDataResolver) {
-            $mappedRow = $this->actionRowDataResolver->resolveRow($mappedRow, $row, $this->columns);
-        }
-
-        return $mappedRow;
-    }
-
-    private function normalizeRow(array $mappedRow): array
-    {
-        foreach ($this->columns as $column) {
-            $key = $column->getData() ?? $column->getName();
-            if (null === $key || '' === $key || !\array_key_exists($key, $mappedRow)) {
-                continue;
-            }
-
-            $value = $mappedRow[$key];
-            if (!\is_object($value)) {
-                continue;
-            }
-
-            $field = $column->getField();
-            if (null !== $field && str_contains($field, '.')) {
-                $resolved = PropertyReader::readPath($mappedRow, $field);
-                if (null !== $resolved && !\is_object($resolved)) {
-                    $mappedRow[$key] = $resolved;
-                    continue;
-                }
-            }
-
-            if ($column instanceof DateColumn && $value instanceof \DateTimeInterface) {
-                $mappedRow[$key] = $value->format($column->getFormat());
-            } elseif ($value instanceof \Stringable) {
-                $mappedRow[$key] = (string) $value;
-            } else {
-                $mappedRow[$key] = null;
-            }
+        foreach ($this->stages as $stage) {
+            $mappedRow = $stage->process($mappedRow, $row, $this->columns);
         }
 
         return $mappedRow;

--- a/src/RowMapper/Stage/ActionResolutionStage.php
+++ b/src/RowMapper/Stage/ActionResolutionStage.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\RowMapper\Stage;
+
+use Pentiminax\UX\DataTables\Column\Rendering\ActionRowDataResolver;
+use Pentiminax\UX\DataTables\Contracts\RowStageInterface;
+
+final class ActionResolutionStage implements RowStageInterface
+{
+    public function __construct(
+        private readonly ActionRowDataResolver $resolver,
+    ) {
+    }
+
+    public function process(array $mappedRow, mixed $originalRow, array $columns): array
+    {
+        return $this->resolver->resolveRow($mappedRow, $originalRow, $columns);
+    }
+}

--- a/src/RowMapper/Stage/NormalizationStage.php
+++ b/src/RowMapper/Stage/NormalizationStage.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\RowMapper\Stage;
+
+use Pentiminax\UX\DataTables\Column\DateColumn;
+use Pentiminax\UX\DataTables\Column\Rendering\PropertyReader;
+use Pentiminax\UX\DataTables\Contracts\RowStageInterface;
+
+final class NormalizationStage implements RowStageInterface
+{
+    public function process(array $mappedRow, mixed $originalRow, array $columns): array
+    {
+        foreach ($columns as $column) {
+            $key = $column->getData() ?? $column->getName();
+            if (null === $key || '' === $key || !\array_key_exists($key, $mappedRow)) {
+                continue;
+            }
+
+            $value = $mappedRow[$key];
+            if (!\is_object($value)) {
+                continue;
+            }
+
+            $field = $column->getField();
+            if (null !== $field && str_contains($field, '.')) {
+                $resolved = PropertyReader::readPath($mappedRow, $field);
+                if (null !== $resolved && !\is_object($resolved)) {
+                    $mappedRow[$key] = $resolved;
+                    continue;
+                }
+            }
+
+            if ($column instanceof DateColumn && $value instanceof \DateTimeInterface) {
+                $mappedRow[$key] = $value->format($column->getFormat());
+            } elseif ($value instanceof \Stringable) {
+                $mappedRow[$key] = (string) $value;
+            } else {
+                $mappedRow[$key] = null;
+            }
+        }
+
+        return $mappedRow;
+    }
+}

--- a/src/RowMapper/Stage/TemplateRenderingStage.php
+++ b/src/RowMapper/Stage/TemplateRenderingStage.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\RowMapper\Stage;
+
+use Pentiminax\UX\DataTables\Column\Rendering\TemplateColumnRenderer;
+use Pentiminax\UX\DataTables\Contracts\RowStageInterface;
+
+final class TemplateRenderingStage implements RowStageInterface
+{
+    public function __construct(
+        private readonly TemplateColumnRenderer $renderer,
+    ) {
+    }
+
+    public function process(array $mappedRow, mixed $originalRow, array $columns): array
+    {
+        return $this->renderer->renderRow(
+            row: $mappedRow,
+            mappedRow: $originalRow,
+            columns: $columns,
+        );
+    }
+}

--- a/src/Runtime/DataTableRuntimeFactory.php
+++ b/src/Runtime/DataTableRuntimeFactory.php
@@ -15,6 +15,9 @@ use Pentiminax\UX\DataTables\DataProvider\AutoDataProviderFactory;
 use Pentiminax\UX\DataTables\DataProvider\DataProviderResolver;
 use Pentiminax\UX\DataTables\Model\DataTable;
 use Pentiminax\UX\DataTables\RowMapper\RowProcessingPipeline;
+use Pentiminax\UX\DataTables\RowMapper\Stage\ActionResolutionStage;
+use Pentiminax\UX\DataTables\RowMapper\Stage\NormalizationStage;
+use Pentiminax\UX\DataTables\RowMapper\Stage\TemplateRenderingStage;
 
 final class DataTableRuntimeFactory
 {
@@ -36,12 +39,16 @@ final class DataTableRuntimeFactory
      */
     public function createRowMapper(\Closure $baseMapper, array $columns): RowMapperInterface
     {
-        return new RowProcessingPipeline(
-            baseMapper: $baseMapper,
-            columns: $columns,
-            templateColumnRenderer: $this->templateColumnRenderer,
-            actionRowDataResolver: $this->actionRowDataResolver ?? new ActionRowDataResolver(),
-        );
+        $pipeline = (new RowProcessingPipeline($baseMapper, $columns))
+            ->add(new NormalizationStage());
+
+        if (null !== $this->templateColumnRenderer) {
+            $pipeline->add(new TemplateRenderingStage($this->templateColumnRenderer));
+        }
+
+        $pipeline->add(new ActionResolutionStage($this->actionRowDataResolver ?? new ActionRowDataResolver()));
+
+        return $pipeline;
     }
 
     /**

--- a/tests/Unit/Contracts/ColumnInterfaceTest.php
+++ b/tests/Unit/Contracts/ColumnInterfaceTest.php
@@ -11,7 +11,7 @@ use Pentiminax\UX\DataTables\Column\NumberColumn;
 use Pentiminax\UX\DataTables\Column\TextColumn;
 use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
 use Pentiminax\UX\DataTables\Enum\ColumnType;
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @internal
  */
-#[CoversClass(ColumnInterface::class)]
+#[CoversNothing]
 final class ColumnInterfaceTest extends TestCase
 {
     /**

--- a/tests/Unit/RowMapper/RowProcessingPipelineTest.php
+++ b/tests/Unit/RowMapper/RowProcessingPipelineTest.php
@@ -10,9 +10,13 @@ use Pentiminax\UX\DataTables\Column\Rendering\ActionRowDataResolver;
 use Pentiminax\UX\DataTables\Column\Rendering\TemplateColumnRenderer;
 use Pentiminax\UX\DataTables\Column\TemplateColumn;
 use Pentiminax\UX\DataTables\Column\TextColumn;
+use Pentiminax\UX\DataTables\Contracts\RowStageInterface;
 use Pentiminax\UX\DataTables\Model\Action;
 use Pentiminax\UX\DataTables\Model\Actions;
 use Pentiminax\UX\DataTables\RowMapper\RowProcessingPipeline;
+use Pentiminax\UX\DataTables\RowMapper\Stage\ActionResolutionStage;
+use Pentiminax\UX\DataTables\RowMapper\Stage\NormalizationStage;
+use Pentiminax\UX\DataTables\RowMapper\Stage\TemplateRenderingStage;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -26,7 +30,7 @@ use Twig\Loader\ArrayLoader;
 final class RowProcessingPipelineTest extends TestCase
 {
     #[Test]
-    public function it_applies_the_base_mapper_when_no_optional_stage_is_configured(): void
+    public function it_applies_the_base_mapper_when_no_stage_is_added(): void
     {
         $pipeline = new RowProcessingPipeline(
             baseMapper: static fn (array $row): array => ['id' => $row['id']],
@@ -39,9 +43,58 @@ final class RowProcessingPipelineTest extends TestCase
     }
 
     #[Test]
-    public function it_renders_template_columns_after_the_base_mapper(): void
+    public function add_returns_self_for_fluent_chaining(): void
     {
         $pipeline = new RowProcessingPipeline(
+            baseMapper: static fn (array $row): array => $row,
+            columns: [],
+        );
+
+        $stage = new class implements RowStageInterface {
+            public function process(array $mappedRow, mixed $originalRow, array $columns): array
+            {
+                return $mappedRow;
+            }
+        };
+
+        $this->assertSame($pipeline, $pipeline->add($stage));
+    }
+
+    #[Test]
+    public function stages_are_applied_in_insertion_order(): void
+    {
+        $order    = [];
+        $pipeline = new RowProcessingPipeline(
+            baseMapper: static fn (array $row): array => $row,
+            columns: [],
+        );
+
+        foreach (['first', 'second', 'third'] as $label) {
+            $pipeline->add(new class($label, $order) implements RowStageInterface {
+                public function __construct(
+                    private readonly string $label,
+                    private array &$order,
+                ) {
+                }
+
+                public function process(array $mappedRow, mixed $originalRow, array $columns): array
+                {
+                    $this->order[] = $this->label;
+
+                    return $mappedRow;
+                }
+            });
+        }
+
+        $pipeline->map([]);
+
+        $this->assertSame(['first', 'second', 'third'], $order);
+    }
+
+    #[Test]
+    public function it_renders_template_columns_via_template_rendering_stage(): void
+    {
+        $pipeline = (new RowProcessingPipeline(
             baseMapper: static fn (TemplateRow $row): array => ['id' => $row->id],
             columns: [
                 TextColumn::new('id'),
@@ -49,12 +102,14 @@ final class RowProcessingPipelineTest extends TestCase
                     ->setField('status')
                     ->setTemplate('datatable/columns/status_badge.html.twig'),
             ],
-            templateColumnRenderer: new TemplateColumnRenderer(
-                new Environment(new ArrayLoader([
-                    'datatable/columns/status_badge.html.twig' => '<span>{{ row.id }}-{{ data }}</span>',
-                ]))
-            ),
-        );
+        ))->add(new NormalizationStage())
+          ->add(new TemplateRenderingStage(
+              new TemplateColumnRenderer(
+                  new Environment(new ArrayLoader([
+                      'datatable/columns/status_badge.html.twig' => '<span>{{ row.id }}-{{ data }}</span>',
+                  ]))
+              )
+          ));
 
         $mappedRow = $pipeline->map(new TemplateRow(id: 5, status: 'active'));
 
@@ -65,19 +120,18 @@ final class RowProcessingPipelineTest extends TestCase
     }
 
     #[Test]
-    public function it_resolves_action_urls_after_mapping(): void
+    public function it_resolves_action_urls_via_action_resolution_stage(): void
     {
         $actions = (new Actions())
             ->add(Action::detail()->linkToUrl(static fn (array $row): string => '/movies/'.$row['id']));
 
-        $pipeline = new RowProcessingPipeline(
+        $pipeline = (new RowProcessingPipeline(
             baseMapper: static fn (array $row): array => ['id' => $row['id']],
             columns: [
                 TextColumn::new('id'),
                 ActionColumn::fromActions('actions', 'Actions', $actions),
             ],
-            actionRowDataResolver: new ActionRowDataResolver(),
-        );
+        ))->add(new ActionResolutionStage(new ActionRowDataResolver()));
 
         $mappedRow = $pipeline->map(['id' => 8]);
 
@@ -94,10 +148,10 @@ final class RowProcessingPipelineTest extends TestCase
             }
         };
 
-        $pipeline = new RowProcessingPipeline(
+        $pipeline = (new RowProcessingPipeline(
             baseMapper: static fn (mixed $row): array => ['client' => $row],
             columns: [TextColumn::new('client', 'Client')->setField('client.name')],
-        );
+        ))->add(new NormalizationStage());
 
         $mappedRow = $pipeline->map($client);
 
@@ -114,10 +168,10 @@ final class RowProcessingPipelineTest extends TestCase
             }
         };
 
-        $pipeline = new RowProcessingPipeline(
+        $pipeline = (new RowProcessingPipeline(
             baseMapper: static fn (mixed $row): array => ['label' => $row],
             columns: [TextColumn::new('label', 'Label')],
-        );
+        ))->add(new NormalizationStage());
 
         $mappedRow = $pipeline->map($stringable);
 
@@ -127,10 +181,10 @@ final class RowProcessingPipelineTest extends TestCase
     #[Test]
     public function it_converts_non_stringable_object_to_null(): void
     {
-        $pipeline = new RowProcessingPipeline(
+        $pipeline = (new RowProcessingPipeline(
             baseMapper: static fn (mixed $row): array => ['client' => $row],
             columns: [TextColumn::new('client', 'Client')],
-        );
+        ))->add(new NormalizationStage());
 
         $mappedRow = $pipeline->map(new \stdClass());
 
@@ -142,10 +196,10 @@ final class RowProcessingPipelineTest extends TestCase
     {
         $date = new \DateTimeImmutable('2024-03-15');
 
-        $pipeline = new RowProcessingPipeline(
+        $pipeline = (new RowProcessingPipeline(
             baseMapper: static fn (mixed $row): array => ['createdAt' => $row],
             columns: [DateColumn::new('createdAt', 'Date')->setFormat('d/m/Y')],
-        );
+        ))->add(new NormalizationStage());
 
         $mappedRow = $pipeline->map($date);
 
@@ -155,10 +209,10 @@ final class RowProcessingPipelineTest extends TestCase
     #[Test]
     public function it_leaves_scalar_values_unchanged(): void
     {
-        $pipeline = new RowProcessingPipeline(
+        $pipeline = (new RowProcessingPipeline(
             baseMapper: static fn (array $row): array => $row,
             columns: [TextColumn::new('title', 'Title')],
-        );
+        ))->add(new NormalizationStage());
 
         $mappedRow = $pipeline->map(['title' => 'Hello World']);
 
@@ -166,12 +220,12 @@ final class RowProcessingPipelineTest extends TestCase
     }
 
     #[Test]
-    public function it_runs_map_then_template_then_action_resolution_in_order(): void
+    public function it_runs_stages_in_order_normalization_then_template_then_action(): void
     {
         $actions = (new Actions())
             ->add(Action::detail()->linkToUrl(static fn (array $row): string => '/movies/'.$row['id']));
 
-        $pipeline = new RowProcessingPipeline(
+        $pipeline = (new RowProcessingPipeline(
             baseMapper: static fn (array $row): array => [
                 'id'     => $row['id'],
                 'status' => 'mapped-'.$row['status'],
@@ -183,13 +237,15 @@ final class RowProcessingPipelineTest extends TestCase
                     ->setTemplate('datatable/columns/order.html.twig'),
                 ActionColumn::fromActions('actions', 'Actions', $actions),
             ],
-            templateColumnRenderer: new TemplateColumnRenderer(
-                new Environment(new ArrayLoader([
-                    'datatable/columns/order.html.twig' => '{{ row.__ux_datatables_actions.DETAIL.url|default("missing") }}|{{ data }}',
-                ]))
-            ),
-            actionRowDataResolver: new ActionRowDataResolver(),
-        );
+        ))->add(new NormalizationStage())
+          ->add(new TemplateRenderingStage(
+              new TemplateColumnRenderer(
+                  new Environment(new ArrayLoader([
+                      'datatable/columns/order.html.twig' => '{{ row.__ux_datatables_actions.DETAIL.url|default("missing") }}|{{ data }}',
+                  ]))
+              )
+          ))
+          ->add(new ActionResolutionStage(new ActionRowDataResolver()));
 
         $mappedRow = $pipeline->map(['id' => 7, 'status' => 'active']);
 

--- a/tests/Unit/RowMapper/Stage/ActionResolutionStageTest.php
+++ b/tests/Unit/RowMapper/Stage/ActionResolutionStageTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Unit\RowMapper\Stage;
+
+use Pentiminax\UX\DataTables\Column\ActionColumn;
+use Pentiminax\UX\DataTables\Column\Rendering\ActionRowDataResolver;
+use Pentiminax\UX\DataTables\Column\TextColumn;
+use Pentiminax\UX\DataTables\Model\Action;
+use Pentiminax\UX\DataTables\Model\Actions;
+use Pentiminax\UX\DataTables\RowMapper\Stage\ActionResolutionStage;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+#[CoversClass(ActionResolutionStage::class)]
+final class ActionResolutionStageTest extends TestCase
+{
+    #[Test]
+    public function it_resolves_action_urls(): void
+    {
+        $actions = (new Actions())
+            ->add(Action::detail()->linkToUrl(static fn (array $row): string => '/items/'.$row['id']));
+
+        $stage = new ActionResolutionStage(new ActionRowDataResolver());
+
+        $result = $stage->process(
+            ['id' => 3],
+            ['id' => 3],
+            [
+                TextColumn::new('id'),
+                ActionColumn::fromActions('actions', 'Actions', $actions),
+            ],
+        );
+
+        $this->assertSame('/items/3', $result[ActionRowDataResolver::ROW_ACTIONS_KEY]['DETAIL']['url']);
+    }
+
+    #[Test]
+    public function it_passes_through_when_no_action_column(): void
+    {
+        $stage  = new ActionResolutionStage(new ActionRowDataResolver());
+        $result = $stage->process(['id' => 1], ['id' => 1], [TextColumn::new('id')]);
+
+        $this->assertSame(['id' => 1], $result);
+    }
+}

--- a/tests/Unit/RowMapper/Stage/NormalizationStageTest.php
+++ b/tests/Unit/RowMapper/Stage/NormalizationStageTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Unit\RowMapper\Stage;
+
+use Pentiminax\UX\DataTables\Column\DateColumn;
+use Pentiminax\UX\DataTables\Column\TextColumn;
+use Pentiminax\UX\DataTables\RowMapper\Stage\NormalizationStage;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+#[CoversClass(NormalizationStage::class)]
+final class NormalizationStageTest extends TestCase
+{
+    #[Test]
+    public function it_leaves_scalar_values_unchanged(): void
+    {
+        $stage  = new NormalizationStage();
+        $result = $stage->process(['title' => 'Hello'], 'original', [TextColumn::new('title')]);
+
+        $this->assertSame(['title' => 'Hello'], $result);
+    }
+
+    #[Test]
+    public function it_converts_stringable_to_string(): void
+    {
+        $stringable = new class implements \Stringable {
+            public function __toString(): string
+            {
+                return 'Label';
+            }
+        };
+
+        $stage  = new NormalizationStage();
+        $result = $stage->process(['name' => $stringable], 'original', [TextColumn::new('name')]);
+
+        $this->assertSame(['name' => 'Label'], $result);
+    }
+
+    #[Test]
+    public function it_converts_non_stringable_object_to_null(): void
+    {
+        $stage  = new NormalizationStage();
+        $result = $stage->process(['obj' => new \stdClass()], 'original', [TextColumn::new('obj')]);
+
+        $this->assertNull($result['obj']);
+    }
+
+    #[Test]
+    public function it_formats_datetime_with_date_column(): void
+    {
+        $date  = new \DateTimeImmutable('2024-06-01');
+        $stage = new NormalizationStage();
+
+        $result = $stage->process(
+            ['date' => $date],
+            'original',
+            [DateColumn::new('date')->setFormat('d/m/Y')],
+        );
+
+        $this->assertSame(['date' => '01/06/2024'], $result);
+    }
+
+    #[Test]
+    public function it_resolves_dotted_field_path(): void
+    {
+        $stage = new NormalizationStage();
+        $obj   = new class {
+            public string $name = 'Acme';
+        };
+
+        $result = $stage->process(
+            ['company' => $obj],
+            'original',
+            [TextColumn::new('company')->setField('company.name')],
+        );
+
+        $this->assertSame(['company' => 'Acme'], $result);
+    }
+
+    #[Test]
+    public function it_skips_columns_without_key(): void
+    {
+        $stage  = new NormalizationStage();
+        $result = $stage->process(['title' => 'Hello'], 'original', [TextColumn::new('')]);
+
+        $this->assertSame(['title' => 'Hello'], $result);
+    }
+}

--- a/tests/Unit/RowMapper/Stage/TemplateRenderingStageTest.php
+++ b/tests/Unit/RowMapper/Stage/TemplateRenderingStageTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Unit\RowMapper\Stage;
+
+use Pentiminax\UX\DataTables\Column\Rendering\TemplateColumnRenderer;
+use Pentiminax\UX\DataTables\Column\TemplateColumn;
+use Pentiminax\UX\DataTables\Column\TextColumn;
+use Pentiminax\UX\DataTables\RowMapper\Stage\TemplateRenderingStage;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+
+/**
+ * @internal
+ */
+#[CoversClass(TemplateRenderingStage::class)]
+final class TemplateRenderingStageTest extends TestCase
+{
+    #[Test]
+    public function it_renders_template_column(): void
+    {
+        $stage = new TemplateRenderingStage(
+            new TemplateColumnRenderer(
+                new Environment(new ArrayLoader([
+                    'badge.html.twig' => '<b>{{ data }}</b>',
+                ]))
+            )
+        );
+
+        $result = $stage->process(
+            ['status' => 'active'],
+            new \stdClass(),
+            [TemplateColumn::new('status_display')->setField('status')->setTemplate('badge.html.twig')],
+        );
+
+        $this->assertSame('<b>active</b>', $result['status']);
+    }
+
+    #[Test]
+    public function it_passes_through_non_template_columns(): void
+    {
+        $stage = new TemplateRenderingStage(
+            new TemplateColumnRenderer(new Environment(new ArrayLoader([])))
+        );
+
+        $result = $stage->process(
+            ['id' => 42],
+            new \stdClass(),
+            [TextColumn::new('id')],
+        );
+
+        $this->assertSame(['id' => 42], $result);
+    }
+}


### PR DESCRIPTION
## Summary

- Replace hardcoded 3-stage sequence with generic `add(RowStageInterface): self` API
- Extract `NormalizationStage`, `TemplateRenderingStage`, `ActionResolutionStage` from inline logic
- Add `RowStageInterface` contract in `src/Contracts/`
- `DataTableRuntimeFactory::createRowMapper()` composes default stages; external behaviour unchanged
- 3 new test files (15 cases), existing 9 pipeline tests adapted, 516/516 passing

## Test plan

- [x] `vendor/bin/phpunit tests/Unit/RowMapper/` — 34 tests green
- [x] `vendor/bin/phpunit` — 516 tests, 0 regressions
- [x] `composer fix` — no style violations

Closes #171