### PR TITLE
Add JS/TS tests and typecheck to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,12 +7,12 @@ on:
       - main
 
 jobs:
-  run:
+  php:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         php: ['8.3', '8.4', '8.5']
-    name: PHP ${{ matrix.php }} ${{ matrix.description }}
+    name: PHP ${{ matrix.php }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -38,3 +38,32 @@ jobs:
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  js:
+    runs-on: ubuntu-latest
+    name: JS / TypeScript
+    defaults:
+      run:
+        working-directory: assets
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: assets/package.json
+
+      - name: Install dependencies
+        run: npm install --no-progress
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Run tests
+        run: npm test

--- a/assets/src/controller.ts
+++ b/assets/src/controller.ts
@@ -131,9 +131,9 @@ export default class extends Controller {
 
         if (snap.search !== undefined) this.table.search(snap.search as string)
         if (snap.order !== undefined) this.table.order(snap.order as any)
-        if (snap.pageLength !== undefined) ;(this.table.page as any).len(snap.pageLength)
+        if (snap.pageLength !== undefined) this.table.page.len(snap.pageLength)
         if (snap.start !== undefined) {
-            const pageLen = (this.table.page as any).len() as number
+            const pageLen = this.table.page.len() as number
             this.table.page(Math.floor(snap.start / (pageLen || 10)))
         }
 
@@ -399,4 +399,9 @@ type DataTableWithAjax = DataTable<any> & {
     ajax?: {
         reload: (callback?: null, resetPaging?: boolean) => void
     }
+    on: (event: string, callback: (...args: any[]) => void) => DataTableWithAjax
+    search: (input: string) => DataTableWithAjax
+    order: (order: any) => DataTableWithAjax
+    page: ((page?: number) => DataTableWithAjax) & { len: (len?: number) => number }
+    draw: (resetPaging?: boolean | string) => DataTableWithAjax
 }

--- a/assets/src/functions/urlState.ts
+++ b/assets/src/functions/urlState.ts
@@ -47,7 +47,7 @@ function clearOrderParams(params: URLSearchParams, base: string): void {
     params.forEach((_, key) => {
         if (key.startsWith(`${base}[`)) toDelete.push(key)
     })
-    toDelete.forEach((key) => params.delete(key))
+    for (const key of toDelete) params.delete(key)
 }
 
 function resolveColumnName(table: any, idx: number): string {

--- a/assets/vitest.config.ts
+++ b/assets/vitest.config.ts
@@ -1,0 +1,6 @@
+export default {
+    test: {
+        environment: 'jsdom',
+        include: ['test/**/*.test.ts', 'src/**/__tests__/**/*.test.ts'],
+    },
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,0 @@
-export default {
-    test: {
-        environment: 'jsdom',
-        include: ['assets/test/**/*.test.ts', 'assets/src/**/__tests__/**/*.test.ts'],
-    },
-}


### PR DESCRIPTION
- Move vitest.config.ts from repo root into assets/ so it's colocated with package.json; update include paths accordingly
- Add js job to ci.yaml: Node 22, npm install, typecheck, lint, vitest
- Fix pre-existing type errors in DataTableWithAjax (missing on/search/order/page/draw methods)
- Fix pre-existing lint error in urlState.ts (forEach callback returning a value)
- Fix pre-existing syntax bug in controller.ts (stray semicolon creating empty if body)

https://claude.ai/code/session_017T8bFZ47T4GPYAapnB7Koa