### PR TITLE
feat(datatable): add Ajax data-loading support with auto-configuration

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Pentiminax\UX\DataTables\Builder\DataTableBuilder;
+use Pentiminax\UX\DataTables\Ajax\AjaxDataTableTokenManager;
 use Pentiminax\UX\DataTables\Column\AttributeColumnReader;
 use Pentiminax\UX\DataTables\Column\ColumnResolver;
 use Pentiminax\UX\DataTables\Column\PropertyNameHumanizer;
@@ -12,6 +13,7 @@ use Pentiminax\UX\DataTables\Column\Rendering\TemplateColumnRenderer;
 use Pentiminax\UX\DataTables\Column\Rendering\UrlColumnDataResolver;
 use Pentiminax\UX\DataTables\Contracts\ColumnAutoDetectorInterface;
 use Pentiminax\UX\DataTables\Contracts\DataTableBuilderInterface;
+use Pentiminax\UX\DataTables\Controller\AjaxDataController;
 use Pentiminax\UX\DataTables\Controller\AjaxDeleteController;
 use Pentiminax\UX\DataTables\Controller\AjaxEditController;
 use Pentiminax\UX\DataTables\DataProvider\AutoDataProviderFactory;
@@ -30,7 +32,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
-
 return static function (ContainerConfigurator $container): void {
     $services = $container->services();
 
@@ -48,6 +49,10 @@ return static function (ContainerConfigurator $container): void {
         ->private();
 
     $services->alias(PermissionChecker::class, 'datatables.security.permission_checker')
+        ->private();
+
+    $services->set('datatables.ajax.token_manager', AjaxDataTableTokenManager::class)
+        ->arg(0, param('kernel.secret'))
         ->private();
 
     $services->set('datatables.column.template_column_renderer', TemplateColumnRenderer::class)
@@ -81,6 +86,11 @@ return static function (ContainerConfigurator $container): void {
 
     $services->set('datatables.controller.ajax_delete', AjaxDeleteController::class)
         ->arg(0, service('doctrine')->nullOnInvalid())
+        ->tag('controller.service_arguments')
+        ->public();
+
+    $services->set('datatables.controller.ajax_data', AjaxDataController::class)
+        ->arg(0, service('datatables.ajax.registry'))
         ->tag('controller.service_arguments')
         ->public();
 
@@ -123,6 +133,8 @@ return static function (ContainerConfigurator $container): void {
         ->arg(1, service(MercureConfigResolverInterface::class)->nullOnInvalid())
         ->arg(2, service(TranslatorInterface::class)->nullOnInvalid())
         ->arg(3, service(MercureHubUrlResolverInterface::class)->nullOnInvalid())
+        ->arg(4, service('router')->nullOnInvalid())
+        ->arg(5, service('datatables.ajax.registry'))
         ->private();
 
     $services->alias(RenderingPreparer::class, 'datatables.rendering.preparer')

--- a/docs/src/content/docs/guide/server-side-processing.mdx
+++ b/docs/src/content/docs/guide/server-side-processing.mdx
@@ -9,6 +9,38 @@ Move filtering, ordering, and paging to the backend for large datasets.
 
 ## Minimal Setup
 
+When a reusable `AbstractDataTable` enables server-side processing and does not define its own
+Ajax source, UX DataTables wires the bundle Ajax endpoint automatically:
+
+```php
+use Pentiminax\UX\DataTables\Model\DataTable;
+
+protected function configureDataTable(DataTable $table): DataTable
+{
+    return $table
+        ->serverSide()
+        ->processing();
+}
+```
+
+The rendered table will call the built-in `ux_datatables_ajax_data` route. The request includes an
+opaque table token, not the PHP class name, and the bundle resolves the matching tagged
+`AbstractDataTable` service before calling `handleRequest()` internally.
+
+Make sure the bundle routes are imported once in your app:
+
+```php
+// config/routes/ux_datatables.php
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+return static function (RoutingConfigurator $routes): void {
+    $routes->import('@DataTablesBundle/config/routes.php');
+};
+```
+
+Use an explicit `ajax()` URL when the endpoint is not an `AbstractDataTable` service, when you want a
+custom route, or when you are using a plain `DataTable` instance:
+
 ```php
 use Pentiminax\UX\DataTables\Model\DataTable;
 
@@ -25,8 +57,10 @@ With the current bundle defaults, `ajax()` configures a `GET` request. DataTable
 server-side parameters such as `draw`, `start`, `length`, `search`, and `order` to that URL,
 and `DataTableRequest::fromRequest()` reads them from the query string.
 
-At controller level, do not rely on `$request->isXmlHttpRequest()` to detect a DataTables
-request. The supported flow is:
+With automatic Ajax wiring, the page controller only renders the table. Manual request handling is
+still useful when your table posts back to the same route or when you configured a custom Ajax URL.
+In that case, do not rely on `$request->isXmlHttpRequest()` to detect a DataTables request. The
+supported flow is:
 
 1. Call `handleRequest($request)`
 2. Check `isRequestHandled()`
@@ -63,7 +97,23 @@ Use this DTO when you need direct access to paging, ordering, or search values. 
 `AbstractDataTable` in a controller, the usual entry point is still `handleRequest()` followed by
 `isRequestHandled()`.
 
-## Typical Controller With AbstractDataTable
+## Typical Controller With Automatic Ajax
+
+```php
+use App\DataTables\ProductsDataTable;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/products', name: 'app_products')]
+public function index(ProductsDataTable $table): Response
+{
+    return $this->render('product/index.html.twig', [
+        'table' => $table
+    ]);
+}
+```
+
+## Manual Same-Route Handling
 
 ```php
 use App\DataTables\ProductsDataTable;
@@ -74,6 +124,7 @@ use Symfony\Component\Routing\Attribute\Route;
 #[Route('/products', name: 'app_products')]
 public function index(ProductsDataTable $table, Request $request): Response
 {
+    // Needed only when the table Ajax URL points to this route.
     $table->handleRequest($request);
 
     if ($table->isRequestHandled()) {
@@ -89,6 +140,7 @@ public function index(ProductsDataTable $table, Request $request): Response
 ## Best Practices
 
 - Use `isRequestHandled()` instead of `$request->isXmlHttpRequest()`.
+- Let `AbstractDataTable` auto-wire Ajax when the default bundle route is enough.
 - Always whitelist sortable/searchable fields in your query layer.
 - Keep backend response time predictable (indexes, query limits).
 - Prefer `AbstractDataTable` for reusable query behavior.

--- a/docs/src/content/docs/reference/abstract-datatable.mdx
+++ b/docs/src/content/docs/reference/abstract-datatable.mdx
@@ -103,18 +103,45 @@ final class UsersDataTable extends AbstractDataTable
 
 ## Using in a Controller
 
+For server-side tables without a custom Ajax URL, the page controller only needs to render the table.
+UX DataTables adds the bundle Ajax endpoint during rendering and handles DataTables requests through
+that endpoint. The generated Ajax request uses an opaque table token so the PHP DataTable class name
+is not exposed in the browser URL or payload:
+
+```php
+use App\DataTables\UsersDataTable;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class UsersController extends AbstractController
+{
+    #[Route('/users', name: 'app_users')]
+    public function index(UsersDataTable $table): Response
+    {
+        return $this->render('users/index.html.twig', [
+            'table' => $table,
+        ]);
+    }
+}
+```
+
+When you configure the table to use the same route as its Ajax endpoint, handle the request manually:
+
 ```php
 use App\DataTables\UsersDataTable;
 use Pentiminax\UX\DataTables\DataTableRequest\DataTableRequest;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
 
 class UsersController extends AbstractController
 {
     #[Route('/users', name: 'app_users')]
     public function index(UsersDataTable $table, Request $request): Response
     {
-        // Handle Ajax requests for server-side processing
+        // Needed only when this controller is also the configured Ajax endpoint.
         $table->handleRequest($request);
 
         if ($table->isRequestHandled()) {
@@ -191,7 +218,6 @@ final class UsersDataTable extends AbstractDataTable
     public function configureDataTable(DataTable $table): DataTable
     {
         return $table
-            ->ajax(url: '/users')
             ->pageLength(25)
             ->ordering(handler: true, indicators: true)
             ->searching()
@@ -205,6 +231,8 @@ final class UsersDataTable extends AbstractDataTable
     }
 }
 ```
+
+Add `->ajax(url: '/users')` only when you want to override the automatic bundle endpoint.
 
 ### Extensions
 

--- a/docs/src/content/docs/reference/datatable.mdx
+++ b/docs/src/content/docs/reference/datatable.mdx
@@ -42,6 +42,10 @@ new DataTable(
       "`ajax(string $url, ?string $dataSrc = null, string $type = 'GET')`",
       'Configure Ajax endpoint and request mode',
     ],
+    [
+      "`ajaxRequestData(string $url, array $data, string $type = 'POST')`",
+      'Configure Ajax endpoint with extra request data sent on every call',
+    ],
     ['`data(array $data)`', 'Provide inline client-side data'],
     ['`serverSide(bool $serverSide = true)`', 'Enable server-side processing mode'],
     ['`apiPlatform(bool $enabled = true)`', 'Enable API Platform adapter behavior'],

--- a/src/Ajax/AjaxDataTableRegistry.php
+++ b/src/Ajax/AjaxDataTableRegistry.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Ajax;
+
+use Pentiminax\UX\DataTables\Model\AbstractDataTable;
+use Psr\Container\ContainerInterface;
+
+final class AjaxDataTableRegistry
+{
+    /**
+     * @param array<class-string<AbstractDataTable>, string> $serviceIdsByClass
+     */
+    public function __construct(
+        private readonly ContainerInterface $locator,
+        private readonly AjaxDataTableTokenManager $tokenManager,
+        private readonly array $serviceIdsByClass,
+    ) {
+    }
+
+    public function getToken(string $dataTableClass): ?string
+    {
+        $dataTableClass = ltrim($dataTableClass, '\\');
+
+        if (!isset($this->serviceIdsByClass[$dataTableClass])) {
+            return null;
+        }
+
+        return $this->tokenManager->generateHmacSignature($dataTableClass);
+    }
+
+    public function get(string $token): ?AbstractDataTable
+    {
+        foreach ($this->serviceIdsByClass as $dataTableClass => $serviceId) {
+            $generatedSignature = $this->tokenManager->generateHmacSignature($dataTableClass);
+            if (!$this->validateSignature($generatedSignature, $token)) {
+                continue;
+            }
+
+            $table = $this->locator->get($serviceId);
+
+            if (!$table instanceof AbstractDataTable) {
+                throw new \LogicException(\sprintf('Service "%s" must be an instance of "%s".', $serviceId, AbstractDataTable::class));
+            }
+
+            return $table;
+        }
+
+        return null;
+    }
+
+    private function validateSignature($generatedSignature, string $token): bool
+    {
+        return hash_equals($generatedSignature, $token);
+    }
+}

--- a/src/Ajax/AjaxDataTableTokenManager.php
+++ b/src/Ajax/AjaxDataTableTokenManager.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Ajax;
+
+final class AjaxDataTableTokenManager
+{
+    public function __construct(
+        #[\SensitiveParameter]
+        private readonly string $secret,
+    ) {
+        if ('' === $this->secret) {
+            throw new \InvalidArgumentException('A non-empty secret is required to generate DataTable Ajax tokens.');
+        }
+    }
+
+    public function generateHmacSignature(string $dataTableClass): string
+    {
+        $signature = base64_encode(hash_hmac('sha256', $dataTableClass, $this->secret));
+
+        return strtr($signature, [
+            '+' => '',
+            '=' => '',
+        ]);
+    }
+}

--- a/src/Controller/AjaxDataController.php
+++ b/src/Controller/AjaxDataController.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Controller;
+
+use Pentiminax\UX\DataTables\Ajax\AjaxDataTableRegistry;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+final class AjaxDataController
+{
+    public function __construct(
+        private readonly AjaxDataTableRegistry $registry,
+    ) {
+    }
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        $token = $request->query->get('table');
+
+        if (!\is_string($token) || '' === $token) {
+            throw new NotFoundHttpException('DataTable not found.');
+        }
+
+        $table = $this->registry->get($token);
+
+        if (null === $table) {
+            throw new NotFoundHttpException('DataTable not found.');
+        }
+
+        $table->handleRequest($request);
+
+        if (!$table->isRequestHandled()) {
+            throw new BadRequestHttpException('Invalid DataTables request.');
+        }
+
+        return $table->getResponse();
+    }
+}

--- a/src/DataTablesBundle.php
+++ b/src/DataTablesBundle.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pentiminax\UX\DataTables;
 
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use Pentiminax\UX\DataTables\DependencyInjection\Compiler\DataTableRegistryPass;
 use Pentiminax\UX\DataTables\Model\AbstractDataTable;
 use Symfony\Bundle\MakerBundle\Maker\AbstractMaker;
 use Symfony\Component\AssetMapper\AssetMapperInterface;
@@ -18,6 +19,13 @@ use Symfony\Component\Mercure\HubInterface;
 
 class DataTablesBundle extends AbstractBundle
 {
+    public function build(ContainerBuilder $container): void
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new DataTableRegistryPass());
+    }
+
     public function configure(DefinitionConfigurator $definition): void
     {
         $definition->rootNode()

--- a/src/DependencyInjection/Compiler/DataTableRegistryPass.php
+++ b/src/DependencyInjection/Compiler/DataTableRegistryPass.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\DependencyInjection\Compiler;
+
+use Pentiminax\UX\DataTables\Ajax\AjaxDataTableRegistry;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+
+final class DataTableRegistryPass implements CompilerPassInterface
+{
+    public const REGISTRY_ID = 'datatables.ajax.registry';
+
+    public const TAG = 'datatables.data_table';
+
+    private const LOCATOR_ID = 'datatables.ajax.registry.locator';
+
+    public function process(ContainerBuilder $container): void
+    {
+        $references        = [];
+        $serviceIdsByClass = [];
+
+        foreach ($container->findTaggedServiceIds(self::TAG) as $id => $tags) {
+            $definition = $container->getDefinition($id);
+            $class      = ltrim($definition->getClass() ?? $id, '\\');
+
+            $references[$id]           = new Reference($id);
+            $serviceIdsByClass[$class] = $id;
+        }
+
+        $locator = (new Definition(ServiceLocator::class))
+            ->setArguments([$references])
+            ->addTag('container.service_locator');
+
+        $container->setDefinition(self::LOCATOR_ID, $locator);
+
+        $container->setDefinition(self::REGISTRY_ID, (new Definition(AjaxDataTableRegistry::class))
+            ->setArguments([
+                new Reference(self::LOCATOR_ID),
+                new Reference('datatables.ajax.token_manager'),
+                $serviceIdsByClass,
+            ]));
+    }
+}

--- a/src/Model/AbstractDataTable.php
+++ b/src/Model/AbstractDataTable.php
@@ -74,6 +74,8 @@ abstract class AbstractDataTable
             new DataTable($this->getClassName())
         );
 
+        $this->table->setDataTableClass(static::class);
+
         $this->columns = iterator_to_array($this->configureColumns());
 
         $columnResolver = $this->infrastructure()->columnResolver();

--- a/src/Model/DataTable.php
+++ b/src/Model/DataTable.php
@@ -31,6 +31,8 @@ class DataTable
 
     private ?string $editModalAdapter = null;
 
+    private ?string $dataTableClass = null;
+
     public function __construct(
         private readonly string $id,
         array $options = [],
@@ -408,6 +410,22 @@ class DataTable
     }
 
     /**
+     * Load data via Ajax with extra request data merged into every call.
+     *
+     * @param array<string, mixed> $data
+     */
+    public function ajaxRequestData(string $url, array $data, string $type = 'GET'): static
+    {
+        $this->options->set('ajax', [
+            'type' => $type,
+            'url'  => $url,
+            'data' => $data,
+        ]);
+
+        return $this;
+    }
+
+    /**
      * Data to use as the display data for the table.
      */
     public function data(array $data): static
@@ -556,6 +574,18 @@ class DataTable
     public function isServerSide(): bool
     {
         return $this->options->get('serverSide') ?? false;
+    }
+
+    public function setDataTableClass(string $fqcn): static
+    {
+        $this->dataTableClass = $fqcn;
+
+        return $this;
+    }
+
+    public function getDataTableClass(): ?string
+    {
+        return $this->dataTableClass;
     }
 
     private function addButtonsToLayout(array &$options): void

--- a/src/Rendering/RenderingPreparer.php
+++ b/src/Rendering/RenderingPreparer.php
@@ -4,21 +4,27 @@ declare(strict_types=1);
 
 namespace Pentiminax\UX\DataTables\Rendering;
 
+use Pentiminax\UX\DataTables\Ajax\AjaxDataTableRegistry;
 use Pentiminax\UX\DataTables\ApiPlatform\ApiResourceCollectionUrlResolverInterface;
 use Pentiminax\UX\DataTables\Attribute\AsDataTable;
 use Pentiminax\UX\DataTables\Mercure\MercureConfig;
 use Pentiminax\UX\DataTables\Mercure\MercureConfigResolverInterface;
 use Pentiminax\UX\DataTables\Mercure\MercureHubUrlResolverInterface;
 use Pentiminax\UX\DataTables\Model\DataTable;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class RenderingPreparer
 {
+    public const AJAX_DATA_ROUTE = 'ux_datatables_ajax_data';
+
     public function __construct(
         private readonly ?ApiResourceCollectionUrlResolverInterface $urlResolver = null,
         private readonly ?MercureConfigResolverInterface $mercureResolver = null,
         private readonly ?TranslatorInterface $translator = null,
         private readonly ?MercureHubUrlResolverInterface $mercureHubUrlResolver = null,
+        private readonly ?UrlGeneratorInterface $urlGenerator = null,
+        private readonly ?AjaxDataTableRegistry $ajaxRegistry = null,
     ) {
     }
 
@@ -31,6 +37,7 @@ final class RenderingPreparer
     public function prepareBeforeDataHydration(DataTable $table, ?AsDataTable $asDataTable): void
     {
         $this->configureApiPlatform($table, $asDataTable);
+        $this->configureAutoAjax($table);
         $this->configureEditModal($table, $asDataTable);
         $this->translateColumnTitles($table);
     }
@@ -61,6 +68,41 @@ final class RenderingPreparer
             && null !== $this->urlResolver
             && null !== $asDataTable
             && ($asDataTable->apiPlatform || $table->getOption('apiPlatform'));
+    }
+
+    private function configureAutoAjax(DataTable $table): void
+    {
+        if (!$this->canAutoWireAjax($table)) {
+            return;
+        }
+
+        $fqcn = $table->getDataTableClass();
+        if (null === $fqcn) {
+            return;
+        }
+
+        $token = $this->ajaxRegistry?->getToken($fqcn);
+        if (null === $token) {
+            return;
+        }
+
+        $url = $this->urlGenerator->generate(self::AJAX_DATA_ROUTE);
+
+        $table->ajaxRequestData(
+            url: $url,
+            data: ['table' => $token],
+            type: 'GET',
+        );
+    }
+
+    private function canAutoWireAjax(DataTable $table): bool
+    {
+        return $table->isServerSide()
+            && null === $table->getOption('ajax')
+            && null === $table->getOption('data')
+            && true !== $table->getOption('apiPlatform')
+            && null !== $this->urlGenerator
+            && null !== $this->ajaxRegistry;
     }
 
     private function configureMercure(DataTable $table, ?AsDataTable $asDataTable): void

--- a/src/Routing/RouteLoader.php
+++ b/src/Routing/RouteLoader.php
@@ -14,6 +14,12 @@ final class RouteLoader implements RouteLoaderInterface
     {
         $routes = new RouteCollection();
 
+        $routes->add('ux_datatables_ajax_data', new Route(
+            path: '/datatables/ajax/data',
+            defaults: ['_controller' => 'datatables.controller.ajax_data'],
+            methods: ['GET'],
+        ));
+
         $routes->add('ux_datatables_ajax_edit', new Route(
             path: '/datatables/ajax/edit',
             defaults: ['_controller' => 'datatables.controller.ajax_edit'],

--- a/tests/Fixtures/DataTable/AutoAjaxServerSideDataTable.php
+++ b/tests/Fixtures/DataTable/AutoAjaxServerSideDataTable.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Fixtures\DataTable;
+
+use Pentiminax\UX\DataTables\Column\TextColumn;
+use Pentiminax\UX\DataTables\Contracts\DataProviderInterface;
+use Pentiminax\UX\DataTables\DataProvider\ArrayDataProvider;
+use Pentiminax\UX\DataTables\Model\AbstractDataTable;
+use Pentiminax\UX\DataTables\Model\DataTable;
+
+final class AutoAjaxServerSideDataTable extends AbstractDataTable
+{
+    public function configureDataTable(DataTable $table): DataTable
+    {
+        return $table->serverSide();
+    }
+
+    public function configureColumns(): iterable
+    {
+        yield TextColumn::new('id');
+        yield TextColumn::new('title');
+    }
+
+    protected function createDataProvider(): ?DataProviderInterface
+    {
+        return new ArrayDataProvider([
+            new AutoAjaxServerSideRow(id: 11, title: 'Generated endpoint'),
+        ], $this->createRowMapper());
+    }
+}
+
+final readonly class AutoAjaxServerSideRow
+{
+    public function __construct(
+        private int $id,
+        private string $title,
+    ) {
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+}

--- a/tests/Kernel/TwigAppKernel.php
+++ b/tests/Kernel/TwigAppKernel.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pentiminax\UX\DataTables\Tests\Kernel;
 
 use Pentiminax\UX\DataTables\DataTablesBundle;
+use Pentiminax\UX\DataTables\Tests\Fixtures\DataTable\AutoAjaxServerSideDataTable;
 use Pentiminax\UX\DataTables\Tests\Fixtures\DataTable\ServerSideTemplateDataTable;
 use Pentiminax\UX\DataTables\Tests\Fixtures\Security\TestAuthorizationChecker;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
@@ -56,6 +57,11 @@ class TwigAppKernel extends Kernel
 
             $container
                 ->register('test.datatables.server_side_template', ServerSideTemplateDataTable::class)
+                ->setAutoconfigured(true)
+                ->setPublic(true);
+
+            $container
+                ->register('test.datatables.auto_ajax_server_side', AutoAjaxServerSideDataTable::class)
                 ->setAutoconfigured(true)
                 ->setPublic(true);
         });

--- a/tests/Unit/Ajax/AjaxDataTableRegistryTest.php
+++ b/tests/Unit/Ajax/AjaxDataTableRegistryTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Unit\Ajax;
+
+use Pentiminax\UX\DataTables\Ajax\AjaxDataTableRegistry;
+use Pentiminax\UX\DataTables\Ajax\AjaxDataTableTokenManager;
+use Pentiminax\UX\DataTables\Model\AbstractDataTable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+/**
+ * @internal
+ */
+#[CoversClass(AjaxDataTableRegistry::class)]
+#[CoversClass(AjaxDataTableTokenManager::class)]
+final class AjaxDataTableRegistryTest extends TestCase
+{
+    #[Test]
+    public function it_resolves_registered_tables_by_token(): void
+    {
+        $table = $this->createMock(AbstractDataTable::class);
+
+        $registry = $this->createRegistry(['custom.service_id' => $table], [
+            'App\\DataTable\\UserDataTable' => 'custom.service_id',
+        ]);
+
+        $token = $registry->getToken('App\\DataTable\\UserDataTable');
+
+        $this->assertIsString($token);
+        $this->assertSame($table, $registry->get($token));
+    }
+
+    #[Test]
+    public function it_returns_null_for_unknown_tables_and_tokens(): void
+    {
+        $registry = $this->createRegistry([], []);
+
+        $this->assertNull($registry->getToken('App\\DataTable\\UnknownDataTable'));
+        $this->assertNull($registry->get('unknown-token'));
+    }
+
+    private function createRegistry(array $services, array $serviceIdsByClass): AjaxDataTableRegistry
+    {
+        return new AjaxDataTableRegistry(
+            new class($services) implements ContainerInterface {
+                public function __construct(private readonly array $services)
+                {
+                }
+
+                public function get(string $id): mixed
+                {
+                    return $this->services[$id];
+                }
+
+                public function has(string $id): bool
+                {
+                    return isset($this->services[$id]);
+                }
+            },
+            new AjaxDataTableTokenManager('test-secret'),
+            $serviceIdsByClass,
+        );
+    }
+}

--- a/tests/Unit/Ajax/AjaxDataTableTokenManagerTest.php
+++ b/tests/Unit/Ajax/AjaxDataTableTokenManagerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Unit\Ajax;
+
+use Pentiminax\UX\DataTables\Ajax\AjaxDataTableTokenManager;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+#[CoversClass(AjaxDataTableTokenManager::class)]
+final class AjaxDataTableTokenManagerTest extends TestCase
+{
+    #[Test]
+    public function it_generates_deterministic_opaque_tokens(): void
+    {
+        $manager = new AjaxDataTableTokenManager('test-secret');
+
+        $token = $manager->generateHmacSignature('App\\DataTable\\UserDataTable');
+
+        $this->assertSame($token, $manager->generateHmacSignature('App\\DataTable\\UserDataTable'));
+        $this->assertNotSame($token, $manager->generateHmacSignature('App\\DataTable\\AdminDataTable'));
+        $this->assertStringNotContainsString('UserDataTable', $token);
+        $this->assertStringNotContainsString('App', $token);
+    }
+
+    #[Test]
+    public function it_rejects_empty_secrets(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new AjaxDataTableTokenManager('');
+    }
+}

--- a/tests/Unit/Controller/AjaxDataControllerTest.php
+++ b/tests/Unit/Controller/AjaxDataControllerTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Unit\Controller;
+
+use Pentiminax\UX\DataTables\Ajax\AjaxDataTableRegistry;
+use Pentiminax\UX\DataTables\Ajax\AjaxDataTableTokenManager;
+use Pentiminax\UX\DataTables\Controller\AjaxDataController;
+use Pentiminax\UX\DataTables\Model\AbstractDataTable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * @internal
+ */
+#[CoversClass(AjaxDataController::class)]
+final class AjaxDataControllerTest extends TestCase
+{
+    #[Test]
+    public function it_throws_404_when_table_field_is_missing(): void
+    {
+        $controller = new AjaxDataController($this->createRegistry());
+        $request    = new Request();
+
+        $this->expectException(NotFoundHttpException::class);
+
+        $controller($request);
+    }
+
+    #[Test]
+    public function it_throws_404_when_table_token_is_unknown(): void
+    {
+        $controller = new AjaxDataController($this->createRegistry());
+        $request    = new Request(query: ['table' => 'unknown-token']);
+
+        $this->expectException(NotFoundHttpException::class);
+
+        $controller($request);
+    }
+
+    #[Test]
+    public function it_dispatches_to_resolved_data_table(): void
+    {
+        $expectedResponse = new JsonResponse(['draw' => 1, 'data' => []]);
+
+        $dataTable = $this->createMock(AbstractDataTable::class);
+        $dataTable->expects($this->once())->method('handleRequest');
+        $dataTable->expects($this->once())->method('isRequestHandled')->willReturn(true);
+        $dataTable->expects($this->once())->method('getResponse')->willReturn($expectedResponse);
+
+        $registry = $this->createRegistry($dataTable);
+        $token    = $registry->getToken('App\\UserDataTable');
+
+        $controller = new AjaxDataController($registry);
+        $response   = $controller(new Request(query: ['table' => $token, 'draw' => 1]));
+
+        $this->assertSame($expectedResponse, $response);
+    }
+
+    #[Test]
+    public function it_throws_400_when_request_is_not_a_datatables_payload(): void
+    {
+        $dataTable = $this->createMock(AbstractDataTable::class);
+        $dataTable->expects($this->once())->method('handleRequest');
+        $dataTable->expects($this->once())->method('isRequestHandled')->willReturn(false);
+        $dataTable->expects($this->never())->method('getResponse');
+
+        $registry = $this->createRegistry($dataTable);
+        $token    = $registry->getToken('App\\UserDataTable');
+
+        $controller = new AjaxDataController($registry);
+
+        $this->expectException(BadRequestHttpException::class);
+
+        $controller(new Request(query: ['table' => $token]));
+    }
+
+    private function createRegistry(?AbstractDataTable $table = null): AjaxDataTableRegistry
+    {
+        $services = [];
+        $map      = [];
+
+        if (null !== $table) {
+            $services['app.user_datatable'] = $table;
+            $map['App\\UserDataTable']      = 'app.user_datatable';
+        }
+
+        return new AjaxDataTableRegistry(
+            new class($services) implements ContainerInterface {
+                public function __construct(private readonly array $services)
+                {
+                }
+
+                public function get(string $id): mixed
+                {
+                    return $this->services[$id];
+                }
+
+                public function has(string $id): bool
+                {
+                    return isset($this->services[$id]);
+                }
+            },
+            new AjaxDataTableTokenManager('test-secret'),
+            $map,
+        );
+    }
+}

--- a/tests/Unit/DependencyInjection/Compiler/DataTableRegistryPassTest.php
+++ b/tests/Unit/DependencyInjection/Compiler/DataTableRegistryPassTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Unit\DependencyInjection\Compiler;
+
+use Pentiminax\UX\DataTables\Ajax\AjaxDataTableRegistry;
+use Pentiminax\UX\DataTables\DependencyInjection\Compiler\DataTableRegistryPass;
+use Pentiminax\UX\DataTables\Model\AbstractDataTable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+
+/**
+ * @internal
+ */
+#[CoversClass(DataTableRegistryPass::class)]
+final class DataTableRegistryPassTest extends TestCase
+{
+    #[Test]
+    public function it_registers_ajax_registry_keyed_by_data_table_class_and_backed_by_service_ids(): void
+    {
+        $container = new ContainerBuilder();
+
+        $definition = (new Definition(FakeDataTableForRegistry::class))
+            ->addTag(DataTableRegistryPass::TAG)
+            ->setPublic(true);
+        $container->setDefinition('app.custom_data_table_service', $definition);
+
+        (new DataTableRegistryPass())->process($container);
+
+        $this->assertTrue($container->hasDefinition(DataTableRegistryPass::REGISTRY_ID));
+
+        $registryDefinition = $container->getDefinition(DataTableRegistryPass::REGISTRY_ID);
+        $this->assertSame(AjaxDataTableRegistry::class, $registryDefinition->getClass());
+        $this->assertSame([
+            FakeDataTableForRegistry::class => 'app.custom_data_table_service',
+        ], $registryDefinition->getArgument(2));
+
+        $locatorDefinition = $container->getDefinition('datatables.ajax.registry.locator');
+        $this->assertSame(ServiceLocator::class, $locatorDefinition->getClass());
+        $this->assertArrayHasKey('app.custom_data_table_service', $locatorDefinition->getArgument(0));
+    }
+
+    #[Test]
+    public function it_registers_empty_registry_when_no_data_tables_are_tagged(): void
+    {
+        $container = new ContainerBuilder();
+
+        (new DataTableRegistryPass())->process($container);
+
+        $registryDefinition = $container->getDefinition(DataTableRegistryPass::REGISTRY_ID);
+        $this->assertSame([], $registryDefinition->getArgument(2));
+    }
+}
+
+final class FakeDataTableForRegistry extends AbstractDataTable
+{
+}

--- a/tests/Unit/Rendering/RenderingPreparerTest.php
+++ b/tests/Unit/Rendering/RenderingPreparerTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Pentiminax\UX\DataTables\Tests\Unit\Rendering;
 
+use Pentiminax\UX\DataTables\Ajax\AjaxDataTableRegistry;
+use Pentiminax\UX\DataTables\Ajax\AjaxDataTableTokenManager;
 use Pentiminax\UX\DataTables\ApiPlatform\ApiResourceCollectionUrlResolverInterface;
 use Pentiminax\UX\DataTables\Attribute\AsDataTable;
 use Pentiminax\UX\DataTables\Column\TextColumn;
@@ -15,6 +17,8 @@ use Pentiminax\UX\DataTables\Rendering\RenderingPreparer;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -274,6 +278,150 @@ final class RenderingPreparerTest extends TestCase
         $preparer->prepare($table, new AsDataTable(entityClass: \stdClass::class, mercure: true));
 
         $this->assertNull($table->getMercureConfig());
+    }
+
+    #[Test]
+    public function it_auto_configures_ajax_for_server_side_table_without_explicit_url(): void
+    {
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->method('generate')
+            ->with(RenderingPreparer::AJAX_DATA_ROUTE)
+            ->willReturn('/datatables/ajax/data');
+
+        $registry = $this->createAjaxRegistry(['App\\DataTables\\UserDataTable' => 'app.users_datatable']);
+        $preparer = new RenderingPreparer(urlGenerator: $urlGenerator, ajaxRegistry: $registry);
+        $table    = (new DataTable('Test'))
+            ->setDataTableClass('App\\DataTables\\UserDataTable')
+            ->serverSide();
+
+        $preparer->prepare($table, null);
+
+        $ajax = $table->getOption('ajax');
+        $this->assertIsArray($ajax);
+        $this->assertSame('/datatables/ajax/data', $ajax['url']);
+        $this->assertSame('GET', $ajax['type']);
+        $this->assertSame(['table' => $registry->getToken('App\\DataTables\\UserDataTable')], $ajax['data']);
+        $this->assertStringNotContainsString('UserDataTable', $ajax['data']['table']);
+    }
+
+    #[Test]
+    public function it_does_not_auto_configure_ajax_for_client_side_table(): void
+    {
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->expects($this->never())->method('generate');
+
+        $preparer = new RenderingPreparer(urlGenerator: $urlGenerator);
+        $table    = (new DataTable('Test'))->setDataTableClass('App\\DataTables\\UserDataTable');
+
+        $preparer->prepare($table, null);
+
+        $this->assertNull($table->getOption('ajax'));
+    }
+
+    #[Test]
+    public function it_does_not_override_manual_ajax_url(): void
+    {
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->expects($this->never())->method('generate');
+
+        $preparer = new RenderingPreparer(
+            urlGenerator: $urlGenerator,
+            ajaxRegistry: $this->createAjaxRegistry(['App\\DataTables\\UserDataTable' => 'app.users_datatable']),
+        );
+        $table = (new DataTable('Test'))
+            ->setDataTableClass('App\\DataTables\\UserDataTable')
+            ->serverSide()
+            ->ajax('/custom-endpoint');
+
+        $preparer->prepare($table, null);
+
+        $this->assertSame('/custom-endpoint', $table->getOption('ajax')['url']);
+    }
+
+    #[Test]
+    public function it_does_not_auto_configure_ajax_when_api_platform_is_enabled(): void
+    {
+        $urlResolver = $this->createMock(ApiResourceCollectionUrlResolverInterface::class);
+        $urlResolver->method('resolveCollectionUrl')->willReturn('/api/users');
+
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->expects($this->never())->method('generate');
+
+        $preparer = new RenderingPreparer(urlResolver: $urlResolver, urlGenerator: $urlGenerator);
+        $table    = (new DataTable('Test'))
+            ->setDataTableClass('App\\DataTables\\UserDataTable')
+            ->serverSide();
+
+        $preparer->prepare($table, new AsDataTable(entityClass: \stdClass::class, apiPlatform: true));
+
+        $this->assertSame('/api/users', $table->getOption('ajax')['url']);
+    }
+
+    #[Test]
+    public function it_does_not_auto_configure_ajax_when_url_generator_is_missing(): void
+    {
+        $preparer = new RenderingPreparer(
+            ajaxRegistry: $this->createAjaxRegistry(['App\\DataTables\\UserDataTable' => 'app.users_datatable']),
+        );
+        $table = (new DataTable('Test'))
+            ->setDataTableClass('App\\DataTables\\UserDataTable')
+            ->serverSide();
+
+        $preparer->prepare($table, null);
+
+        $this->assertNull($table->getOption('ajax'));
+    }
+
+    #[Test]
+    public function it_does_not_auto_configure_ajax_when_registry_is_missing(): void
+    {
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->expects($this->never())->method('generate');
+
+        $preparer = new RenderingPreparer(urlGenerator: $urlGenerator);
+        $table    = (new DataTable('Test'))
+            ->setDataTableClass('App\\DataTables\\UserDataTable')
+            ->serverSide();
+
+        $preparer->prepare($table, null);
+
+        $this->assertNull($table->getOption('ajax'));
+    }
+
+    #[Test]
+    public function it_does_not_auto_configure_ajax_when_fqcn_is_missing(): void
+    {
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->expects($this->never())->method('generate');
+
+        $preparer = new RenderingPreparer(
+            urlGenerator: $urlGenerator,
+            ajaxRegistry: $this->createAjaxRegistry(['App\\DataTables\\UserDataTable' => 'app.users_datatable']),
+        );
+        $table = (new DataTable('Test'))->serverSide();
+
+        $preparer->prepare($table, null);
+
+        $this->assertNull($table->getOption('ajax'));
+    }
+
+    private function createAjaxRegistry(array $serviceIdsByClass): AjaxDataTableRegistry
+    {
+        return new AjaxDataTableRegistry(
+            new class implements ContainerInterface {
+                public function get(string $id): mixed
+                {
+                    throw new \LogicException('The test registry should only generate tokens.');
+                }
+
+                public function has(string $id): bool
+                {
+                    return false;
+                }
+            },
+            new AjaxDataTableTokenManager('test-secret'),
+            $serviceIdsByClass,
+        );
     }
 
     #[Test]

--- a/tests/Unit/Twig/DataTablesExtensionTest.php
+++ b/tests/Unit/Twig/DataTablesExtensionTest.php
@@ -15,12 +15,14 @@ use Pentiminax\UX\DataTables\Model\Action;
 use Pentiminax\UX\DataTables\Model\Actions;
 use Pentiminax\UX\DataTables\Model\DataTable;
 use Pentiminax\UX\DataTables\Runtime\DataTableInfrastructure;
+use Pentiminax\UX\DataTables\Tests\Fixtures\DataTable\AutoAjaxServerSideDataTable;
 use Pentiminax\UX\DataTables\Tests\Kernel\TwigAppKernel;
 use Pentiminax\UX\DataTables\Twig\DataTablesExtension;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 /**
  * @internal
@@ -519,6 +521,49 @@ final class DataTablesExtensionTest extends TestCase
         $payload = json_decode($table->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
 
         $this->assertSame('<span class="badge">7-active</span>', trim($payload['data'][0]['status']));
+
+        $kernel->shutdown();
+    }
+
+    #[Test]
+    public function it_dispatches_auto_ajax_for_service_managed_server_side_table_with_custom_service_id(): void
+    {
+        $kernel = new TwigAppKernel('test', true);
+        $kernel->boot();
+        $container = $kernel->getContainer()->get('test.service_container');
+
+        $registry = $container->get('datatables.ajax.registry');
+        $token    = $registry->getToken(AutoAjaxServerSideDataTable::class);
+
+        $this->assertIsString($token);
+        $this->assertStringNotContainsString('AutoAjaxServerSideDataTable', $token);
+
+        $controller = $container->get('datatables.controller.ajax_data');
+        $response   = $controller(Request::create('/datatables/ajax/data', 'GET', [
+            'table'   => $token,
+            'draw'    => 1,
+            'start'   => 0,
+            'length'  => 10,
+            'search'  => ['value' => '', 'regex' => 'false'],
+            'columns' => [
+                ['data' => 'id', 'name' => 'id', 'searchable' => 'true', 'orderable' => 'true'],
+                ['data' => 'title', 'name' => 'title', 'searchable' => 'true', 'orderable' => 'true'],
+            ],
+        ]));
+
+        $payload = json_decode($response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame(1, $payload['draw']);
+        $this->assertSame('Generated endpoint', $payload['data'][0]['title']);
+
+        try {
+            $controller(Request::create('/datatables/ajax/data', 'GET', [
+                'table' => $token,
+            ]));
+            $this->fail('Expected invalid DataTables payload to be rejected.');
+        } catch (BadRequestHttpException) {
+            $this->addToAssertionCount(1);
+        }
 
         $kernel->shutdown();
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic server-side AJAX support for DataTables with secure token-based request routing.
  * Simplified configuration: tables now auto-wire AJAX without manual URL setup.

* **Documentation**
  * Updated guides for server-side processing and automatic AJAX setup.
  * Clarified controller-side request handling patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pentiminax/ux-datatables/pull/219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->