### PR TITLE
Make DataTable runtime infrastructure container-owned

### DIFF
--- a/src/DataProvider/AutoDataProviderFactory.php
+++ b/src/DataProvider/AutoDataProviderFactory.php
@@ -18,11 +18,6 @@ final class AutoDataProviderFactory
     ) {
     }
 
-    public function setEntityManager(?EntityManagerInterface $em): void
-    {
-        $this->em = $em;
-    }
-
     /**
      * @param callable(QueryBuilder, DataTableRequest):QueryBuilder $configureQueryBuilder
      */
@@ -36,7 +31,7 @@ final class AutoDataProviderFactory
         }
 
         if (null === $this->em) {
-            throw new \LogicException('EntityManagerInterface is required to auto-configure a DoctrineDataProvider from #[AsDataTable]. Inject it via the runtime factory or setEntityManager().');
+            throw new \LogicException('EntityManagerInterface is required to auto-configure a DoctrineDataProvider from #[AsDataTable]. Ensure Doctrine ORM is installed and the DataTable is managed by Symfony.');
         }
 
         return new DoctrineDataProvider(

--- a/src/DataProvider/DataProviderResolver.php
+++ b/src/DataProvider/DataProviderResolver.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Pentiminax\UX\DataTables\DataProvider;
 
-use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
 use Pentiminax\UX\DataTables\Attribute\AsDataTable;
 use Pentiminax\UX\DataTables\Contracts\DataProviderInterface;
@@ -16,11 +15,6 @@ final class DataProviderResolver
     public function __construct(
         private readonly AutoDataProviderFactory $autoDataProviderFactory,
     ) {
-    }
-
-    public function setEntityManager(?EntityManagerInterface $em): void
-    {
-        $this->autoDataProviderFactory->setEntityManager($em);
     }
 
     /**

--- a/src/DataTablesBundle.php
+++ b/src/DataTablesBundle.php
@@ -43,6 +43,7 @@ use Pentiminax\UX\DataTables\Mercure\MercureUpdatePublisher;
 use Pentiminax\UX\DataTables\Model\AbstractDataTable;
 use Pentiminax\UX\DataTables\Rendering\RenderingPreparer;
 use Pentiminax\UX\DataTables\Routing\RouteLoader;
+use Pentiminax\UX\DataTables\Runtime\DataTableInfrastructure;
 use Pentiminax\UX\DataTables\Runtime\DataTableRuntimeFactory;
 use Symfony\Component\AssetMapper\AssetMapperInterface;
 use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
@@ -113,11 +114,12 @@ class DataTablesBundle extends AbstractBundle
     public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
     {
         $builder->registerForAutoconfiguration(AbstractDataTable::class)
-            ->addTag('datatables.data_table');
+            ->addTag('datatables.data_table')
+            ->addMethodCall('setDataTableInfrastructure', [new Reference('datatables.infrastructure')]);
 
         $this->registerCoreServices($container, $config);
 
-        if (interface_exists(ResourceMetadataCollectionFactoryInterface::class)) {
+        if ($this->isApiPlatformAvailable($builder)) {
             $this->registerApiPlatformServices($container);
         }
 
@@ -159,6 +161,15 @@ class DataTablesBundle extends AbstractBundle
         }
 
         return is_file($bundlesMetadata['FrameworkBundle']['path'].'/Resources/config/asset_mapper.php');
+    }
+
+    private function isApiPlatformAvailable(ContainerBuilder $builder): bool
+    {
+        if (!interface_exists(ResourceMetadataCollectionFactoryInterface::class)) {
+            return false;
+        }
+
+        return isset($builder->getParameter('kernel.bundles')['ApiPlatformBundle']);
     }
 
     private function registerCoreServices(ContainerConfigurator $container, array $config): void
@@ -246,7 +257,7 @@ class DataTablesBundle extends AbstractBundle
         if (interface_exists(\Symfony\Component\Routing\Generator\UrlGeneratorInterface::class)) {
             $container->services()
                 ->set('datatables.column.url_column_data_resolver', UrlColumnDataResolver::class)
-                ->arg(0, service('router'))
+                ->arg(0, service('router')->nullOnInvalid())
                 ->private();
 
             $container->services()
@@ -286,6 +297,17 @@ class DataTablesBundle extends AbstractBundle
 
         $container->services()
             ->alias(DataTableRuntimeFactory::class, 'datatables.runtime.factory')
+            ->private();
+
+        $container->services()
+            ->set('datatables.infrastructure', DataTableInfrastructure::class)
+            ->arg(0, service('datatables.column.resolver'))
+            ->arg(1, service('datatables.rendering.preparer'))
+            ->arg(2, service('datatables.runtime.factory'))
+            ->private();
+
+        $container->services()
+            ->alias(DataTableInfrastructure::class, 'datatables.infrastructure')
             ->private();
     }
 

--- a/src/Model/AbstractDataTable.php
+++ b/src/Model/AbstractDataTable.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace Pentiminax\UX\DataTables\Model;
 
-use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
 use Pentiminax\UX\DataTables\Attribute\AsDataTable;
 use Pentiminax\UX\DataTables\Column\ActionColumn;
-use Pentiminax\UX\DataTables\Column\ColumnResolver;
 use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
 use Pentiminax\UX\DataTables\Contracts\DataProviderInterface;
 use Pentiminax\UX\DataTables\Contracts\RowMapperInterface;
@@ -19,10 +17,9 @@ use Pentiminax\UX\DataTables\Query\Builder\QueryFilterChain;
 use Pentiminax\UX\DataTables\Query\QueryFilterContext;
 use Pentiminax\UX\DataTables\Query\Strategy\DefaultSearchStrategyRegistry;
 use Pentiminax\UX\DataTables\Query\Strategy\SearchStrategyRegistry;
-use Pentiminax\UX\DataTables\Rendering\RenderingPreparer;
 use Pentiminax\UX\DataTables\RowMapper\DefaultRowMapper;
+use Pentiminax\UX\DataTables\Runtime\DataTableInfrastructure;
 use Pentiminax\UX\DataTables\Runtime\DataTableRuntime;
-use Pentiminax\UX\DataTables\Runtime\DataTableRuntimeFactory;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -42,72 +39,58 @@ abstract class AbstractDataTable
 
     private ?RowMapperInterface $defaultRowMapper = null;
 
-    private ?AsDataTable $asDataTable;
+    private ?AsDataTable $asDataTable = null;
 
-    private ColumnResolver $columnResolver;
-
-    private RenderingPreparer $renderingPreparer;
-
-    private DataTableRuntimeFactory $runtimeFactory;
+    private ?DataTableInfrastructure $infrastructure = null;
 
     private ?DataTableRuntime $runtime = null;
+
+    private bool $initialized = false;
 
     private bool $renderingPrepared = false;
 
     public function __construct()
     {
-        $this->asDataTable       = $this->resolveAsDataTable();
-        $this->columnResolver    = $this->createColumnResolver();
-        $this->renderingPreparer = $this->createRenderingPreparer();
-        $this->runtimeFactory    = $this->createRuntimeFactory();
-
-        $this->initializeTable();
-        $this->initializeColumns();
-        $this->initializeExtensions();
     }
 
-    protected function createColumnResolver(): ColumnResolver
+    final public function setDataTableInfrastructure(DataTableInfrastructure $infrastructure): void
     {
-        return new ColumnResolver();
+        if ($this->initialized || null !== $this->runtime) {
+            throw new \LogicException('DataTable infrastructure must be injected before the table is initialized.');
+        }
+
+        $this->infrastructure = $infrastructure;
     }
 
-    protected function createRenderingPreparer(): RenderingPreparer
+    private function initialize(): void
     {
-        return new RenderingPreparer();
-    }
+        if ($this->initialized) {
+            return;
+        }
 
-    protected function createRuntimeFactory(): DataTableRuntimeFactory
-    {
-        return new DataTableRuntimeFactory();
-    }
+        $this->asDataTable = $this->resolveAsDataTable();
 
-    private function initializeTable(): void
-    {
         $this->table = $this->configureDataTable(
             new DataTable($this->getClassName())
         );
-    }
 
-    private function initializeColumns(): void
-    {
         $this->columns = iterator_to_array($this->configureColumns());
 
-        $this->columnResolver->configureBooleanColumns($this->columns, $this->asDataTable);
+        $this->infrastructure()->columnResolver()->configureBooleanColumns($this->columns, $this->asDataTable);
 
         $actions = $this->configureActions(new Actions());
 
-        $this->columnResolver->configureActionEntityClass($actions, $this->asDataTable);
+        $this->infrastructure()->columnResolver()->configureActionEntityClass($actions, $this->asDataTable);
 
         $this->configureActionColumn($actions);
 
         $this->table->columns($this->columns);
-    }
 
-    private function initializeExtensions(): void
-    {
         $this->table->setExtensions(
             $this->configureExtensions(new DataTableExtensions())
         );
+
+        $this->initialized = true;
     }
 
     public function getRequest(): ?DataTableRequest
@@ -139,13 +122,17 @@ abstract class AbstractDataTable
 
     public function prepareForRendering(): void
     {
+        $this->initialize();
+
         if ($this->renderingPrepared) {
             return;
         }
 
-        $this->renderingPreparer->prepareBeforeDataHydration($this->table, $this->asDataTable);
+        $renderingPreparer = $this->infrastructure()->renderingPreparer();
+
+        $renderingPreparer->prepareBeforeDataHydration($this->table, $this->asDataTable);
         $this->hydrateClientSideData();
-        $this->renderingPreparer->prepareAfterDataHydration($this->table, $this->asDataTable);
+        $renderingPreparer->prepareAfterDataHydration($this->table, $this->asDataTable);
 
         $this->renderingPrepared = true;
     }
@@ -159,6 +146,8 @@ abstract class AbstractDataTable
 
     public function getConfiguredDataTable(): DataTable
     {
+        $this->initialize();
+
         return $this->table;
     }
 
@@ -167,12 +156,14 @@ abstract class AbstractDataTable
      */
     public function configureColumns(): iterable
     {
-        $columns = $this->table->getColumns();
-        if ([] !== $columns) {
-            return $columns;
+        if (isset($this->table)) {
+            $columns = $this->table->getColumns();
+            if ([] !== $columns) {
+                return $columns;
+            }
         }
 
-        return $this->columnResolver->resolveColumns($this->asDataTable);
+        return $this->infrastructure()->columnResolver()->resolveColumns($this->asDataTable ?? $this->resolveAsDataTable());
     }
 
     public function configureDataTable(DataTable $table): DataTable
@@ -268,13 +259,10 @@ abstract class AbstractDataTable
         return new DefaultSearchStrategyRegistry();
     }
 
-    public function setEntityManager(?EntityManagerInterface $em): void
-    {
-        $this->runtimeFactory->setEntityManager($em);
-    }
-
     public function getColumnByName(string $name): ?ColumnInterface
     {
+        $this->initialize();
+
         return $this->table->getColumnByName($name);
     }
 
@@ -290,7 +278,9 @@ abstract class AbstractDataTable
 
     final protected function createRowMapper(): RowMapperInterface
     {
-        return $this->runtimeFactory->createRowMapper(
+        $this->initialize();
+
+        return $this->infrastructure()->runtimeFactory()->createRowMapper(
             baseMapper: $this->mapRow(...),
             columns: $this->columns,
         );
@@ -298,6 +288,8 @@ abstract class AbstractDataTable
 
     public function setData(array $data): void
     {
+        $this->initialize();
+
         $rowMapper = $this->createRowMapper();
         $rows      = [];
 
@@ -311,6 +303,8 @@ abstract class AbstractDataTable
 
     private function getDefaultRowMapper(): DefaultRowMapper
     {
+        $this->initialize();
+
         if (null === $this->defaultRowMapper) {
             $this->defaultRowMapper = new DefaultRowMapper($this->columns);
         }
@@ -341,7 +335,9 @@ abstract class AbstractDataTable
 
     private function runtime(): DataTableRuntime
     {
-        return $this->runtime ??= $this->runtimeFactory->createRuntime(
+        $this->initialize();
+
+        return $this->runtime ??= $this->infrastructure()->runtimeFactory()->createRuntime(
             table: $this->table,
             columns: $this->columns,
             asDataTable: $this->asDataTable,
@@ -349,6 +345,11 @@ abstract class AbstractDataTable
             manualDataProviderFactory: $this->createDataProvider(...),
             configureQueryBuilder: $this->configureQueryBuilder(...),
         );
+    }
+
+    private function infrastructure(): DataTableInfrastructure
+    {
+        return $this->infrastructure ??= DataTableInfrastructure::createDefault();
     }
 
     private function configureActionColumn(Actions $actions): void

--- a/src/Runtime/DataTableInfrastructure.php
+++ b/src/Runtime/DataTableInfrastructure.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Runtime;
+
+use Pentiminax\UX\DataTables\Column\ColumnResolver;
+use Pentiminax\UX\DataTables\Rendering\RenderingPreparer;
+
+final class DataTableInfrastructure
+{
+    public function __construct(
+        private readonly ColumnResolver $columnResolver,
+        private readonly RenderingPreparer $renderingPreparer,
+        private readonly DataTableRuntimeFactory $runtimeFactory,
+    ) {
+    }
+
+    public static function createDefault(
+        ?ColumnResolver $columnResolver = null,
+        ?RenderingPreparer $renderingPreparer = null,
+        ?DataTableRuntimeFactory $runtimeFactory = null,
+    ): self {
+        return new self(
+            columnResolver: $columnResolver       ?? new ColumnResolver(),
+            renderingPreparer: $renderingPreparer ?? new RenderingPreparer(),
+            runtimeFactory: $runtimeFactory       ?? new DataTableRuntimeFactory(),
+        );
+    }
+
+    public function columnResolver(): ColumnResolver
+    {
+        return $this->columnResolver;
+    }
+
+    public function renderingPreparer(): RenderingPreparer
+    {
+        return $this->renderingPreparer;
+    }
+
+    public function runtimeFactory(): DataTableRuntimeFactory
+    {
+        return $this->runtimeFactory;
+    }
+}

--- a/src/Runtime/DataTableRuntimeFactory.php
+++ b/src/Runtime/DataTableRuntimeFactory.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Pentiminax\UX\DataTables\Runtime;
 
-use Doctrine\ORM\EntityManagerInterface;
 use Pentiminax\UX\DataTables\Attribute\AsDataTable;
 use Pentiminax\UX\DataTables\Column\Rendering\ActionRowDataResolver;
 use Pentiminax\UX\DataTables\Column\Rendering\TemplateColumnRenderer;
@@ -31,11 +30,6 @@ final class DataTableRuntimeFactory
     ) {
     }
 
-    public function setEntityManager(?EntityManagerInterface $em): void
-    {
-        $this->getDataProviderResolver()->setEntityManager($em);
-    }
-
     /**
      * @param ColumnInterface[]     $columns
      * @param \Closure(mixed):array $baseMapper
@@ -47,9 +41,7 @@ final class DataTableRuntimeFactory
 
         $pipeline->add(new UrlColumnResolutionStage($this->urlColumnDataResolver ?? new UrlColumnDataResolver()));
 
-        if (null !== $this->templateColumnRenderer) {
-            $pipeline->add(new TemplateRenderingStage($this->templateColumnRenderer));
-        }
+        $pipeline->add(new TemplateRenderingStage($this->templateColumnRenderer ?? new TemplateColumnRenderer()));
 
         $pipeline->add(new ActionResolutionStage($this->actionRowDataResolver ?? new ActionRowDataResolver()));
 

--- a/tests/Fixtures/DataTable/AutoDetectNoAttributeDataTable.php
+++ b/tests/Fixtures/DataTable/AutoDetectNoAttributeDataTable.php
@@ -7,16 +7,15 @@ namespace Pentiminax\UX\DataTables\Tests\Fixtures\DataTable;
 use Pentiminax\UX\DataTables\Column\ColumnResolver;
 use Pentiminax\UX\DataTables\Contracts\ColumnAutoDetectorInterface;
 use Pentiminax\UX\DataTables\Model\AbstractDataTable;
+use Pentiminax\UX\DataTables\Runtime\DataTableInfrastructure;
 
 class AutoDetectNoAttributeDataTable extends AbstractDataTable
 {
     public function __construct(private readonly ?ColumnAutoDetectorInterface $columnAutoDetector = null)
     {
         parent::__construct();
-    }
-
-    protected function createColumnResolver(): ColumnResolver
-    {
-        return new ColumnResolver(columnAutoDetector: $this->columnAutoDetector);
+        $this->setDataTableInfrastructure(DataTableInfrastructure::createDefault(
+            columnResolver: new ColumnResolver(columnAutoDetector: $this->columnAutoDetector)
+        ));
     }
 }

--- a/tests/Fixtures/DataTable/AutoDetectTestDataTable.php
+++ b/tests/Fixtures/DataTable/AutoDetectTestDataTable.php
@@ -8,6 +8,7 @@ use Pentiminax\UX\DataTables\Attribute\AsDataTable;
 use Pentiminax\UX\DataTables\Column\ColumnResolver;
 use Pentiminax\UX\DataTables\Contracts\ColumnAutoDetectorInterface;
 use Pentiminax\UX\DataTables\Model\AbstractDataTable;
+use Pentiminax\UX\DataTables\Runtime\DataTableInfrastructure;
 
 #[AsDataTable(entityClass: \stdClass::class, apiPlatform: true)]
 class AutoDetectTestDataTable extends AbstractDataTable
@@ -15,10 +16,8 @@ class AutoDetectTestDataTable extends AbstractDataTable
     public function __construct(private readonly ?ColumnAutoDetectorInterface $columnAutoDetector = null)
     {
         parent::__construct();
-    }
-
-    protected function createColumnResolver(): ColumnResolver
-    {
-        return new ColumnResolver(columnAutoDetector: $this->columnAutoDetector);
+        $this->setDataTableInfrastructure(DataTableInfrastructure::createDefault(
+            columnResolver: new ColumnResolver(columnAutoDetector: $this->columnAutoDetector)
+        ));
     }
 }

--- a/tests/Fixtures/DataTable/AutoDetectWithGroupsDataTable.php
+++ b/tests/Fixtures/DataTable/AutoDetectWithGroupsDataTable.php
@@ -8,6 +8,7 @@ use Pentiminax\UX\DataTables\Attribute\AsDataTable;
 use Pentiminax\UX\DataTables\Column\ColumnResolver;
 use Pentiminax\UX\DataTables\Contracts\ColumnAutoDetectorInterface;
 use Pentiminax\UX\DataTables\Model\AbstractDataTable;
+use Pentiminax\UX\DataTables\Runtime\DataTableInfrastructure;
 
 #[AsDataTable(entityClass: \stdClass::class, serializationGroups: ['product:list'], apiPlatform: true)]
 class AutoDetectWithGroupsDataTable extends AbstractDataTable
@@ -15,10 +16,8 @@ class AutoDetectWithGroupsDataTable extends AbstractDataTable
     public function __construct(private readonly ?ColumnAutoDetectorInterface $columnAutoDetector = null)
     {
         parent::__construct();
-    }
-
-    protected function createColumnResolver(): ColumnResolver
-    {
-        return new ColumnResolver(columnAutoDetector: $this->columnAutoDetector);
+        $this->setDataTableInfrastructure(DataTableInfrastructure::createDefault(
+            columnResolver: new ColumnResolver(columnAutoDetector: $this->columnAutoDetector)
+        ));
     }
 }

--- a/tests/Fixtures/DataTable/AutoDetectWithoutApiPlatformOptInDataTable.php
+++ b/tests/Fixtures/DataTable/AutoDetectWithoutApiPlatformOptInDataTable.php
@@ -8,6 +8,7 @@ use Pentiminax\UX\DataTables\Attribute\AsDataTable;
 use Pentiminax\UX\DataTables\Column\ColumnResolver;
 use Pentiminax\UX\DataTables\Contracts\ColumnAutoDetectorInterface;
 use Pentiminax\UX\DataTables\Model\AbstractDataTable;
+use Pentiminax\UX\DataTables\Runtime\DataTableInfrastructure;
 
 #[AsDataTable(entityClass: \stdClass::class)]
 class AutoDetectWithoutApiPlatformOptInDataTable extends AbstractDataTable
@@ -15,10 +16,8 @@ class AutoDetectWithoutApiPlatformOptInDataTable extends AbstractDataTable
     public function __construct(private readonly ?ColumnAutoDetectorInterface $columnAutoDetector = null)
     {
         parent::__construct();
-    }
-
-    protected function createColumnResolver(): ColumnResolver
-    {
-        return new ColumnResolver(columnAutoDetector: $this->columnAutoDetector);
+        $this->setDataTableInfrastructure(DataTableInfrastructure::createDefault(
+            columnResolver: new ColumnResolver(columnAutoDetector: $this->columnAutoDetector)
+        ));
     }
 }

--- a/tests/Fixtures/DataTable/ServerSideTemplateDataTable.php
+++ b/tests/Fixtures/DataTable/ServerSideTemplateDataTable.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Fixtures\DataTable;
+
+use Pentiminax\UX\DataTables\Column\TemplateColumn;
+use Pentiminax\UX\DataTables\Column\TextColumn;
+use Pentiminax\UX\DataTables\Contracts\DataProviderInterface;
+use Pentiminax\UX\DataTables\DataProvider\ArrayDataProvider;
+use Pentiminax\UX\DataTables\Model\AbstractDataTable;
+use Pentiminax\UX\DataTables\Model\DataTable;
+
+final class ServerSideTemplateDataTable extends AbstractDataTable
+{
+    public function configureDataTable(DataTable $table): DataTable
+    {
+        return $table
+            ->ajax('/datatable/books')
+            ->serverSide();
+    }
+
+    public function configureColumns(): iterable
+    {
+        yield TextColumn::new('id');
+        yield TemplateColumn::new('status_display')
+            ->setField('status')
+            ->setTemplate('datatable/columns/status_badge.html.twig');
+    }
+
+    protected function createDataProvider(): ?DataProviderInterface
+    {
+        return new ArrayDataProvider([
+            new ServerSideTemplateRow(id: 7, status: 'active'),
+        ], $this->createRowMapper());
+    }
+}
+
+final readonly class ServerSideTemplateRow
+{
+    public function __construct(
+        private int $id,
+        private string $status,
+    ) {
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+}

--- a/tests/Fixtures/DataTable/TestDataTableWithAttribute.php
+++ b/tests/Fixtures/DataTable/TestDataTableWithAttribute.php
@@ -10,6 +10,7 @@ use Pentiminax\UX\DataTables\Contracts\ApiResourceCollectionUrlResolverInterface
 use Pentiminax\UX\DataTables\Contracts\MercureConfigResolverInterface;
 use Pentiminax\UX\DataTables\Model\AbstractDataTable;
 use Pentiminax\UX\DataTables\Rendering\RenderingPreparer;
+use Pentiminax\UX\DataTables\Runtime\DataTableInfrastructure;
 
 #[AsDataTable(entityClass: \stdClass::class, apiPlatform: true)]
 class TestDataTableWithAttribute extends AbstractDataTable
@@ -19,11 +20,9 @@ class TestDataTableWithAttribute extends AbstractDataTable
         private readonly ?MercureConfigResolverInterface $mercureConfigResolver = null,
     ) {
         parent::__construct();
-    }
-
-    protected function createRenderingPreparer(): RenderingPreparer
-    {
-        return new RenderingPreparer($this->apiResourceCollectionUrlResolver, $this->mercureConfigResolver);
+        $this->setDataTableInfrastructure(DataTableInfrastructure::createDefault(
+            renderingPreparer: new RenderingPreparer($this->apiResourceCollectionUrlResolver, $this->mercureConfigResolver)
+        ));
     }
 
     public function configureColumns(): iterable

--- a/tests/Fixtures/DataTable/TestDataTableWithData.php
+++ b/tests/Fixtures/DataTable/TestDataTableWithData.php
@@ -11,6 +11,7 @@ use Pentiminax\UX\DataTables\Contracts\MercureConfigResolverInterface;
 use Pentiminax\UX\DataTables\Model\AbstractDataTable;
 use Pentiminax\UX\DataTables\Model\DataTable;
 use Pentiminax\UX\DataTables\Rendering\RenderingPreparer;
+use Pentiminax\UX\DataTables\Runtime\DataTableInfrastructure;
 
 #[AsDataTable(entityClass: \stdClass::class)]
 class TestDataTableWithData extends AbstractDataTable
@@ -20,11 +21,9 @@ class TestDataTableWithData extends AbstractDataTable
         private readonly ?MercureConfigResolverInterface $mercureConfigResolver = null,
     ) {
         parent::__construct();
-    }
-
-    protected function createRenderingPreparer(): RenderingPreparer
-    {
-        return new RenderingPreparer($this->apiResourceCollectionUrlResolver, $this->mercureConfigResolver);
+        $this->setDataTableInfrastructure(DataTableInfrastructure::createDefault(
+            renderingPreparer: new RenderingPreparer($this->apiResourceCollectionUrlResolver, $this->mercureConfigResolver)
+        ));
     }
 
     public function configureDataTable(DataTable $table): DataTable

--- a/tests/Fixtures/DataTable/TestDataTableWithManualAjax.php
+++ b/tests/Fixtures/DataTable/TestDataTableWithManualAjax.php
@@ -11,6 +11,7 @@ use Pentiminax\UX\DataTables\Contracts\MercureConfigResolverInterface;
 use Pentiminax\UX\DataTables\Model\AbstractDataTable;
 use Pentiminax\UX\DataTables\Model\DataTable;
 use Pentiminax\UX\DataTables\Rendering\RenderingPreparer;
+use Pentiminax\UX\DataTables\Runtime\DataTableInfrastructure;
 
 #[AsDataTable(entityClass: \stdClass::class)]
 class TestDataTableWithManualAjax extends AbstractDataTable
@@ -20,11 +21,9 @@ class TestDataTableWithManualAjax extends AbstractDataTable
         private readonly ?MercureConfigResolverInterface $mercureConfigResolver = null,
     ) {
         parent::__construct();
-    }
-
-    protected function createRenderingPreparer(): RenderingPreparer
-    {
-        return new RenderingPreparer($this->apiResourceCollectionUrlResolver, $this->mercureConfigResolver);
+        $this->setDataTableInfrastructure(DataTableInfrastructure::createDefault(
+            renderingPreparer: new RenderingPreparer($this->apiResourceCollectionUrlResolver, $this->mercureConfigResolver)
+        ));
     }
 
     public function configureDataTable(DataTable $table): DataTable

--- a/tests/Fixtures/DataTable/TestDataTableWithManualMercure.php
+++ b/tests/Fixtures/DataTable/TestDataTableWithManualMercure.php
@@ -12,6 +12,7 @@ use Pentiminax\UX\DataTables\Contracts\MercureHubUrlResolverInterface;
 use Pentiminax\UX\DataTables\Model\AbstractDataTable;
 use Pentiminax\UX\DataTables\Model\DataTable;
 use Pentiminax\UX\DataTables\Rendering\RenderingPreparer;
+use Pentiminax\UX\DataTables\Runtime\DataTableInfrastructure;
 
 #[AsDataTable(entityClass: \stdClass::class, mercure: true)]
 class TestDataTableWithManualMercure extends AbstractDataTable
@@ -22,16 +23,14 @@ class TestDataTableWithManualMercure extends AbstractDataTable
         private readonly ?MercureHubUrlResolverInterface $mercureHubUrlResolver = null,
     ) {
         parent::__construct();
-    }
-
-    protected function createRenderingPreparer(): RenderingPreparer
-    {
-        return new RenderingPreparer(
-            $this->apiResourceCollectionUrlResolver,
-            $this->mercureConfigResolver,
-            null,
-            $this->mercureHubUrlResolver,
-        );
+        $this->setDataTableInfrastructure(DataTableInfrastructure::createDefault(
+            renderingPreparer: new RenderingPreparer(
+                $this->apiResourceCollectionUrlResolver,
+                $this->mercureConfigResolver,
+                null,
+                $this->mercureHubUrlResolver,
+            )
+        ));
     }
 
     public function configureDataTable(DataTable $table): DataTable

--- a/tests/Fixtures/DataTable/TestDataTableWithMercureAndData.php
+++ b/tests/Fixtures/DataTable/TestDataTableWithMercureAndData.php
@@ -11,6 +11,7 @@ use Pentiminax\UX\DataTables\Contracts\MercureConfigResolverInterface;
 use Pentiminax\UX\DataTables\Model\AbstractDataTable;
 use Pentiminax\UX\DataTables\Model\DataTable;
 use Pentiminax\UX\DataTables\Rendering\RenderingPreparer;
+use Pentiminax\UX\DataTables\Runtime\DataTableInfrastructure;
 
 #[AsDataTable(entityClass: \stdClass::class, mercure: true)]
 class TestDataTableWithMercureAndData extends AbstractDataTable
@@ -20,11 +21,9 @@ class TestDataTableWithMercureAndData extends AbstractDataTable
         private readonly ?MercureConfigResolverInterface $mercureConfigResolver = null,
     ) {
         parent::__construct();
-    }
-
-    protected function createRenderingPreparer(): RenderingPreparer
-    {
-        return new RenderingPreparer($this->apiResourceCollectionUrlResolver, $this->mercureConfigResolver);
+        $this->setDataTableInfrastructure(DataTableInfrastructure::createDefault(
+            renderingPreparer: new RenderingPreparer($this->apiResourceCollectionUrlResolver, $this->mercureConfigResolver)
+        ));
     }
 
     public function configureDataTable(DataTable $table): DataTable

--- a/tests/Fixtures/DataTable/TestDataTableWithMercureAndManualAjax.php
+++ b/tests/Fixtures/DataTable/TestDataTableWithMercureAndManualAjax.php
@@ -11,6 +11,7 @@ use Pentiminax\UX\DataTables\Contracts\MercureConfigResolverInterface;
 use Pentiminax\UX\DataTables\Model\AbstractDataTable;
 use Pentiminax\UX\DataTables\Model\DataTable;
 use Pentiminax\UX\DataTables\Rendering\RenderingPreparer;
+use Pentiminax\UX\DataTables\Runtime\DataTableInfrastructure;
 
 #[AsDataTable(entityClass: \stdClass::class, mercure: true)]
 class TestDataTableWithMercureAndManualAjax extends AbstractDataTable
@@ -20,11 +21,9 @@ class TestDataTableWithMercureAndManualAjax extends AbstractDataTable
         private readonly ?MercureConfigResolverInterface $mercureConfigResolver = null,
     ) {
         parent::__construct();
-    }
-
-    protected function createRenderingPreparer(): RenderingPreparer
-    {
-        return new RenderingPreparer($this->apiResourceCollectionUrlResolver, $this->mercureConfigResolver);
+        $this->setDataTableInfrastructure(DataTableInfrastructure::createDefault(
+            renderingPreparer: new RenderingPreparer($this->apiResourceCollectionUrlResolver, $this->mercureConfigResolver)
+        ));
     }
 
     public function configureDataTable(DataTable $table): DataTable

--- a/tests/Fixtures/DataTable/TestDataTableWithMercureAttribute.php
+++ b/tests/Fixtures/DataTable/TestDataTableWithMercureAttribute.php
@@ -11,6 +11,7 @@ use Pentiminax\UX\DataTables\Contracts\MercureConfigResolverInterface;
 use Pentiminax\UX\DataTables\Model\AbstractDataTable;
 use Pentiminax\UX\DataTables\Model\DataTable;
 use Pentiminax\UX\DataTables\Rendering\RenderingPreparer;
+use Pentiminax\UX\DataTables\Runtime\DataTableInfrastructure;
 
 #[AsDataTable(entityClass: \stdClass::class, mercure: true)]
 class TestDataTableWithMercureAttribute extends AbstractDataTable
@@ -20,11 +21,9 @@ class TestDataTableWithMercureAttribute extends AbstractDataTable
         private readonly ?MercureConfigResolverInterface $mercureConfigResolver = null,
     ) {
         parent::__construct();
-    }
-
-    protected function createRenderingPreparer(): RenderingPreparer
-    {
-        return new RenderingPreparer($this->apiResourceCollectionUrlResolver, $this->mercureConfigResolver);
+        $this->setDataTableInfrastructure(DataTableInfrastructure::createDefault(
+            renderingPreparer: new RenderingPreparer($this->apiResourceCollectionUrlResolver, $this->mercureConfigResolver)
+        ));
     }
 
     public function configureColumns(): iterable

--- a/tests/Fixtures/DataTable/TestDataTableWithServerSide.php
+++ b/tests/Fixtures/DataTable/TestDataTableWithServerSide.php
@@ -11,6 +11,7 @@ use Pentiminax\UX\DataTables\Contracts\MercureConfigResolverInterface;
 use Pentiminax\UX\DataTables\Model\AbstractDataTable;
 use Pentiminax\UX\DataTables\Model\DataTable;
 use Pentiminax\UX\DataTables\Rendering\RenderingPreparer;
+use Pentiminax\UX\DataTables\Runtime\DataTableInfrastructure;
 
 #[AsDataTable(entityClass: \stdClass::class, apiPlatform: true)]
 class TestDataTableWithServerSide extends AbstractDataTable
@@ -20,11 +21,9 @@ class TestDataTableWithServerSide extends AbstractDataTable
         private readonly ?MercureConfigResolverInterface $mercureConfigResolver = null,
     ) {
         parent::__construct();
-    }
-
-    protected function createRenderingPreparer(): RenderingPreparer
-    {
-        return new RenderingPreparer($this->apiResourceCollectionUrlResolver, $this->mercureConfigResolver);
+        $this->setDataTableInfrastructure(DataTableInfrastructure::createDefault(
+            renderingPreparer: new RenderingPreparer($this->apiResourceCollectionUrlResolver, $this->mercureConfigResolver)
+        ));
     }
 
     public function configureDataTable(DataTable $table): DataTable

--- a/tests/Fixtures/DataTable/TestDataTableWithoutAttribute.php
+++ b/tests/Fixtures/DataTable/TestDataTableWithoutAttribute.php
@@ -9,6 +9,7 @@ use Pentiminax\UX\DataTables\Contracts\ApiResourceCollectionUrlResolverInterface
 use Pentiminax\UX\DataTables\Contracts\MercureConfigResolverInterface;
 use Pentiminax\UX\DataTables\Model\AbstractDataTable;
 use Pentiminax\UX\DataTables\Rendering\RenderingPreparer;
+use Pentiminax\UX\DataTables\Runtime\DataTableInfrastructure;
 
 class TestDataTableWithoutAttribute extends AbstractDataTable
 {
@@ -17,11 +18,9 @@ class TestDataTableWithoutAttribute extends AbstractDataTable
         private readonly ?MercureConfigResolverInterface $mercureConfigResolver = null,
     ) {
         parent::__construct();
-    }
-
-    protected function createRenderingPreparer(): RenderingPreparer
-    {
-        return new RenderingPreparer($this->apiResourceCollectionUrlResolver, $this->mercureConfigResolver);
+        $this->setDataTableInfrastructure(DataTableInfrastructure::createDefault(
+            renderingPreparer: new RenderingPreparer($this->apiResourceCollectionUrlResolver, $this->mercureConfigResolver)
+        ));
     }
 
     public function configureColumns(): iterable

--- a/tests/Kernel/TwigAppKernel.php
+++ b/tests/Kernel/TwigAppKernel.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pentiminax\UX\DataTables\Tests\Kernel;
 
 use Pentiminax\UX\DataTables\DataTablesBundle;
+use Pentiminax\UX\DataTables\Tests\Fixtures\DataTable\ServerSideTemplateDataTable;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\MercureBundle\MercureBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
@@ -46,6 +47,12 @@ class TwigAppKernel extends Kernel
 
             $container->setAlias('test.datatables.builder', 'datatables.builder')->setPublic(true);
             $container->setAlias('test.datatables.twig_extension', 'datatables.twig_extension')->setPublic(true);
+            $container->setAlias('test.datatables.infrastructure', 'datatables.infrastructure')->setPublic(true);
+
+            $container
+                ->register('test.datatables.server_side_template', ServerSideTemplateDataTable::class)
+                ->setAutoconfigured(true)
+                ->setPublic(true);
         });
     }
 

--- a/tests/Unit/ApiPlatform/AbstractDataTableAutoDetectTest.php
+++ b/tests/Unit/ApiPlatform/AbstractDataTableAutoDetectTest.php
@@ -99,6 +99,6 @@ final class AbstractDataTableAutoDetectTest extends TestCase
             ->with(\stdClass::class, ['product:list'])
             ->willReturn([]);
 
-        new AutoDetectWithGroupsDataTable(columnAutoDetector: $detector);
+        (new AutoDetectWithGroupsDataTable(columnAutoDetector: $detector))->getConfiguredDataTable();
     }
 }

--- a/tests/Unit/Attribute/AsDataTableTest.php
+++ b/tests/Unit/Attribute/AsDataTableTest.php
@@ -10,8 +10,12 @@ use Pentiminax\UX\DataTables\Contracts\ApiResourceCollectionUrlResolverInterface
 use Pentiminax\UX\DataTables\Contracts\MercureConfigResolverInterface;
 use Pentiminax\UX\DataTables\Contracts\MercureHubUrlResolverInterface;
 use Pentiminax\UX\DataTables\DataProvider\ArrayDataProvider;
+use Pentiminax\UX\DataTables\DataProvider\AutoDataProviderFactory;
+use Pentiminax\UX\DataTables\DataProvider\DataProviderResolver;
 use Pentiminax\UX\DataTables\DataProvider\DoctrineDataProvider;
 use Pentiminax\UX\DataTables\Mercure\MercureConfig;
+use Pentiminax\UX\DataTables\Runtime\DataTableInfrastructure;
+use Pentiminax\UX\DataTables\Runtime\DataTableRuntimeFactory;
 use Pentiminax\UX\DataTables\Tests\Fixtures\DataTable\TestDataTableWithAttribute;
 use Pentiminax\UX\DataTables\Tests\Fixtures\DataTable\TestDataTableWithBooleanColumn;
 use Pentiminax\UX\DataTables\Tests\Fixtures\DataTable\TestDataTableWithData;
@@ -66,7 +70,7 @@ final class AsDataTableTest extends TestCase
     {
         $table = new TestDataTableWithAttribute();
         $em    = $this->createMock(EntityManagerInterface::class);
-        $table->setEntityManager($em);
+        $table->setDataTableInfrastructure($this->createInfrastructureWithEntityManager($em));
 
         $provider = $table->getDataProvider();
 
@@ -96,12 +100,21 @@ final class AsDataTableTest extends TestCase
     {
         $table = new TestDataTableWithAttribute();
         $em    = $this->createMock(EntityManagerInterface::class);
-        $table->setEntityManager($em);
+        $table->setDataTableInfrastructure($this->createInfrastructureWithEntityManager($em));
 
         $provider1 = $table->getDataProvider();
         $provider2 = $table->getDataProvider();
 
         $this->assertSame($provider1, $provider2);
+    }
+
+    private function createInfrastructureWithEntityManager(EntityManagerInterface $em): DataTableInfrastructure
+    {
+        return DataTableInfrastructure::createDefault(
+            runtimeFactory: new DataTableRuntimeFactory(
+                dataProviderResolver: new DataProviderResolver(new AutoDataProviderFactory($em))
+            )
+        );
     }
 
     #[Test]

--- a/tests/Unit/Model/AbstractDataTableMapRowTest.php
+++ b/tests/Unit/Model/AbstractDataTableMapRowTest.php
@@ -12,6 +12,7 @@ use Pentiminax\UX\DataTables\Column\UrlColumn;
 use Pentiminax\UX\DataTables\Model\AbstractDataTable;
 use Pentiminax\UX\DataTables\Model\Action;
 use Pentiminax\UX\DataTables\Model\Actions;
+use Pentiminax\UX\DataTables\Runtime\DataTableInfrastructure;
 use Pentiminax\UX\DataTables\Runtime\DataTableRuntimeFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -269,13 +270,11 @@ final class DetailActionMapRowTestTable extends AbstractDataTable
     public function __construct(private readonly array $columnsConfig)
     {
         parent::__construct();
-    }
-
-    protected function createRuntimeFactory(): DataTableRuntimeFactory
-    {
-        return new DataTableRuntimeFactory(
-            actionRowDataResolver: new ActionRowDataResolver(),
-        );
+        $this->setDataTableInfrastructure(DataTableInfrastructure::createDefault(
+            runtimeFactory: new DataTableRuntimeFactory(
+                actionRowDataResolver: new ActionRowDataResolver(),
+            )
+        ));
     }
 
     public function configureColumns(): iterable
@@ -305,13 +304,11 @@ final class TypedDetailActionSetDataTable extends AbstractDataTable
     public function __construct(private readonly array $columnsConfig)
     {
         parent::__construct();
-    }
-
-    protected function createRuntimeFactory(): DataTableRuntimeFactory
-    {
-        return new DataTableRuntimeFactory(
-            actionRowDataResolver: new ActionRowDataResolver(),
-        );
+        $this->setDataTableInfrastructure(DataTableInfrastructure::createDefault(
+            runtimeFactory: new DataTableRuntimeFactory(
+                actionRowDataResolver: new ActionRowDataResolver(),
+            )
+        ));
     }
 
     public function configureColumns(): iterable
@@ -332,13 +329,11 @@ final class ArrayDetailActionSetDataTable extends AbstractDataTable
     public function __construct(private readonly array $columnsConfig)
     {
         parent::__construct();
-    }
-
-    protected function createRuntimeFactory(): DataTableRuntimeFactory
-    {
-        return new DataTableRuntimeFactory(
-            actionRowDataResolver: new ActionRowDataResolver(),
-        );
+        $this->setDataTableInfrastructure(DataTableInfrastructure::createDefault(
+            runtimeFactory: new DataTableRuntimeFactory(
+                actionRowDataResolver: new ActionRowDataResolver(),
+            )
+        ));
     }
 
     public function configureColumns(): iterable
@@ -361,13 +356,11 @@ final class TypedUrlColumnSetDataTable extends AbstractDataTable
         private readonly UrlGeneratorInterface $urlGenerator,
     ) {
         parent::__construct();
-    }
-
-    protected function createRuntimeFactory(): DataTableRuntimeFactory
-    {
-        return new DataTableRuntimeFactory(
-            urlColumnDataResolver: new UrlColumnDataResolver($this->urlGenerator),
-        );
+        $this->setDataTableInfrastructure(DataTableInfrastructure::createDefault(
+            runtimeFactory: new DataTableRuntimeFactory(
+                urlColumnDataResolver: new UrlColumnDataResolver($this->urlGenerator),
+            )
+        ));
     }
 
     public function configureColumns(): iterable

--- a/tests/Unit/Model/AbstractDataTableTemplateColumnTest.php
+++ b/tests/Unit/Model/AbstractDataTableTemplateColumnTest.php
@@ -8,6 +8,7 @@ use Pentiminax\UX\DataTables\Column\Rendering\TemplateColumnRenderer;
 use Pentiminax\UX\DataTables\Column\TemplateColumn;
 use Pentiminax\UX\DataTables\Column\TextColumn;
 use Pentiminax\UX\DataTables\Model\AbstractDataTable;
+use Pentiminax\UX\DataTables\Runtime\DataTableInfrastructure;
 use Pentiminax\UX\DataTables\Runtime\DataTableRuntimeFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -44,13 +45,11 @@ final class TemplatePipelineTable extends AbstractDataTable
     public function __construct(private readonly TemplateColumnRenderer $renderer)
     {
         parent::__construct();
-    }
-
-    protected function createRuntimeFactory(): DataTableRuntimeFactory
-    {
-        return new DataTableRuntimeFactory(
-            templateColumnRenderer: $this->renderer,
-        );
+        $this->setDataTableInfrastructure(DataTableInfrastructure::createDefault(
+            runtimeFactory: new DataTableRuntimeFactory(
+                templateColumnRenderer: $this->renderer,
+            )
+        ));
     }
 
     public function configureColumns(): iterable

--- a/tests/Unit/Runtime/DataTableRuntimeFactoryTest.php
+++ b/tests/Unit/Runtime/DataTableRuntimeFactoryTest.php
@@ -9,6 +9,7 @@ use Pentiminax\UX\DataTables\Attribute\AsDataTable;
 use Pentiminax\UX\DataTables\Contracts\DataProviderInterface;
 use Pentiminax\UX\DataTables\Contracts\RowMapperInterface;
 use Pentiminax\UX\DataTables\DataProvider\AutoDataProviderFactory;
+use Pentiminax\UX\DataTables\DataProvider\DataProviderResolver;
 use Pentiminax\UX\DataTables\DataTableRequest\DataTableRequest;
 use Pentiminax\UX\DataTables\Model\DataTable;
 use Pentiminax\UX\DataTables\Model\DataTableResult;
@@ -136,12 +137,12 @@ final class DataTableRuntimeFactoryTest extends TestCase
     }
 
     #[Test]
-    public function set_entity_manager_enables_auto_provider_resolution(): void
+    public function injected_data_provider_resolver_enables_auto_provider_resolution(): void
     {
         $em      = $this->createMock(EntityManagerInterface::class);
-        $factory = new DataTableRuntimeFactory();
-
-        $factory->setEntityManager($em);
+        $factory = new DataTableRuntimeFactory(
+            dataProviderResolver: new DataProviderResolver(new AutoDataProviderFactory($em))
+        );
 
         $runtime = $factory->createRuntime(
             table: new DataTable('movies'),
@@ -152,8 +153,6 @@ final class DataTableRuntimeFactoryTest extends TestCase
             configureQueryBuilder: static fn ($qb, $req) => $qb,
         );
 
-        // AutoDataProviderFactory::create() returns a DoctrineDataProvider (not null)
-        // only if the em was properly forwarded via setEntityManager()
         $this->assertInstanceOf(DataProviderInterface::class, $runtime->getDataProvider());
     }
 }

--- a/tests/Unit/Twig/DataTablesExtensionTest.php
+++ b/tests/Unit/Twig/DataTablesExtensionTest.php
@@ -14,11 +14,13 @@ use Pentiminax\UX\DataTables\Model\AbstractDataTable;
 use Pentiminax\UX\DataTables\Model\Action;
 use Pentiminax\UX\DataTables\Model\Actions;
 use Pentiminax\UX\DataTables\Model\DataTable;
+use Pentiminax\UX\DataTables\Runtime\DataTableInfrastructure;
 use Pentiminax\UX\DataTables\Tests\Kernel\TwigAppKernel;
 use Pentiminax\UX\DataTables\Twig\DataTablesExtension;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @internal
@@ -309,20 +311,7 @@ final class DataTablesExtensionTest extends TestCase
         $kernel->boot();
         $container = $kernel->getContainer()->get('test.service_container');
 
-        /** @var DataTablesExtension $twigExtension */
-        $twigExtension = $container->get('test.datatables.twig_extension');
-        $reflection    = new \ReflectionClass($twigExtension);
-
-        $templateRendererProperty = $reflection->getProperty('templateColumnRenderer');
-        $templateRendererProperty->setAccessible(true);
-
-        $actionResolverProperty = $reflection->getProperty('actionRowDataResolver');
-        $actionResolverProperty->setAccessible(true);
-
-        $table = new InlinePreparedDataTable(
-            $templateRendererProperty->getValue($twigExtension),
-            $actionResolverProperty->getValue($twigExtension),
-        );
+        $table = new InlinePreparedDataTable($container->get('test.datatables.infrastructure'));
 
         $table->setData([
             new InlineBookEntity(id: 5, status: 'active'),
@@ -379,6 +368,33 @@ final class DataTablesExtensionTest extends TestCase
         }
     }
 
+    #[Test]
+    public function it_renders_template_columns_in_service_managed_server_side_ajax_response(): void
+    {
+        $kernel = new TwigAppKernel('test', true);
+        $kernel->boot();
+        $container = $kernel->getContainer()->get('test.service_container');
+
+        /** @var AbstractDataTable $table */
+        $table = $container->get('test.datatables.server_side_template');
+        $table->handleRequest(Request::create('/datatable/books', 'GET', [
+            'draw'    => 1,
+            'start'   => 0,
+            'length'  => 10,
+            'search'  => ['value' => '', 'regex' => 'false'],
+            'columns' => [
+                ['data' => 'id', 'name' => 'id', 'searchable' => 'true', 'orderable' => 'true'],
+                ['data' => 'status', 'name' => 'status_display', 'searchable' => 'true', 'orderable' => 'true'],
+            ],
+        ]));
+
+        $payload = json_decode($table->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('<span class="badge">7-active</span>', trim($payload['data'][0]['status']));
+
+        $kernel->shutdown();
+    }
+
     private function renderPayload(AbstractDataTable|DataTable $table): array
     {
         $kernel = new TwigAppKernel('test', true);
@@ -433,19 +449,10 @@ final readonly class InlineBookEntity
 
 final class InlinePreparedDataTable extends AbstractDataTable
 {
-    public function __construct(
-        private readonly \Pentiminax\UX\DataTables\Column\Rendering\TemplateColumnRenderer $templateColumnRenderer,
-        private readonly \Pentiminax\UX\DataTables\Column\Rendering\ActionRowDataResolver $actionRowDataResolver,
-    ) {
-        parent::__construct();
-    }
-
-    protected function createRuntimeFactory(): \Pentiminax\UX\DataTables\Runtime\DataTableRuntimeFactory
+    public function __construct(DataTableInfrastructure $infrastructure)
     {
-        return new \Pentiminax\UX\DataTables\Runtime\DataTableRuntimeFactory(
-            templateColumnRenderer: $this->templateColumnRenderer,
-            actionRowDataResolver: $this->actionRowDataResolver,
-        );
+        parent::__construct();
+        $this->setDataTableInfrastructure($infrastructure);
     }
 
     public function configureColumns(): iterable


### PR DESCRIPTION
Move DataTable runtime wiring behind bundle-injected infrastructure so TemplateColumn rendering is available consistently in server-side AJAX responses without per-table setup.

Constraint: Symfony-managed DataTables should require only business configuration when Twig and Doctrine are available.

Rejected: Protected factory hooks on AbstractDataTable | they exposed bundle internals and made service wiring optional by accident.

Confidence: high

Scope-risk: moderate

Directive: Keep runtime/resolver construction inside bundle services; do not reintroduce per-DataTable infrastructure hooks.

Tested: vendor/bin/phpunit; vendor/bin/php-cs-fixer fix --dry-run --diff --sequential

Not-tested: GitHub CI matrix on remote runners

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Removed `setEntityManager()` method from public API across factory and resolver classes
  * AbstractDataTable now requires `setDataTableInfrastructure()` for dependency injection

* **New Features**
  * Introduced `DataTableInfrastructure` class for streamlined dependency management
  * API Platform services now conditionally registered based on availability

* **Improvements**
  * Router dependency is now optional
  * Enhanced error guidance when required dependencies are missing
  * Lazy initialization enables better performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->