### PR TITLE
feat(datatable): enable query parameter forwarding for server-side AJ…

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -170,6 +170,7 @@ return static function (ContainerConfigurator $container): void {
         ->arg(3, service(MercureHubUrlResolverInterface::class)->nullOnInvalid())
         ->arg(4, service('router')->nullOnInvalid())
         ->arg(5, service('datatables.ajax.registry'))
+        ->arg(6, service('request_stack')->nullOnInvalid())
         ->private();
 
     $services->alias(RenderingPreparer::class, 'datatables.rendering.preparer')

--- a/docs/src/content/docs/guide/server-side-processing.mdx
+++ b/docs/src/content/docs/guide/server-side-processing.mdx
@@ -137,6 +137,35 @@ public function index(ProductsDataTable $table, Request $request): Response
 }
 ```
 
+## Forwarding Page Query Parameters
+
+With automatic Ajax, the browser sends its request to the bundle endpoint rather than to the page URL, so query parameters present on the page (`?q=...&pending=...`) never reach your server-side query. `forwardQueryParameters()` captures the named parameters **at render time** and forwards them on every Ajax call, letting you read them in `customizeQueryBuilder()` — no dedicated relay controller required.
+
+```php
+use Pentiminax\UX\DataTables\DataTableRequest\DataTableRequest;
+use Pentiminax\UX\DataTables\Model\DataTable;
+
+public function configureDataTable(DataTable $table): DataTable
+{
+    return $table
+        ->serverSide()
+        ->forwardQueryParameters(['q', 'pending']);
+}
+
+protected function customizeQueryBuilder(QueryBuilder $qb, DataTableRequest $request): QueryBuilder
+{
+    $httpRequest = $this->getHttpRequest();
+
+    if (null !== $pending = $httpRequest?->query->get('pending')) {
+        $qb->andWhere('e.pending = :pending')->setParameter('pending', $pending);
+    }
+
+    return $qb;
+}
+```
+
+The forwarded values are a snapshot taken when the page renders and are sent unchanged on every paging/search/sort reload. Only parameters actually present in the request are forwarded. This works with automatic Ajax and with manual `ajax()` / `ajaxRequestData()`; it is not applied in API Platform mode.
+
 ## Best Practices
 
 - Use `isRequestHandled()` instead of `$request->isXmlHttpRequest()`.

--- a/docs/src/content/docs/reference/datatable.mdx
+++ b/docs/src/content/docs/reference/datatable.mdx
@@ -47,6 +47,10 @@ new DataTable(
       'Configure Ajax endpoint with extra request data sent on every call',
     ],
     ['`data(array $data)`', 'Provide inline client-side data'],
+    [
+      '`forwardQueryParameters(array $parameters)`',
+      'Capture the named page query parameters at render time and forward them on every Ajax call',
+    ],
     ['`serverSide(bool $serverSide = true)`', 'Enable server-side processing mode'],
     ['`apiPlatform(bool $enabled = true)`', 'Enable API Platform adapter behavior'],
     [

--- a/skills/ux-datatables/references/server-side.md
+++ b/skills/ux-datatables/references/server-side.md
@@ -61,6 +61,32 @@ $table->ajax('/api/products', dataSrc: null, type: 'GET')->serverSide();
 $table->ajaxRequestData('/api/products', ['tenant' => 5], 'GET');
 ```
 
+## Forward page query parameters
+
+When using Auto Ajax, the browser sends its request to the bundle endpoint, not the page URL — so contextual query parameters present on the page (`?q=...&pending=...`) never reach the server. `forwardQueryParameters()` captures the named params **at render time** and forwards them on every Ajax call, so you can read them in `customizeQueryBuilder()` without writing a dedicated relay controller:
+
+```php
+public function configureDataTable(DataTable $table): DataTable
+{
+    return $table
+        ->serverSide()
+        ->forwardQueryParameters(['q', 'pending']);
+}
+
+protected function customizeQueryBuilder(QueryBuilder $qb, DataTableRequest $request): QueryBuilder
+{
+    $request = $this->getHttpRequest();
+
+    if (null !== $pending = $request?->query->get('pending')) {
+        $qb->andWhere('e.pending = :pending')->setParameter('pending', $pending);
+    }
+
+    return $qb;
+}
+```
+
+Values are a **snapshot** taken when the page renders (sent unchanged on every paging/search/sort reload); only params present in the request are forwarded. Works with Auto Ajax and manual `ajax()` / `ajaxRequestData()` alike. Not applied in API Platform mode.
+
 ## Frontend hooks (Stimulus)
 
 The controller is registered as `@pentiminax/ux-datatables/datatable` and dispatches events with the `datatables` prefix. Attach a custom controller via `render_datatable(table, {'data-controller': 'my-table'})` and listen:

--- a/src/Model/DataTable.php
+++ b/src/Model/DataTable.php
@@ -33,6 +33,9 @@ class DataTable
 
     private ?string $dataTableClass = null;
 
+    /** @var string[] */
+    private array $forwardedQueryParameters = [];
+
     public function __construct(
         private readonly string $id,
         array $options = [],
@@ -431,6 +434,49 @@ class DataTable
             'url'  => $url,
             'data' => $data,
         ]);
+
+        return $this;
+    }
+
+    /**
+     * Names of current-request query parameters to capture at render time and
+     * forward to the AJAX endpoint on every request. Read them server-side in
+     * customizeQueryBuilder() via $this->getHttpRequest()?->query->get($name).
+     *
+     * @param string[] $parameters
+     */
+    public function forwardQueryParameters(array $parameters): static
+    {
+        $this->forwardedQueryParameters = $parameters;
+
+        return $this;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getForwardedQueryParameters(): array
+    {
+        return $this->forwardedQueryParameters;
+    }
+
+    /**
+     * Merge extra entries into the existing AJAX `data` payload.
+     *
+     * No-op when no AJAX source is configured (e.g. client-side data tables).
+     *
+     * @param array<string, mixed> $data
+     */
+    public function mergeAjaxData(array $data): static
+    {
+        $ajax = $this->options->get('ajax');
+
+        if (!\is_array($ajax)) {
+            return $this;
+        }
+
+        $ajax['data'] = array_merge($ajax['data'] ?? [], $data);
+        $this->options->set('ajax', $ajax);
 
         return $this;
     }

--- a/src/Rendering/RenderingPreparer.php
+++ b/src/Rendering/RenderingPreparer.php
@@ -12,6 +12,7 @@ use Pentiminax\UX\DataTables\Mercure\MercureConfig;
 use Pentiminax\UX\DataTables\Mercure\MercureConfigResolverInterface;
 use Pentiminax\UX\DataTables\Mercure\MercureHubUrlResolverInterface;
 use Pentiminax\UX\DataTables\Model\DataTable;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -26,6 +27,7 @@ final class RenderingPreparer
         private readonly ?MercureHubUrlResolverInterface $mercureHubUrlResolver = null,
         private readonly ?UrlGeneratorInterface $urlGenerator = null,
         private readonly ?AjaxDataTableRegistry $ajaxRegistry = null,
+        private readonly ?RequestStack $requestStack = null,
     ) {
     }
 
@@ -40,6 +42,7 @@ final class RenderingPreparer
         $this->configureApiPlatform($table, $asDataTable);
         $this->configureApiPlatformTemplateRendering($table);
         $this->configureAutoAjax($table);
+        $this->configureForwardedQueryParameters($table);
         $this->configureEditModal($table, $asDataTable);
         $this->translateColumnTitles($table);
     }
@@ -150,6 +153,33 @@ final class RenderingPreparer
             && true !== $table->getOption('apiPlatform')
             && null !== $this->urlGenerator
             && null !== $this->ajaxRegistry;
+    }
+
+    private function configureForwardedQueryParameters(DataTable $table): void
+    {
+        $names = $table->getForwardedQueryParameters();
+        if ([] === $names) {
+            return;
+        }
+
+        $request = $this->requestStack?->getCurrentRequest();
+        if (null === $request) {
+            return;
+        }
+
+        $all       = $request->query->all();
+        $forwarded = [];
+        foreach ($names as $name) {
+            if (\array_key_exists($name, $all)) {
+                $forwarded[$name] = $all[$name];
+            }
+        }
+
+        if ([] === $forwarded) {
+            return;
+        }
+
+        $table->mergeAjaxData($forwarded);
     }
 
     private function configureMercure(DataTable $table, ?AsDataTable $asDataTable): void

--- a/tests/Unit/Model/DataTableTest.php
+++ b/tests/Unit/Model/DataTableTest.php
@@ -341,4 +341,46 @@ final class DataTableTest extends TestCase
 
         $this->assertSame($table, $table->urlState());
     }
+
+    #[Test]
+    public function it_stores_forwarded_query_parameters(): void
+    {
+        $table = (new DataTable('users'))->forwardQueryParameters(['q', 'pending']);
+
+        $this->assertSame(['q', 'pending'], $table->getForwardedQueryParameters());
+    }
+
+    #[Test]
+    public function it_defaults_forwarded_query_parameters_to_an_empty_array(): void
+    {
+        $this->assertSame([], (new DataTable('users'))->getForwardedQueryParameters());
+    }
+
+    #[Test]
+    public function it_merges_ajax_data_into_existing_ajax_payload(): void
+    {
+        $table = (new DataTable('users'))
+            ->ajaxRequestData('/endpoint', ['table' => 'token'])
+            ->mergeAjaxData(['q' => 'foo']);
+
+        $this->assertSame(['table' => 'token', 'q' => 'foo'], $table->getOption('ajax')['data']);
+    }
+
+    #[Test]
+    public function it_creates_ajax_data_key_when_merging_into_ajax_without_data(): void
+    {
+        $table = (new DataTable('users'))
+            ->ajax('/endpoint')
+            ->mergeAjaxData(['q' => 'foo']);
+
+        $this->assertSame(['q' => 'foo'], $table->getOption('ajax')['data']);
+    }
+
+    #[Test]
+    public function it_does_not_merge_ajax_data_when_no_ajax_source_is_configured(): void
+    {
+        $table = (new DataTable('users'))->mergeAjaxData(['q' => 'foo']);
+
+        $this->assertNull($table->getOption('ajax'));
+    }
 }

--- a/tests/Unit/Rendering/RenderingPreparerTest.php
+++ b/tests/Unit/Rendering/RenderingPreparerTest.php
@@ -19,6 +19,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -464,6 +466,105 @@ final class RenderingPreparerTest extends TestCase
         $preparer->prepare($table, null);
 
         $this->assertNull($table->getOption('ajax'));
+    }
+
+    #[Test]
+    public function it_forwards_present_query_parameters_into_auto_ajax_data(): void
+    {
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->method('generate')->willReturn('/datatables/ajax/data');
+
+        $registry = $this->createAjaxRegistry(['App\\DataTables\\UserDataTable' => 'app.users_datatable']);
+        $preparer = new RenderingPreparer(
+            urlGenerator: $urlGenerator,
+            ajaxRegistry: $registry,
+            requestStack: $this->createRequestStack(['q' => 'foo', 'pending' => '1', 'unrelated' => 'x']),
+        );
+        $table = (new DataTable('Test'))
+            ->setDataTableClass('App\\DataTables\\UserDataTable')
+            ->serverSide()
+            ->forwardQueryParameters(['q', 'pending']);
+
+        $preparer->prepare($table, null);
+
+        $data = $table->getOption('ajax')['data'];
+        $this->assertSame($registry->getToken('App\\DataTables\\UserDataTable'), $data['table']);
+        $this->assertSame('foo', $data['q']);
+        $this->assertSame('1', $data['pending']);
+        $this->assertArrayNotHasKey('unrelated', $data);
+    }
+
+    #[Test]
+    public function it_forwards_only_query_parameters_present_in_the_request(): void
+    {
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->method('generate')->willReturn('/datatables/ajax/data');
+
+        $preparer = new RenderingPreparer(
+            urlGenerator: $urlGenerator,
+            ajaxRegistry: $this->createAjaxRegistry(['App\\DataTables\\UserDataTable' => 'app.users_datatable']),
+            requestStack: $this->createRequestStack(['q' => 'foo']),
+        );
+        $table = (new DataTable('Test'))
+            ->setDataTableClass('App\\DataTables\\UserDataTable')
+            ->serverSide()
+            ->forwardQueryParameters(['q', 'pending']);
+
+        $preparer->prepare($table, null);
+
+        $data = $table->getOption('ajax')['data'];
+        $this->assertSame('foo', $data['q']);
+        $this->assertArrayNotHasKey('pending', $data);
+    }
+
+    #[Test]
+    public function it_does_not_forward_query_parameters_without_a_current_request(): void
+    {
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->method('generate')->willReturn('/datatables/ajax/data');
+
+        $registry = $this->createAjaxRegistry(['App\\DataTables\\UserDataTable' => 'app.users_datatable']);
+        $preparer = new RenderingPreparer(
+            urlGenerator: $urlGenerator,
+            ajaxRegistry: $registry,
+            requestStack: new RequestStack(),
+        );
+        $table = (new DataTable('Test'))
+            ->setDataTableClass('App\\DataTables\\UserDataTable')
+            ->serverSide()
+            ->forwardQueryParameters(['q']);
+
+        $preparer->prepare($table, null);
+
+        $this->assertSame(
+            ['table' => $registry->getToken('App\\DataTables\\UserDataTable')],
+            $table->getOption('ajax')['data'],
+        );
+    }
+
+    #[Test]
+    public function it_forwards_query_parameters_into_manual_ajax(): void
+    {
+        $preparer = new RenderingPreparer(
+            requestStack: $this->createRequestStack(['q' => 'foo']),
+        );
+        $table = (new DataTable('Test'))
+            ->ajax('/custom-endpoint')
+            ->forwardQueryParameters(['q']);
+
+        $preparer->prepare($table, null);
+
+        $ajax = $table->getOption('ajax');
+        $this->assertSame('/custom-endpoint', $ajax['url']);
+        $this->assertSame(['q' => 'foo'], $ajax['data']);
+    }
+
+    private function createRequestStack(array $query): RequestStack
+    {
+        $stack = new RequestStack();
+        $stack->push(new Request($query));
+
+        return $stack;
     }
 
     private function createAjaxRegistry(array $serviceIdsByClass): AjaxDataTableRegistry


### PR DESCRIPTION
…AX requests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `forwardQueryParameters()` method to capture specific URL query parameters at render time and forward them to DataTables AJAX endpoints on each request.
  * Added `mergeAjaxData()` for merging custom data into AJAX request payloads.

* **Documentation**
  * Added comprehensive guidance on forwarding page query parameters with usage examples and behavioral details.

* **Tests**
  * Added unit test coverage for query parameter forwarding and AJAX payload functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->