### PR TITLE
feat(choice-column): EasyAdmin-style setChoices and fix enum rendering

### DIFF
--- a/src/Column/ChoiceColumn.php
+++ b/src/Column/ChoiceColumn.php
@@ -20,7 +20,7 @@ class ChoiceColumn extends AbstractColumn
     }
 
     /**
-     * Define the available choices, mirroring EasyAdmin's ChoiceField::setChoices().
+     * Define the available choices.
      *
      * Accepts:
      *  - an associative array using the EasyAdmin convention `[label => value]`

--- a/src/Column/ChoiceColumn.php
+++ b/src/Column/ChoiceColumn.php
@@ -23,7 +23,7 @@ class ChoiceColumn extends AbstractColumn
      * Define the available choices.
      *
      * Accepts:
-     *  - an associative array using the EasyAdmin convention `[label => value]`
+     *  - an associative array using the following convention `[label => value]`
      *    (keys are the human-readable labels, values are the stored values);
      *  - a list of BackedEnum cases (e.g. `MyEnum::cases()`);
      *  - a BackedEnum class-string (e.g. `MyEnum::class`).
@@ -86,7 +86,7 @@ class ChoiceColumn extends AbstractColumn
     }
 
     /**
-     * Invert the EasyAdmin `[label => value]` convention into the internal
+     * Invert the `[label => value]` convention into the internal
      * `[value => label]` map consumed by the frontend renderer.
      *
      * @param array<string|int, string|int> $choices

--- a/src/Column/ChoiceColumn.php
+++ b/src/Column/ChoiceColumn.php
@@ -20,7 +20,20 @@ class ChoiceColumn extends AbstractColumn
     }
 
     /**
-     * @param array<string|int, string>|list<\BackedEnum>|class-string<\BackedEnum> $choices
+     * Define the available choices, mirroring EasyAdmin's ChoiceField::setChoices().
+     *
+     * Accepts:
+     *  - an associative array using the EasyAdmin convention `[label => value]`
+     *    (keys are the human-readable labels, values are the stored values);
+     *  - a list of BackedEnum cases (e.g. `MyEnum::cases()`);
+     *  - a BackedEnum class-string (e.g. `MyEnum::class`).
+     *
+     * Choices are always stored internally as `[value => label]` so the frontend
+     * renderer can resolve the label from the raw cell value. For enums, the label
+     * is taken from a `getLabel()`/`label()` method when available, otherwise the
+     * case name.
+     *
+     * @param array<string|int, string|int>|list<\BackedEnum>|class-string<\BackedEnum> $choices
      */
     public function setChoices(array|string $choices): self
     {
@@ -35,10 +48,12 @@ class ChoiceColumn extends AbstractColumn
         }
 
         if ($this->isBackedEnumList($choices)) {
-            $choices = $this->normalizeBackedEnumChoices($choices);
+            $this->setCustomOption(self::OPTION_CHOICES, $this->normalizeBackedEnumChoices($choices));
+
+            return $this;
         }
 
-        $this->setCustomOption(self::OPTION_CHOICES, $choices);
+        $this->setCustomOption(self::OPTION_CHOICES, $this->normalizeArrayChoices($choices));
 
         return $this;
     }
@@ -71,6 +86,25 @@ class ChoiceColumn extends AbstractColumn
     }
 
     /**
+     * Invert the EasyAdmin `[label => value]` convention into the internal
+     * `[value => label]` map consumed by the frontend renderer.
+     *
+     * @param array<string|int, string|int> $choices
+     *
+     * @return array<string, string>
+     */
+    private function normalizeArrayChoices(array $choices): array
+    {
+        $map = [];
+
+        foreach ($choices as $label => $value) {
+            $map[(string) $value] = (string) $label;
+        }
+
+        return $map;
+    }
+
+    /**
      * @param list<\BackedEnum> $choices
      *
      * @return array<string, string>
@@ -80,10 +114,23 @@ class ChoiceColumn extends AbstractColumn
         $map = [];
 
         foreach ($choices as $case) {
-            $map[(string) $case->value] = $case->name;
+            $map[(string) $case->value] = $this->resolveEnumLabel($case);
         }
 
         return $map;
+    }
+
+    private function resolveEnumLabel(\BackedEnum $case): string
+    {
+        if (method_exists($case, 'getLabel')) {
+            return (string) $case->getLabel();
+        }
+
+        if (method_exists($case, 'label')) {
+            return (string) $case->label();
+        }
+
+        return $case->name;
     }
 
     /**

--- a/src/RowMapper/Stage/NormalizationStage.php
+++ b/src/RowMapper/Stage/NormalizationStage.php
@@ -34,6 +34,8 @@ final class NormalizationStage implements RowStageInterface
 
             if ($column instanceof DateColumn && $value instanceof \DateTimeInterface) {
                 $mappedRow[$key] = $value->format($column->getFormat());
+            } elseif ($value instanceof \BackedEnum) {
+                $mappedRow[$key] = $value->value;
             } elseif ($value instanceof \Stringable) {
                 $mappedRow[$key] = (string) $value;
             } else {

--- a/tests/Unit/Column/ChoiceColumnTest.php
+++ b/tests/Unit/Column/ChoiceColumnTest.php
@@ -34,14 +34,39 @@ final class ChoiceColumnTest extends TestCase
     }
 
     #[Test]
-    public function it_sets_choices_from_array(): void
+    public function it_sets_choices_from_array_using_easyadmin_convention(): void
     {
+        // EasyAdmin convention: keys are the human-readable labels, values are the stored values.
         $data = ChoiceColumn::new('status')
-            ->setChoices(['active' => 'Active', 'inactive' => 'Inactive'])
+            ->setChoices(['Active' => 'active', 'Inactive' => 'inactive'])
             ->jsonSerialize();
 
         $this->assertArrayHasKey('choices', $data['customOptions']);
+        // Stored internally as [value => label] so the renderer can resolve label from the cell value.
         $this->assertSame(['active' => 'Active', 'inactive' => 'Inactive'], $data['customOptions']['choices']);
+    }
+
+    #[Test]
+    public function it_casts_non_string_choice_values_to_string_keys(): void
+    {
+        $data = ChoiceColumn::new('status')
+            ->setChoices(['One' => 1, 'Two' => 2])
+            ->jsonSerialize();
+
+        $this->assertSame(['1' => 'One', '2' => 'Two'], $data['customOptions']['choices']);
+    }
+
+    #[Test]
+    public function it_resolves_enum_labels_from_get_label_method(): void
+    {
+        $data = ChoiceColumn::new('status')
+            ->setChoices(TestStatusWithLabel::cases())
+            ->jsonSerialize();
+
+        $this->assertSame([
+            'active'   => 'Active ✅',
+            'inactive' => 'Inactive ❌',
+        ], $data['customOptions']['choices']);
     }
 
     #[Test]

--- a/tests/Unit/Column/TestStatusWithLabel.php
+++ b/tests/Unit/Column/TestStatusWithLabel.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Unit\Column;
+
+enum TestStatusWithLabel: string
+{
+    case Active   = 'active';
+    case Inactive = 'inactive';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Active   => 'Active ✅',
+            self::Inactive => 'Inactive ❌',
+        };
+    }
+}

--- a/tests/Unit/RowMapper/Stage/NormalizationStageTest.php
+++ b/tests/Unit/RowMapper/Stage/NormalizationStageTest.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Pentiminax\UX\DataTables\Tests\Unit\RowMapper\Stage;
 
+use Pentiminax\UX\DataTables\Column\ChoiceColumn;
 use Pentiminax\UX\DataTables\Column\DateColumn;
 use Pentiminax\UX\DataTables\Column\TextColumn;
 use Pentiminax\UX\DataTables\RowMapper\Stage\NormalizationStage;
+use Pentiminax\UX\DataTables\Tests\Unit\Column\TestStatus;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -49,6 +51,15 @@ final class NormalizationStageTest extends TestCase
         $result = $stage->process(['obj' => new \stdClass()], 'original', [TextColumn::new('obj')]);
 
         $this->assertNull($result['obj']);
+    }
+
+    #[Test]
+    public function it_converts_backed_enum_to_its_value(): void
+    {
+        $stage  = new NormalizationStage();
+        $result = $stage->process(['status' => TestStatus::Active], 'original', [ChoiceColumn::new('status')]);
+
+        $this->assertSame(['status' => 'active'], $result);
     }
 
     #[Test]


### PR DESCRIPTION
BREAKING CHANGE: ChoiceColumn::setChoices() now follows this convention for associative arrays — keys are the human-readable labels and values are the stored values (`['Label' => 'value']`), inverted internally to `[value => label]`. Enum cases now resolve their label from a `getLabel()`/`label()` method when present, otherwise the case name.

Fix NormalizationStage forcing BackedEnum cells to null: backed enums are objects without __toString, so they were normalized to null and rendered as empty cells. They now serialize to their backing value, so enum-backed columns render without a custom mapRow() override.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced choice columns with improved support for backed enums, including automatic label resolution from enum methods.
  * Improved handling of choice value normalization for arrays and non-string values.

* **Bug Fixes**
  * Better normalization of backed enum values in data mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->