### PR TITLE
Remove mandatory `hubUrl` from `mercure()` method 

### DIFF
--- a/src/DataTablesBundle.php
+++ b/src/DataTablesBundle.php
@@ -259,6 +259,7 @@ class DataTablesBundle extends AbstractBundle
             ->arg(0, service(ApiResourceCollectionUrlResolverInterface::class)->nullOnInvalid())
             ->arg(1, service(MercureConfigResolverInterface::class)->nullOnInvalid())
             ->arg(2, service(TranslatorInterface::class)->nullOnInvalid())
+            ->arg(3, service(MercureHubUrlResolverInterface::class)->nullOnInvalid())
             ->private();
 
         $container->services()

--- a/src/Mercure/MercureConfig.php
+++ b/src/Mercure/MercureConfig.php
@@ -11,11 +11,13 @@ final class MercureConfig implements \JsonSerializable
      */
     public readonly array $topics;
 
+    public readonly ?string $hubUrl;
+
     public function __construct(
-        public readonly string $hubUrl,
         array $topics,
         public readonly bool $withCredentials = false,
         public readonly ?int $debounceMs = null,
+        ?string $hubUrl = null,
     ) {
         $this->topics = array_values(array_filter(
             $topics,
@@ -25,10 +27,26 @@ final class MercureConfig implements \JsonSerializable
         if ([] === $this->topics) {
             throw new \InvalidArgumentException('Mercure topics cannot be empty.');
         }
+
+        $this->hubUrl = $hubUrl;
+    }
+
+    public function withHubUrl(string $hubUrl): self
+    {
+        return new self(
+            topics: $this->topics,
+            withCredentials: $this->withCredentials,
+            debounceMs: $this->debounceMs,
+            hubUrl: $hubUrl,
+        );
     }
 
     public function jsonSerialize(): array
     {
+        if (null === $this->hubUrl || '' === $this->hubUrl) {
+            throw new \LogicException('MercureConfig hubUrl is not set. It must be resolved before serialization.');
+        }
+
         $data = [
             'hubUrl' => $this->hubUrl,
             'topics' => $this->topics,

--- a/src/Mercure/MercureConfigResolver.php
+++ b/src/Mercure/MercureConfigResolver.php
@@ -31,8 +31,8 @@ final class MercureConfigResolver implements MercureConfigResolverInterface
         }
 
         return new MercureConfig(
-            hubUrl: $hubUrl,
             topics: $topics,
+            hubUrl: $hubUrl,
         );
     }
 

--- a/src/Model/DataTable.php
+++ b/src/Model/DataTable.php
@@ -319,25 +319,30 @@ class DataTable
 
     /**
      * Enable Mercure SSE real-time updates for this DataTable.
-     * Requires symfony/mercure-bundle to be installed.
+     * Requires symfony/mercure-bundle to be installed. The hub URL is resolved
+     * automatically from the configured Mercure HubInterface at render time.
      *
-     * @param string   $hubUrl          The Mercure hub URL (e.g. "/.well-known/mercure")
      * @param string[] $topics          Mercure topics. Defaults to ["/datatables/{pluralized-id}/{id}"]
      * @param bool     $withCredentials Whether to send credentials with the SSE request
      * @param int|null $debounceMs      Debounce delay in ms (default: 500)
      */
     public function mercure(
-        string $hubUrl,
         array $topics = [],
         bool $withCredentials = false,
         ?int $debounceMs = null,
     ): static {
         $this->mercureConfig = new MercureConfig(
-            hubUrl: $hubUrl,
             topics: [] !== $topics ? $topics : [$this->buildFallbackMercureTopic()],
             withCredentials: $withCredentials,
             debounceMs: $debounceMs,
         );
+
+        return $this;
+    }
+
+    public function setMercureConfig(MercureConfig $config): static
+    {
+        $this->mercureConfig = $config;
 
         return $this;
     }

--- a/src/Rendering/RenderingPreparer.php
+++ b/src/Rendering/RenderingPreparer.php
@@ -7,6 +7,7 @@ namespace Pentiminax\UX\DataTables\Rendering;
 use Pentiminax\UX\DataTables\Attribute\AsDataTable;
 use Pentiminax\UX\DataTables\Contracts\ApiResourceCollectionUrlResolverInterface;
 use Pentiminax\UX\DataTables\Contracts\MercureConfigResolverInterface;
+use Pentiminax\UX\DataTables\Contracts\MercureHubUrlResolverInterface;
 use Pentiminax\UX\DataTables\Model\DataTable;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -16,6 +17,7 @@ final class RenderingPreparer
         private readonly ?ApiResourceCollectionUrlResolverInterface $urlResolver = null,
         private readonly ?MercureConfigResolverInterface $mercureResolver = null,
         private readonly ?TranslatorInterface $translator = null,
+        private readonly ?MercureHubUrlResolverInterface $mercureHubUrlResolver = null,
     ) {
     }
 
@@ -62,7 +64,13 @@ final class RenderingPreparer
 
     private function configureMercure(DataTable $table, ?AsDataTable $asDataTable): void
     {
-        if (null !== $table->getMercureConfig()) {
+        $manualConfig = $table->getMercureConfig();
+
+        if (null !== $manualConfig) {
+            $table->setMercureConfig(
+                $manualConfig->withHubUrl($this->resolveHubUrlOrThrow())
+            );
+
             return;
         }
 
@@ -83,12 +91,18 @@ final class RenderingPreparer
             return;
         }
 
-        $table->mercure(
-            hubUrl: $mercureConfig->hubUrl,
-            topics: $mercureConfig->topics,
-            withCredentials: $mercureConfig->withCredentials,
-            debounceMs: $mercureConfig->debounceMs,
-        );
+        $table->setMercureConfig($mercureConfig);
+    }
+
+    private function resolveHubUrlOrThrow(): string
+    {
+        $hubUrl = $this->mercureHubUrlResolver?->resolveHubUrl();
+
+        if (null === $hubUrl || '' === $hubUrl) {
+            throw new \LogicException('Cannot enable Mercure on this DataTable: the Mercure hub URL could not be resolved. Ensure symfony/mercure-bundle is installed and configured (e.g. MERCURE_URL / MERCURE_PUBLIC_URL).');
+        }
+
+        return $hubUrl;
     }
 
     private function configureEditModal(DataTable $table, ?AsDataTable $asDataTable): void

--- a/tests/Fixtures/DataTable/TestDataTableWithManualMercure.php
+++ b/tests/Fixtures/DataTable/TestDataTableWithManualMercure.php
@@ -8,6 +8,7 @@ use Pentiminax\UX\DataTables\Attribute\AsDataTable;
 use Pentiminax\UX\DataTables\Column\TextColumn;
 use Pentiminax\UX\DataTables\Contracts\ApiResourceCollectionUrlResolverInterface;
 use Pentiminax\UX\DataTables\Contracts\MercureConfigResolverInterface;
+use Pentiminax\UX\DataTables\Contracts\MercureHubUrlResolverInterface;
 use Pentiminax\UX\DataTables\Model\AbstractDataTable;
 use Pentiminax\UX\DataTables\Model\DataTable;
 use Pentiminax\UX\DataTables\Rendering\RenderingPreparer;
@@ -18,9 +19,15 @@ class TestDataTableWithManualMercure extends AbstractDataTable
     public function __construct(
         ?ApiResourceCollectionUrlResolverInterface $apiResourceCollectionUrlResolver = null,
         ?MercureConfigResolverInterface $mercureConfigResolver = null,
+        ?MercureHubUrlResolverInterface $mercureHubUrlResolver = null,
     ) {
         parent::__construct(
-            renderingPreparer: new RenderingPreparer($apiResourceCollectionUrlResolver, $mercureConfigResolver),
+            renderingPreparer: new RenderingPreparer(
+                $apiResourceCollectionUrlResolver,
+                $mercureConfigResolver,
+                null,
+                $mercureHubUrlResolver,
+            ),
         );
     }
 
@@ -28,10 +35,7 @@ class TestDataTableWithManualMercure extends AbstractDataTable
     {
         return $table
             ->ajax('/api/books')
-            ->mercure(
-                hubUrl: '/.well-known/mercure',
-                topics: ['manual/topic'],
-            );
+            ->mercure(topics: ['manual/topic']);
     }
 
     public function configureColumns(): iterable

--- a/tests/Unit/Attribute/AsDataTableTest.php
+++ b/tests/Unit/Attribute/AsDataTableTest.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Pentiminax\UX\DataTables\Attribute\AsDataTable;
 use Pentiminax\UX\DataTables\Contracts\ApiResourceCollectionUrlResolverInterface;
 use Pentiminax\UX\DataTables\Contracts\MercureConfigResolverInterface;
+use Pentiminax\UX\DataTables\Contracts\MercureHubUrlResolverInterface;
 use Pentiminax\UX\DataTables\DataProvider\ArrayDataProvider;
 use Pentiminax\UX\DataTables\DataProvider\DoctrineDataProvider;
 use Pentiminax\UX\DataTables\Mercure\MercureConfig;
@@ -222,10 +223,10 @@ final class AsDataTableTest extends TestCase
             ->expects($this->once())
             ->method('resolveMercureConfig')
             ->with(\stdClass::class)
-            ->willReturn(new MercureConfig(
-                hubUrl: 'http://localhost/.well-known/mercure',
-                topics: ['/api/books/{id}'],
-            ));
+            ->willReturn(
+                (new MercureConfig(topics: ['/api/books/{id}']))
+                    ->withHubUrl('http://localhost/.well-known/mercure')
+            );
 
         $table = new TestDataTableWithMercureAttribute(mercureConfigResolver: $resolver);
 
@@ -245,10 +246,10 @@ final class AsDataTableTest extends TestCase
             ->expects($this->once())
             ->method('resolveMercureConfig')
             ->with(\stdClass::class)
-            ->willReturn(new MercureConfig(
-                hubUrl: 'http://localhost/.well-known/mercure',
-                topics: ['/api/books/{id}', '/api/authors/{id}'],
-            ));
+            ->willReturn(
+                (new MercureConfig(topics: ['/api/books/{id}', '/api/authors/{id}']))
+                    ->withHubUrl('http://localhost/.well-known/mercure')
+            );
 
         $table = new TestDataTableWithMercureAndManualAjax(mercureConfigResolver: $resolver);
 
@@ -284,7 +285,13 @@ final class AsDataTableTest extends TestCase
         $resolver = $this->createMock(MercureConfigResolverInterface::class);
         $resolver->expects($this->never())->method('resolveMercureConfig');
 
-        $table = new TestDataTableWithManualMercure(mercureConfigResolver: $resolver);
+        $hubUrlResolver = $this->createMock(MercureHubUrlResolverInterface::class);
+        $hubUrlResolver->method('resolveHubUrl')->willReturn('/.well-known/mercure');
+
+        $table = new TestDataTableWithManualMercure(
+            mercureConfigResolver: $resolver,
+            mercureHubUrlResolver: $hubUrlResolver,
+        );
 
         $table->prepareForRendering();
 

--- a/tests/Unit/Mercure/MercureConfigTest.php
+++ b/tests/Unit/Mercure/MercureConfigTest.php
@@ -18,10 +18,8 @@ final class MercureConfigTest extends TestCase
     #[Test]
     public function it_serializes_required_fields(): void
     {
-        $config = new MercureConfig(
-            hubUrl: '/.well-known/mercure',
-            topics: ['datatables/MyTable'],
-        );
+        $config = (new MercureConfig(topics: ['datatables/MyTable']))
+            ->withHubUrl('/.well-known/mercure');
 
         $this->assertSame([
             'hubUrl' => '/.well-known/mercure',
@@ -32,11 +30,10 @@ final class MercureConfigTest extends TestCase
     #[Test]
     public function it_omits_false_with_credentials(): void
     {
-        $config = new MercureConfig(
-            hubUrl: '/.well-known/mercure',
+        $config = (new MercureConfig(
             topics: ['datatables/MyTable'],
             withCredentials: false,
-        );
+        ))->withHubUrl('/.well-known/mercure');
 
         $serialized = $config->jsonSerialize();
 
@@ -46,11 +43,10 @@ final class MercureConfigTest extends TestCase
     #[Test]
     public function it_includes_with_credentials_when_true(): void
     {
-        $config = new MercureConfig(
-            hubUrl: '/.well-known/mercure',
+        $config = (new MercureConfig(
             topics: ['datatables/MyTable'],
             withCredentials: true,
-        );
+        ))->withHubUrl('/.well-known/mercure');
 
         $serialized = $config->jsonSerialize();
 
@@ -60,10 +56,8 @@ final class MercureConfigTest extends TestCase
     #[Test]
     public function it_omits_null_debounce(): void
     {
-        $config = new MercureConfig(
-            hubUrl: '/.well-known/mercure',
-            topics: ['datatables/MyTable'],
-        );
+        $config = (new MercureConfig(topics: ['datatables/MyTable']))
+            ->withHubUrl('/.well-known/mercure');
 
         $this->assertArrayNotHasKey('debounceMs', $config->jsonSerialize());
     }
@@ -71,11 +65,10 @@ final class MercureConfigTest extends TestCase
     #[Test]
     public function it_includes_debounce_when_set(): void
     {
-        $config = new MercureConfig(
-            hubUrl: '/.well-known/mercure',
+        $config = (new MercureConfig(
             topics: ['datatables/MyTable'],
             debounceMs: 1000,
-        );
+        ))->withHubUrl('/.well-known/mercure');
 
         $this->assertSame(1000, $config->jsonSerialize()['debounceMs']);
     }
@@ -83,12 +76,11 @@ final class MercureConfigTest extends TestCase
     #[Test]
     public function it_serializes_all_fields(): void
     {
-        $config = new MercureConfig(
-            hubUrl: '/.well-known/mercure',
+        $config = (new MercureConfig(
             topics: ['datatables/MyTable'],
             withCredentials: true,
             debounceMs: 300,
-        );
+        ))->withHubUrl('/.well-known/mercure');
 
         $this->assertSame([
             'hubUrl'          => '/.well-known/mercure',
@@ -102,10 +94,38 @@ final class MercureConfigTest extends TestCase
     public function it_normalizes_multiple_topics(): void
     {
         $config = new MercureConfig(
-            hubUrl: '/.well-known/mercure',
             topics: ['/api/books/{id}', '/api/authors/{id}'],
         );
 
         $this->assertSame(['/api/books/{id}', '/api/authors/{id}'], $config->topics);
+    }
+
+    #[Test]
+    public function it_throws_when_serializing_without_hub_url(): void
+    {
+        $config = new MercureConfig(topics: ['datatables/MyTable']);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('hubUrl is not set');
+
+        $config->jsonSerialize();
+    }
+
+    #[Test]
+    public function with_hub_url_returns_clone_preserving_other_fields(): void
+    {
+        $base = new MercureConfig(
+            topics: ['datatables/MyTable'],
+            withCredentials: true,
+            debounceMs: 250,
+        );
+
+        $resolved = $base->withHubUrl('/.well-known/mercure');
+
+        $this->assertNull($base->hubUrl);
+        $this->assertSame('/.well-known/mercure', $resolved->hubUrl);
+        $this->assertSame($base->topics, $resolved->topics);
+        $this->assertSame($base->withCredentials, $resolved->withCredentials);
+        $this->assertSame($base->debounceMs, $resolved->debounceMs);
     }
 }

--- a/tests/Unit/Mercure/MercureUpdatePublisherTest.php
+++ b/tests/Unit/Mercure/MercureUpdatePublisherTest.php
@@ -82,7 +82,7 @@ final class MercureUpdatePublisherTest extends TestCase
     public function it_publishes_for_datatable(): void
     {
         $table = (new DataTable('ProductDataTable'))
-            ->mercure(hubUrl: '/.well-known/mercure');
+            ->mercure();
 
         $hub = $this->createMock(HubInterface::class);
         $hub->expects($this->once())
@@ -100,7 +100,7 @@ final class MercureUpdatePublisherTest extends TestCase
     public function it_publishes_all_datatable_topics(): void
     {
         $table = (new DataTable('ProductDataTable'))
-            ->mercure(hubUrl: '/.well-known/mercure', topics: ['/api/products/{id}', '/api/categories/{id}']);
+            ->mercure(topics: ['/api/products/{id}', '/api/categories/{id}']);
 
         $hub = $this->createMock(HubInterface::class);
         $hub->expects($this->once())

--- a/tests/Unit/Model/DataTableTest.php
+++ b/tests/Unit/Model/DataTableTest.php
@@ -158,12 +158,12 @@ final class DataTableTest extends TestCase
     public function it_configures_mercure_with_default_topic(): void
     {
         $table = (new DataTable('ProductDataTable'))
-            ->mercure(hubUrl: '/.well-known/mercure');
+            ->mercure();
 
         $config = $table->getMercureConfig();
 
         $this->assertInstanceOf(MercureConfig::class, $config);
-        $this->assertSame('/.well-known/mercure', $config->hubUrl);
+        $this->assertNull($config->hubUrl);
         $this->assertSame(['/datatables/product-data-tables/{id}'], $config->topics);
         $this->assertFalse($config->withCredentials);
         $this->assertNull($config->debounceMs);
@@ -173,7 +173,7 @@ final class DataTableTest extends TestCase
     public function it_configures_mercure_with_custom_topic(): void
     {
         $table = (new DataTable('ProductDataTable'))
-            ->mercure(hubUrl: '/.well-known/mercure', topics: ['my/custom/topic']);
+            ->mercure(topics: ['my/custom/topic']);
 
         $config = $table->getMercureConfig();
 
@@ -184,7 +184,7 @@ final class DataTableTest extends TestCase
     public function it_configures_mercure_with_multiple_topics(): void
     {
         $table = (new DataTable('ProductDataTable'))
-            ->mercure(hubUrl: '/.well-known/mercure', topics: ['/api/products/{id}', '/api/categories/{id}']);
+            ->mercure(topics: ['/api/products/{id}', '/api/categories/{id}']);
 
         $config = $table->getMercureConfig();
 
@@ -195,7 +195,9 @@ final class DataTableTest extends TestCase
     public function it_includes_mercure_in_get_options(): void
     {
         $table = (new DataTable('ProductDataTable'))
-            ->mercure(hubUrl: '/.well-known/mercure', debounceMs: 300);
+            ->mercure(debounceMs: 300);
+
+        $table->setMercureConfig($table->getMercureConfig()->withHubUrl('/.well-known/mercure'));
 
         $options = $table->getOptions();
 
@@ -221,7 +223,7 @@ final class DataTableTest extends TestCase
     {
         $table = new DataTable('test');
 
-        $this->assertSame($table, $table->mercure('/.well-known/mercure'));
+        $this->assertSame($table, $table->mercure());
     }
 
     #[Test]

--- a/tests/Unit/Rendering/RenderingPreparerTest.php
+++ b/tests/Unit/Rendering/RenderingPreparerTest.php
@@ -8,6 +8,7 @@ use Pentiminax\UX\DataTables\Attribute\AsDataTable;
 use Pentiminax\UX\DataTables\Column\TextColumn;
 use Pentiminax\UX\DataTables\Contracts\ApiResourceCollectionUrlResolverInterface;
 use Pentiminax\UX\DataTables\Contracts\MercureConfigResolverInterface;
+use Pentiminax\UX\DataTables\Contracts\MercureHubUrlResolverInterface;
 use Pentiminax\UX\DataTables\Mercure\MercureConfig;
 use Pentiminax\UX\DataTables\Model\DataTable;
 use Pentiminax\UX\DataTables\Rendering\RenderingPreparer;
@@ -148,10 +149,8 @@ final class RenderingPreparerTest extends TestCase
     #[Test]
     public function it_configures_mercure(): void
     {
-        $mercureConfig = new MercureConfig(
-            hubUrl: '/.well-known/mercure',
-            topics: ['/products/{id}'],
-        );
+        $mercureConfig = (new MercureConfig(topics: ['/products/{id}']))
+            ->withHubUrl('/.well-known/mercure');
 
         $mercureResolver = $this->createMock(MercureConfigResolverInterface::class);
         $mercureResolver->method('resolveMercureConfig')
@@ -182,18 +181,41 @@ final class RenderingPreparerTest extends TestCase
     }
 
     #[Test]
-    public function it_skips_mercure_when_already_configured(): void
+    public function it_enriches_manual_mercure_config_with_resolved_hub_url(): void
     {
         $mercureResolver = $this->createMock(MercureConfigResolverInterface::class);
         $mercureResolver->expects($this->never())->method('resolveMercureConfig');
 
-        $preparer = new RenderingPreparer(mercureResolver: $mercureResolver);
-        $table    = new DataTable('Test');
-        $table->mercure(hubUrl: '/hub', topics: ['/existing']);
+        $hubUrlResolver = $this->createMock(MercureHubUrlResolverInterface::class);
+        $hubUrlResolver->method('resolveHubUrl')->willReturn('/.well-known/mercure');
+
+        $preparer = new RenderingPreparer(
+            mercureResolver: $mercureResolver,
+            mercureHubUrlResolver: $hubUrlResolver,
+        );
+        $table = new DataTable('Test');
+        $table->mercure(topics: ['/existing']);
 
         $preparer->prepare($table, new AsDataTable(entityClass: \stdClass::class, mercure: true));
 
-        $this->assertSame('/hub', $table->getMercureConfig()->hubUrl);
+        $this->assertSame('/.well-known/mercure', $table->getMercureConfig()->hubUrl);
+        $this->assertSame(['/existing'], $table->getMercureConfig()->topics);
+    }
+
+    #[Test]
+    public function it_throws_when_manual_mercure_has_no_resolvable_hub_url(): void
+    {
+        $hubUrlResolver = $this->createMock(MercureHubUrlResolverInterface::class);
+        $hubUrlResolver->method('resolveHubUrl')->willReturn(null);
+
+        $preparer = new RenderingPreparer(mercureHubUrlResolver: $hubUrlResolver);
+        $table    = new DataTable('Test');
+        $table->mercure(topics: ['/existing']);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Mercure hub URL could not be resolved');
+
+        $preparer->prepare($table, null);
     }
 
     #[Test]


### PR DESCRIPTION
refactor(mercure): remove mandatory `hubUrl` from `mercure()` method and enhance automatic resolution via `HubInterface`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `setMercureConfig()` method to DataTable for direct Mercure configuration injection.

* **Refactor**
  * Simplified `DataTable::mercure()` method signature by removing explicit `hubUrl` parameter; hub URL is now resolved internally during rendering.
  * Made Mercure hub URL optional and deferred to render time via fluent `withHubUrl()` method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->