### PR TITLE
Fix code formatting in docs

### DIFF
--- a/docs/src/content/docs/guide/columns.mdx
+++ b/docs/src/content/docs/guide/columns.mdx
@@ -196,7 +196,9 @@ $column = TextColumn::new('createdAt', 'Created')
 ## Complete Example
 
 ```php
-use Pentiminax\UX\DataTables\Column\NumberColumn;use Pentiminax\UX\DataTables\Column\TextColumn;use Pentiminax\UX\DataTables\Contracts\DataTableBuilderInterface;
+use Pentiminax\UX\DataTables\Column\NumberColumn;
+use Pentiminax\UX\DataTables\Column\TextColumn;
+use Pentiminax\UX\DataTables\Contracts\DataTableBuilderInterface;
 
 class ProductTableService
 {

--- a/docs/src/content/docs/guide/usage.mdx
+++ b/docs/src/content/docs/guide/usage.mdx
@@ -14,7 +14,11 @@ Inject the `DataTableBuilderInterface` service and build your table:
 ```php
 namespace App\Controller;
 
-use Pentiminax\UX\DataTables\Column\TextColumn;use Pentiminax\UX\DataTables\Contracts\DataTableBuilderInterface;use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;use Symfony\Component\HttpFoundation\Response;use Symfony\Component\Routing\Annotation\Route;
+use Pentiminax\UX\DataTables\Column\TextColumn;
+use Pentiminax\UX\DataTables\Contracts\DataTableBuilderInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
 
 class HomeController extends AbstractController
 {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced PHP code example readability by reformatting import statements in the usage guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->