### PR TITLE
Support Mercure topics on AsDataTable

### DIFF
--- a/docs/src/content/docs/integrations/mercure.mdx
+++ b/docs/src/content/docs/integrations/mercure.mdx
@@ -7,7 +7,9 @@ description: Real-time DataTables refresh with Mercure SSE
 
 Use Mercure when table data can change outside the current browser session and you want automatic refresh.
 
-`MercureConfig` can now be configured manually through `DataTable::mercure(...)` or auto-resolved from `#[AsDataTable(..., mercure: true)]`.
+`MercureConfig` can be configured manually through `DataTable::mercure(...)`,
+declared on `#[AsDataTable(...)]`, or auto-resolved from
+`#[AsDataTable(..., mercure: true)]`.
 
 ## What The Integration Does
 
@@ -33,6 +35,46 @@ When auto-resolution is enabled:
 - explicit API Platform `mercure.topics` are reused when available
 - otherwise the bundle falls back to an item IRI template (for example `/api/books/{id}`)
 - if no API Platform item metadata is available, it falls back to `/datatables/books/{id}`
+
+## Attribute Topics
+
+Use explicit topics on the attribute when you do not want topic auto-resolution
+from API Platform metadata:
+
+```php
+#[AsDataTable(
+    entityClass: Book::class,
+    mercure: [
+        'topics' => [
+            'https://example.com/books',
+        ],
+    ],
+)]
+final class BookDataTable extends AbstractDataTable
+{
+}
+```
+
+The same form accepts one topic or several topics:
+
+```php
+#[AsDataTable(
+    entityClass: Book::class,
+    mercure: [
+        'topics' => [
+            'https://example.com/books',
+            'https://example.com/authors',
+        ],
+        'withCredentials' => true,
+        'debounceMs' => 300,
+    ],
+)]
+```
+
+Mercure supports multiple subscriptions by repeating the `topic` query
+parameter. For most tables, one topic is enough. Use several topics when a
+single DataTable must refresh after changes published on different resources or
+channels.
 
 ## Advanced Setup
 

--- a/docs/src/content/docs/reference/attributes.mdx
+++ b/docs/src/content/docs/reference/attributes.mdx
@@ -13,6 +13,17 @@ Target: class
 #[AsDataTable(User::class, serializationGroups: ['user:list'], mercure: true, apiPlatform: true)]
 ```
 
+```php
+#[AsDataTable(
+    entityClass: User::class,
+    mercure: [
+        'topics' => [
+            'https://example.com/users',
+        ],
+    ],
+)]
+```
+
 Arguments:
 
 <Table
@@ -27,9 +38,9 @@ Arguments:
     ],
     [
       '`mercure`',
-      '`bool`',
+      '`bool|array`',
       '`false`',
-      'Enable automatic Mercure config resolution for the table',
+      'Enable automatic Mercure config resolution (`true`) or declare explicit Mercure options (`topics`, `withCredentials`, `debounceMs`)',
     ],
     [
       '`apiPlatform`',
@@ -46,6 +57,7 @@ Use this attribute to:
 - opt-in to API Platform-driven column auto-detection (`apiPlatform: true` required)
 - opt-in to automatic API collection URL resolution for Ajax wiring (`apiPlatform: true` required)
 - auto-attach a Mercure config when Mercure is enabled for the table
+- declare explicit Mercure topics with `mercure: ['topics' => [...]]`
 
 ## `#[Column]`
 

--- a/docs/src/content/docs/reference/datatable.mdx
+++ b/docs/src/content/docs/reference/datatable.mdx
@@ -46,7 +46,7 @@ new DataTable(
     ['`serverSide(bool $serverSide = true)`', 'Enable server-side processing mode'],
     ['`apiPlatform(bool $enabled = true)`', 'Enable API Platform adapter behavior'],
     [
-      '`mercure(string $hubUrl, array $topics = [], bool $withCredentials = false, ?int $debounceMs = null)`',
+      '`mercure(array $topics = [], bool $withCredentials = false, ?int $debounceMs = null)`',
       'Enable Mercure live updates with one or many topics',
     ],
   ]}

--- a/src/Attribute/AsDataTable.php
+++ b/src/Attribute/AsDataTable.php
@@ -8,13 +8,14 @@ namespace Pentiminax\UX\DataTables\Attribute;
 final class AsDataTable
 {
     /**
-     * @param string[] $serializationGroups Groups used to filter exposed properties during column auto-detection
-     * @param bool     $apiPlatform         Opt-in to API Platform integration (auto Ajax wiring, URL resolution, column auto-detection)
+     * @param string[]                                                                       $serializationGroups Groups used to filter exposed properties during column auto-detection
+     * @param array{topics?: string|string[], withCredentials?: bool, debounceMs?: int}|bool $mercure             Mercure auto-wiring or explicit Mercure options
+     * @param bool                                                                           $apiPlatform         Opt-in to API Platform integration (auto Ajax wiring, URL resolution, column auto-detection)
      */
     public function __construct(
         public readonly string $entityClass,
         public readonly array $serializationGroups = [],
-        public readonly bool $mercure = false,
+        public readonly bool|array $mercure = false,
         public readonly bool $apiPlatform = false,
         public readonly string $editModalTemplate = '',
         public readonly string $editModalAdapter = '',

--- a/src/Rendering/RenderingPreparer.php
+++ b/src/Rendering/RenderingPreparer.php
@@ -8,6 +8,7 @@ use Pentiminax\UX\DataTables\Attribute\AsDataTable;
 use Pentiminax\UX\DataTables\Contracts\ApiResourceCollectionUrlResolverInterface;
 use Pentiminax\UX\DataTables\Contracts\MercureConfigResolverInterface;
 use Pentiminax\UX\DataTables\Contracts\MercureHubUrlResolverInterface;
+use Pentiminax\UX\DataTables\Mercure\MercureConfig;
 use Pentiminax\UX\DataTables\Model\DataTable;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -74,11 +75,18 @@ final class RenderingPreparer
             return;
         }
 
-        if (null === $asDataTable || !$asDataTable->mercure) {
+        if (null === $asDataTable || false === $asDataTable->mercure) {
             return;
         }
 
         if (null !== $table->getOption('data') && null === $table->getOption('ajax')) {
+            return;
+        }
+
+        $explicitConfig = $this->createExplicitMercureConfig($asDataTable);
+        if (null !== $explicitConfig) {
+            $table->setMercureConfig($explicitConfig);
+
             return;
         }
 
@@ -92,6 +100,33 @@ final class RenderingPreparer
         }
 
         $table->setMercureConfig($mercureConfig);
+    }
+
+    private function createExplicitMercureConfig(AsDataTable $asDataTable): ?MercureConfig
+    {
+        if (!\is_array($asDataTable->mercure)) {
+            return null;
+        }
+
+        $topics = $asDataTable->mercure['topics'] ?? [];
+        if (\is_string($topics)) {
+            $topics = [$topics];
+        }
+
+        if (!\is_array($topics)) {
+            throw new \InvalidArgumentException('AsDataTable mercure topics must be a string or an array of strings.');
+        }
+
+        $debounceMs = $asDataTable->mercure['debounceMs'] ?? null;
+        if (null !== $debounceMs && !\is_int($debounceMs)) {
+            throw new \InvalidArgumentException('AsDataTable mercure debounceMs must be an integer or null.');
+        }
+
+        return (new MercureConfig(
+            topics: $topics,
+            withCredentials: true === ($asDataTable->mercure['withCredentials'] ?? false),
+            debounceMs: $debounceMs,
+        ))->withHubUrl($this->resolveHubUrlOrThrow());
     }
 
     private function resolveHubUrlOrThrow(): string

--- a/tests/Fixtures/DataTable/TestDataTableWithMercureTopicsAttribute.php
+++ b/tests/Fixtures/DataTable/TestDataTableWithMercureTopicsAttribute.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Fixtures\DataTable;
+
+use Pentiminax\UX\DataTables\Attribute\AsDataTable;
+use Pentiminax\UX\DataTables\Column\TextColumn;
+use Pentiminax\UX\DataTables\Contracts\MercureConfigResolverInterface;
+use Pentiminax\UX\DataTables\Contracts\MercureHubUrlResolverInterface;
+use Pentiminax\UX\DataTables\Model\AbstractDataTable;
+use Pentiminax\UX\DataTables\Model\DataTable;
+use Pentiminax\UX\DataTables\Rendering\RenderingPreparer;
+use Pentiminax\UX\DataTables\Runtime\DataTableInfrastructure;
+
+#[AsDataTable(entityClass: \stdClass::class, mercure: [
+    'topics' => [
+        'https://example.com/books',
+    ],
+])]
+class TestDataTableWithMercureTopicsAttribute extends AbstractDataTable
+{
+    public function __construct(
+        private readonly ?MercureConfigResolverInterface $mercureConfigResolver = null,
+        private readonly ?MercureHubUrlResolverInterface $mercureHubUrlResolver = null,
+    ) {
+        parent::__construct();
+        $this->setDataTableInfrastructure(DataTableInfrastructure::createDefault(
+            renderingPreparer: new RenderingPreparer(
+                mercureResolver: $this->mercureConfigResolver,
+                mercureHubUrlResolver: $this->mercureHubUrlResolver,
+            )
+        ));
+    }
+
+    public function configureColumns(): iterable
+    {
+        yield TextColumn::new('id');
+    }
+
+    public function configureDataTable(DataTable $table): DataTable
+    {
+        return $table->ajax('/api/books');
+    }
+}

--- a/tests/Unit/Attribute/AsDataTableTest.php
+++ b/tests/Unit/Attribute/AsDataTableTest.php
@@ -25,6 +25,7 @@ use Pentiminax\UX\DataTables\Tests\Fixtures\DataTable\TestDataTableWithManualOve
 use Pentiminax\UX\DataTables\Tests\Fixtures\DataTable\TestDataTableWithMercureAndData;
 use Pentiminax\UX\DataTables\Tests\Fixtures\DataTable\TestDataTableWithMercureAndManualAjax;
 use Pentiminax\UX\DataTables\Tests\Fixtures\DataTable\TestDataTableWithMercureAttribute;
+use Pentiminax\UX\DataTables\Tests\Fixtures\DataTable\TestDataTableWithMercureTopicsAttribute;
 use Pentiminax\UX\DataTables\Tests\Fixtures\DataTable\TestDataTableWithoutAttribute;
 use Pentiminax\UX\DataTables\Tests\Fixtures\DataTable\TestDataTableWithServerSide;
 use Pentiminax\UX\DataTables\Tests\Fixtures\DataTable\ToggleEntityFixture;
@@ -50,6 +51,22 @@ final class AsDataTableTest extends TestCase
     }
 
     #[Test]
+    public function it_accepts_explicit_mercure_topics(): void
+    {
+        $attribute = new AsDataTable(entityClass: \stdClass::class, mercure: [
+            'topics' => [
+                'https://example.com/books',
+            ],
+        ]);
+
+        $this->assertSame([
+            'topics' => [
+                'https://example.com/books',
+            ],
+        ], $attribute->mercure);
+    }
+
+    #[Test]
     public function it_can_be_applied_to_class(): void
     {
         $reflection = new \ReflectionClass(TestDataTableWithAttribute::class);
@@ -63,6 +80,22 @@ final class AsDataTableTest extends TestCase
         $this->assertFalse($instance->mercure);
         $this->assertSame('', $instance->editModalTemplate);
         $this->assertSame('', $instance->editModalAdapter);
+    }
+
+    #[Test]
+    public function it_can_be_applied_to_class_with_explicit_mercure_topics(): void
+    {
+        $reflection = new \ReflectionClass(TestDataTableWithMercureTopicsAttribute::class);
+        $attributes = $reflection->getAttributes(AsDataTable::class);
+
+        $this->assertCount(1, $attributes);
+
+        $instance = $attributes[0]->newInstance();
+        $this->assertSame([
+            'topics' => [
+                'https://example.com/books',
+            ],
+        ], $instance->mercure);
     }
 
     #[Test]
@@ -276,6 +309,28 @@ final class AsDataTableTest extends TestCase
         $this->assertSame([
             'hubUrl' => 'http://localhost/.well-known/mercure',
             'topics' => ['/api/books/{id}', '/api/authors/{id}'],
+        ], $table->getDataTable()->getOptions()['mercure']);
+    }
+
+    #[Test]
+    public function it_configures_mercure_from_attribute_topics(): void
+    {
+        $resolver = $this->createMock(MercureConfigResolverInterface::class);
+        $resolver->expects($this->never())->method('resolveMercureConfig');
+
+        $hubUrlResolver = $this->createMock(MercureHubUrlResolverInterface::class);
+        $hubUrlResolver->method('resolveHubUrl')->willReturn('/.well-known/mercure');
+
+        $table = new TestDataTableWithMercureTopicsAttribute(
+            mercureConfigResolver: $resolver,
+            mercureHubUrlResolver: $hubUrlResolver,
+        );
+
+        $table->prepareForRendering();
+
+        $this->assertSame([
+            'hubUrl' => '/.well-known/mercure',
+            'topics' => ['https://example.com/books'],
         ], $table->getDataTable()->getOptions()['mercure']);
     }
 

--- a/tests/Unit/Rendering/RenderingPreparerTest.php
+++ b/tests/Unit/Rendering/RenderingPreparerTest.php
@@ -167,6 +167,35 @@ final class RenderingPreparerTest extends TestCase
     }
 
     #[Test]
+    public function it_configures_explicit_mercure_topics_from_attribute(): void
+    {
+        $mercureResolver = $this->createMock(MercureConfigResolverInterface::class);
+        $mercureResolver->expects($this->never())->method('resolveMercureConfig');
+
+        $hubUrlResolver = $this->createMock(MercureHubUrlResolverInterface::class);
+        $hubUrlResolver->method('resolveHubUrl')->willReturn('/.well-known/mercure');
+
+        $preparer = new RenderingPreparer(
+            mercureResolver: $mercureResolver,
+            mercureHubUrlResolver: $hubUrlResolver,
+        );
+        $table = (new DataTable('Test'))->ajax('/api/books');
+
+        $preparer->prepare($table, new AsDataTable(entityClass: \stdClass::class, mercure: [
+            'topics'          => ['https://example.com/books'],
+            'withCredentials' => true,
+            'debounceMs'      => 250,
+        ]));
+
+        $this->assertSame([
+            'hubUrl'          => '/.well-known/mercure',
+            'topics'          => ['https://example.com/books'],
+            'withCredentials' => true,
+            'debounceMs'      => 250,
+        ], $table->getOptions()['mercure']);
+    }
+
+    #[Test]
     public function it_skips_mercure_when_attribute_mercure_is_false(): void
     {
         $mercureResolver = $this->createMock(MercureConfigResolverInterface::class);


### PR DESCRIPTION
## What changed

- Allows `#[AsDataTable(..., mercure: ['topics' => [...]])]` alongside the existing `mercure: true` auto-resolution path.
- Converts explicit attribute Mercure options into `MercureConfig` during rendering.
- Documents attribute-level topics, multi-topic usage, and the corrected `DataTable::mercure()` signature.

## Why

`AsDataTable` only accepted a boolean Mercure flag, so users could not declare explicit Mercure topics at the attribute level without falling back to fluent table configuration or API Platform metadata.

## Validation

- `vendor/bin/phpunit`
- `npm run build` in `docs/`

## Notes

Mercure supports one or many topics. A single topic is enough for most tables; multiple topics are useful when one DataTable must refresh after changes from several resources or channels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Mercure configuration: declare explicit topics, credentials, and debounce settings directly in the attribute alongside automatic configuration support.

* **Documentation**
  * Updated Mercure integration guide, attribute reference, and DataTable API documentation to reflect the new configuration options and methods.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pentiminax/ux-datatables/pull/206)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->