### PR TITLE
docs: document securing the Ajax data routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,5 +94,29 @@ public function index(UserDataTable $table, Request $request): Response
 
 > Tip: run `php bin/console make:datatable` to scaffold a DataTable class from any Doctrine entity.
 
+## Security
+
+The bundle auto-registers a set of Ajax routes under `/datatables/ajax/*` (`ux_datatables_ajax_data`,
+`ux_datatables_ajax_delete`, `ux_datatables_ajax_edit`, `ux_datatables_ajax_edit_form`,
+`ux_datatables_ajax_edit_form_submit`, `ux_datatables_ajax_detail`, `ux_datatables_ajax_templates`).
+
+The table token embedded in the rendered HTML identifies **which** table is requested, not **who** is
+requesting it — it is **not** a user-authentication or per-user authorization mechanism. If a table is
+displayed behind a firewall but these routes are left unprotected, the underlying data (and the
+edit/delete actions) can be reached by anyone holding the token.
+
+Protect the routes with an `access_control` rule that matches the pages rendering your tables:
+
+```yaml
+# config/packages/security.yaml
+security:
+    access_control:
+        # access_control is first-match-wins; place this before any broader rule.
+        - { path: ^/datatables/ajax, roles: ROLE_ADMIN }
+```
+
+See [Securing Ajax Routes](https://pentiminax.github.io/ux-datatables/getting-started/security/) for
+details.
+
 ## Documentation
 - [Online documentation](https://pentiminax.github.io/ux-datatables/)

--- a/docs/src/config/navigation.ts
+++ b/docs/src/config/navigation.ts
@@ -16,6 +16,7 @@ export const docsSidebarSections: NavSection[] = [
       { label: 'Installation', href: '/ux-datatables/getting-started/installation/' },
       { label: 'AI-Assisted Development', href: '/ux-datatables/getting-started/ai-assisted-development/' },
       { label: 'Quick Start', href: '/ux-datatables/getting-started/quick-start/' },
+      { label: 'Securing Ajax Routes', href: '/ux-datatables/getting-started/security/' },
     ],
   },
   {

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -118,6 +118,13 @@ See [Styling](../styling/) for the full setup guide.
   ]}
 />
 
+<Aside type="danger" title="Secure the Ajax routes before production">
+  The bundle auto-registers the `/datatables/ajax/*` routes. The table token they use identifies
+  **which** table is requested, not **who** is requesting it, so it is not a substitute for
+  authentication. Protect these routes with your application's `security.access_control` to match the
+  pages that render your tables. See [Securing Ajax Routes](../security/).
+</Aside>
+
 <Aside type="tip">
   You're all set! Continue to the [Quick Start](../quick-start/) guide to create your first table.
 </Aside>

--- a/docs/src/content/docs/getting-started/security.mdx
+++ b/docs/src/content/docs/getting-started/security.mdx
@@ -1,0 +1,96 @@
+---
+title: Securing Ajax Routes
+description: Protect the bundle's Ajax endpoints with your application's access control
+---
+
+# Securing Ajax Routes
+
+UX DataTables registers a small set of Ajax routes automatically. Server-side tables,
+the inline edit modal, row deletion, detail rendering and template resolution all go through
+these endpoints:
+
+<Table
+  headers={['Route name', 'Path', 'Method(s)', 'Used by']}
+  rows={[
+    ['ux_datatables_ajax_data', '/datatables/ajax/data', 'GET', 'Server-side data loading'],
+    ['ux_datatables_ajax_delete', '/datatables/ajax/delete', 'DELETE', 'Row delete action'],
+    ['ux_datatables_ajax_edit', '/datatables/ajax/edit', 'POST, PATCH', 'Inline cell edit'],
+    ['ux_datatables_ajax_edit_form', '/datatables/ajax/edit-form', 'GET', 'Edit modal form'],
+    ['ux_datatables_ajax_edit_form_submit', '/datatables/ajax/edit-form', 'POST', 'Edit modal submit'],
+    ['ux_datatables_ajax_detail', '/datatables/ajax/detail', 'GET', 'Row detail rendering'],
+    ['ux_datatables_ajax_templates', '/datatables/ajax/templates', 'POST', 'Template column rendering'],
+  ]}
+/>
+
+## Why this matters
+
+<Aside type="danger" title="Read this before going to production">
+  The table token embedded in the rendered HTML authenticates **which** table is requested, not
+  **who** is requesting it. It is **not** a user-authentication or per-user authorization mechanism.
+  You must protect the Ajax routes with the same access control that protects the pages rendering
+  your tables.
+</Aside>
+
+Each rendered table carries a signed token (an HMAC of the DataTable class name, derived from your
+application's `kernel.secret`). The bundle uses this token to resolve the correct `AbstractDataTable`
+service on the server. The token is stable, it is visible in the page source, and it does **not**
+encode anything about the current user.
+
+This means that if a table is displayed on a page behind an admin firewall, but the global
+`/datatables/ajax/*` routes are **not** covered by an equivalent access control rule, the underlying
+data (and the edit/delete actions) can be reached by anyone who obtains the token — including a user
+who is not allowed to view the page that renders the table.
+
+The bundle cannot know how your application authenticates and authorizes users, so it deliberately
+does not enforce anything at the route level. **Securing these routes is the responsibility of the
+host application.**
+
+## Protect the routes with `access_control`
+
+The simplest and most robust approach is to add an `access_control` rule that scopes the shared
+`^/datatables/ajax` path prefix to match the access requirements of the pages that render your
+tables. Add it to `config/packages/security.yaml`:
+
+```yaml
+# config/packages/security.yaml
+security:
+    # ...
+
+    access_control:
+        # Restrict every UX DataTables Ajax endpoint to authenticated admins.
+        # Match this to whatever the pages rendering your tables require.
+        - { path: ^/datatables/ajax, roles: ROLE_ADMIN }
+
+        # ... your other rules
+```
+
+<Aside type="caution">
+  `access_control` rules are evaluated top to bottom and the **first** match wins. Place the
+  `^/datatables/ajax` rule so that it is not shadowed by an earlier, more permissive rule such as
+  `{ path: ^/, roles: PUBLIC_ACCESS }`.
+</Aside>
+
+If different tables live behind different access levels, use more specific rules or place the
+tables (and their Ajax traffic) behind the same firewall so the same authorization applies to both
+the page and the data endpoint.
+
+<Aside type="tip">
+  A good rule of thumb: if a page requires a role to be viewed, the data that feeds its table
+  requires the same role to be fetched. Keep the two in sync.
+</Aside>
+
+## Verifying your configuration
+
+After adding the rule, confirm it is active:
+
+```bash
+# List the registered UX DataTables routes
+php bin/console debug:router | grep ux_datatables
+
+# Check which access_control rule matches the Ajax prefix
+php bin/console debug:firewall
+```
+
+Then, as an unauthenticated (or under-privileged) user, request
+`/datatables/ajax/data` directly and confirm the firewall responds with a redirect to login or a
+`403`/`401` instead of returning table data.

--- a/docs/src/content/docs/guide/server-side-processing.mdx
+++ b/docs/src/content/docs/guide/server-side-processing.mdx
@@ -38,6 +38,13 @@ return static function (RoutingConfigurator $routes): void {
 };
 ```
 
+<Aside type="danger" title="Protect these routes">
+  The table token in the request identifies **which** table is requested, not **who** is requesting
+  it — it is not a user-authentication mechanism. If a table sits behind a firewall, you must also
+  cover the `^/datatables/ajax` routes with a matching `access_control` rule, or the data can be
+  fetched by anyone holding the token. See [Securing Ajax Routes](../../getting-started/security/).
+</Aside>
+
 Use an explicit `ajax()` URL when the endpoint is not an `AbstractDataTable` service, when you want a
 custom route, or when you are using a plain `DataTable` instance:
 


### PR DESCRIPTION
Closes #240

## Problem

The bundle auto-registers a set of Ajax routes under `/datatables/ajax/*`
(`ux_datatables_ajax_data`, `ux_datatables_ajax_delete`, `ux_datatables_ajax_edit`,
`ux_datatables_ajax_edit_form`, `ux_datatables_ajax_edit_form_submit`,
`ux_datatables_ajax_detail`, `ux_datatables_ajax_templates`).

The table token embedded in the rendered HTML is an HMAC of the DataTable class name (derived from
`kernel.secret`). It authenticates **which** table is requested, not **who** is requesting it — it is
not a user-authentication or per-user authorization mechanism. If a table is rendered behind an admin
firewall but the global `/datatables/ajax/*` routes are not covered by an equivalent
`security.access_control` rule, the underlying data (and the edit/delete actions) can be reached by
anyone holding the token.

Because the bundle cannot know how a host application authenticates and authorizes users, it
deliberately does not enforce anything at the route level. Securing these routes is the host
application's responsibility, and that expectation was previously undocumented.

## Changes (documentation only)

- **New "Securing Ajax Routes" page** (`docs/.../getting-started/security.mdx`): lists every
  auto-registered route, explains why the token is not authentication, and provides a concrete
  `config/packages/security.yaml` `access_control` example scoping `^/datatables/ajax`, plus
  verification steps. Added to the Getting Started sidebar in `navigation.ts`.
- **Cross-linking danger callouts** in Installation and Server-Side Processing pages.
- **Security section in the README** with the same `access_control` example.

No code or token behaviour is changed, so no PHP test is added.

## Verification

- Docs-only change; MDX mirrors existing pages' frontmatter and component usage (`Aside`, `Table`).
- `npm install` / Astro build could not be run in this environment (no network for dependency
  install); the new/edited `.mdx` uses only components already registered in
  `docs/src/pages/[...slug].astro` and valid frontmatter per `docs/src/content.config.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2XDb66N37YxbuVWZ6eKpc

---
_Generated by [Claude Code](https://claude.ai/code/session_01L2XDb66N37YxbuVWZ6eKpc)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no PHP or security behavior changes in the bundle.
> 
> **Overview**
> Documents that **auto-registered** `/datatables/ajax/*` endpoints must be protected in the host app: the table token only identifies **which** table is requested, not **who** is calling.
> 
> Adds a **Securing Ajax Routes** getting-started page (route inventory, token vs auth explanation, `security.access_control` example for `^/datatables/ajax`, first-match-wins note, and `debug:router` / `debug:firewall` checks). The README gets a matching **Security** section; Installation and Server-Side Processing gain danger callouts linking to that page; the docs sidebar lists the new page.
> 
> **No runtime or token behavior changes** — documentation only (closes #240).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d705c79966e0ca26f92f7f8f14466b50706799a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->