### PR TITLE
Enforce authorization on AJAX mutation endpoints

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -112,6 +112,7 @@ return static function (ContainerConfigurator $container): void {
         ->arg(0, service('datatables.mutation.locator'))
         ->arg(1, service('property_accessor'))
         ->arg(2, service(MercurePublisherInterface::class))
+        ->arg(3, service('datatables.security.permission_checker'))
         ->private();
 
     $services->set('datatables.event_listener.mutation_exception', MutationExceptionListener::class)

--- a/src/Exception/MutationNotAllowedException.php
+++ b/src/Exception/MutationNotAllowedException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Exception;
+
+final class MutationNotAllowedException extends MutationException
+{
+    public function __construct(string $message = 'You are not allowed to perform this action.')
+    {
+        parent::__construct($message);
+    }
+
+    public function getStatusCode(): int
+    {
+        return 403;
+    }
+}

--- a/src/Mutation/EntityMutator.php
+++ b/src/Mutation/EntityMutator.php
@@ -6,8 +6,10 @@ namespace Pentiminax\UX\DataTables\Mutation;
 
 use Pentiminax\UX\DataTables\Exception\EntityNotFoundException;
 use Pentiminax\UX\DataTables\Exception\FieldNotToggleableException;
+use Pentiminax\UX\DataTables\Exception\MutationNotAllowedException;
 use Pentiminax\UX\DataTables\Exception\PropertyNotWritableException;
 use Pentiminax\UX\DataTables\Mercure\MercurePublisherInterface;
+use Pentiminax\UX\DataTables\Security\PermissionChecker;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 final class EntityMutator
@@ -16,6 +18,7 @@ final class EntityMutator
         private readonly EntityLocator $locator,
         private readonly PropertyAccessorInterface $propertyAccessor,
         private readonly MercurePublisherInterface $publisher,
+        private readonly PermissionChecker $permissionChecker = new PermissionChecker(),
     ) {
     }
 
@@ -23,10 +26,15 @@ final class EntityMutator
      * @param string|string[] $topics
      *
      * @throws EntityNotFoundException
+     * @throws MutationNotAllowedException
      */
     public function delete(string $entityClass, int|string $id, string|array $topics = []): void
     {
         $context = $this->locator->locate($entityClass, $id);
+
+        if (!$this->permissionChecker->isGranted('DELETE', $context->entity)) {
+            throw new MutationNotAllowedException();
+        }
 
         $context->manager->remove($context->entity);
         $context->manager->flush();
@@ -44,11 +52,16 @@ final class EntityMutator
      *
      * @throws EntityNotFoundException
      * @throws FieldNotToggleableException
+     * @throws MutationNotAllowedException
      * @throws PropertyNotWritableException
      */
     public function setProperty(string $entityClass, int|string $id, string $field, bool $value, string|array $topics = []): void
     {
         $context = $this->locator->locate($entityClass, $id);
+
+        if (!$this->permissionChecker->isGranted('EDIT', $context->entity)) {
+            throw new MutationNotAllowedException();
+        }
 
         $metadata = $context->manager->getClassMetadata($entityClass);
 

--- a/tests/Unit/Exception/MutationExceptionTest.php
+++ b/tests/Unit/Exception/MutationExceptionTest.php
@@ -6,6 +6,7 @@ namespace Pentiminax\UX\DataTables\Tests\Unit\Exception;
 
 use Pentiminax\UX\DataTables\Exception\EntityNotFoundException;
 use Pentiminax\UX\DataTables\Exception\MutationException;
+use Pentiminax\UX\DataTables\Exception\MutationNotAllowedException;
 use Pentiminax\UX\DataTables\Exception\PropertyNotWritableException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -16,6 +17,7 @@ use PHPUnit\Framework\TestCase;
  */
 #[CoversClass(MutationException::class)]
 #[CoversClass(EntityNotFoundException::class)]
+#[CoversClass(MutationNotAllowedException::class)]
 #[CoversClass(PropertyNotWritableException::class)]
 final class MutationExceptionTest extends TestCase
 {
@@ -37,5 +39,15 @@ final class MutationExceptionTest extends TestCase
         $this->assertInstanceOf(MutationException::class, $exception);
         $this->assertSame(400, $exception->getStatusCode());
         $this->assertSame('Unable to write "isEnabled" on the entity.', $exception->getClientMessage());
+    }
+
+    #[Test]
+    public function mutation_not_allowed_maps_to_403_with_default_message(): void
+    {
+        $exception = new MutationNotAllowedException();
+
+        $this->assertInstanceOf(MutationException::class, $exception);
+        $this->assertSame(403, $exception->getStatusCode());
+        $this->assertSame('You are not allowed to perform this action.', $exception->getClientMessage());
     }
 }

--- a/tests/Unit/Mutation/EntityMutatorTest.php
+++ b/tests/Unit/Mutation/EntityMutatorTest.php
@@ -10,14 +10,17 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Persistence\ManagerRegistry;
 use Pentiminax\UX\DataTables\Exception\EntityNotFoundException;
 use Pentiminax\UX\DataTables\Exception\FieldNotToggleableException;
+use Pentiminax\UX\DataTables\Exception\MutationNotAllowedException;
 use Pentiminax\UX\DataTables\Exception\PropertyNotWritableException;
 use Pentiminax\UX\DataTables\Mercure\MercurePublisherInterface;
 use Pentiminax\UX\DataTables\Mutation\EntityLocator;
 use Pentiminax\UX\DataTables\Mutation\EntityMutator;
+use Pentiminax\UX\DataTables\Security\PermissionChecker;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 /**
  * @internal
@@ -113,6 +116,69 @@ final class EntityMutatorTest extends TestCase
     }
 
     #[Test]
+    public function it_denies_deletion_and_does_not_remove_or_flush_when_not_granted(): void
+    {
+        $entity = new EntityMutatorFixture();
+
+        $manager = $this->managerReturning($entity, 5);
+        $manager->expects($this->never())->method('remove');
+        $manager->expects($this->never())->method('flush');
+
+        $publisher = $this->createMock(MercurePublisherInterface::class);
+        $publisher->expects($this->never())->method('publish');
+
+        $mutator = new EntityMutator(
+            new EntityLocator($this->registry($manager)),
+            $this->createMock(PropertyAccessorInterface::class),
+            $publisher,
+            $this->denyingChecker('DELETE', $entity),
+        );
+
+        $this->expectException(MutationNotAllowedException::class);
+
+        try {
+            $mutator->delete(EntityMutatorFixture::class, 5, ['/topic/5']);
+        } catch (MutationNotAllowedException $exception) {
+            $this->assertSame(403, $exception->getStatusCode());
+
+            throw $exception;
+        }
+    }
+
+    #[Test]
+    public function it_denies_property_write_and_does_not_set_value_or_flush_when_not_granted(): void
+    {
+        $entity = new EntityMutatorFixture();
+
+        $manager = $this->managerReturning($entity, 5);
+        $manager->expects($this->never())->method('flush');
+
+        $accessor = $this->createMock(PropertyAccessorInterface::class);
+        $accessor->expects($this->never())->method('isWritable');
+        $accessor->expects($this->never())->method('setValue');
+
+        $publisher = $this->createMock(MercurePublisherInterface::class);
+        $publisher->expects($this->never())->method('publish');
+
+        $mutator = new EntityMutator(
+            new EntityLocator($this->registry($manager)),
+            $accessor,
+            $publisher,
+            $this->denyingChecker('EDIT', $entity),
+        );
+
+        $this->expectException(MutationNotAllowedException::class);
+
+        try {
+            $mutator->setProperty(EntityMutatorFixture::class, 5, 'enabled', true, ['/topic/5']);
+        } catch (MutationNotAllowedException $exception) {
+            $this->assertSame(403, $exception->getStatusCode());
+
+            throw $exception;
+        }
+    }
+
+    #[Test]
     public function it_propagates_not_found_from_the_locator_on_delete(): void
     {
         $manager    = $this->createMock(EntityManagerInterface::class);
@@ -161,6 +227,14 @@ final class EntityMutatorTest extends TestCase
         $registry->method('getManagerForClass')->with(EntityMutatorFixture::class)->willReturn($manager);
 
         return $registry;
+    }
+
+    private function denyingChecker(string $attribute, object $subject): PermissionChecker
+    {
+        $checker = $this->createMock(AuthorizationCheckerInterface::class);
+        $checker->method('isGranted')->with($attribute, $subject)->willReturn(false);
+
+        return new PermissionChecker($checker);
     }
 }
 


### PR DESCRIPTION
Closes #236

## Problem

The AJAX mutation endpoints (`AjaxDeleteController` and `AjaxEditController`) accepted an arbitrary entity FQCN + id, loaded the entity, and deleted/edited it with **no authorization check**. Any authenticated user could delete or toggle fields on any entity by id (IDOR / mass deletion).

## Change

`EntityMutator` now performs a server-side authorization check on the **loaded entity** before any mutation:

- `delete()` calls `PermissionChecker::isGranted('DELETE', $entity)` before `remove()`/`flush()`.
- `setProperty()` calls `PermissionChecker::isGranted('EDIT', $entity)` before `setValue()`/`flush()`.
- When denied, a new `MutationNotAllowedException` (HTTP 403) is thrown, so the existing `MutationExceptionListener` returns a clean JSON 403 response.

The `PermissionChecker` is injected via the already DI-wired `datatables.security.permission_checker` service (`config/services.php`). Its intentional grant-all fallback when no security checker is available (CLI/tests) is preserved, so behavior is unchanged where no real checker is present. The constructor argument is optional (defaults to a no-op `PermissionChecker`), keeping existing call sites source-compatible.

Scope is limited to issue #236. The field-allowlist for the boolean toggle (#237) is intentionally out of scope.

## Files changed

- `src/Mutation/EntityMutator.php` — inject `PermissionChecker`, guard `delete`/`setProperty`.
- `src/Exception/MutationNotAllowedException.php` — new 403 `MutationException` subclass.
- `config/services.php` — wire the permission checker into the mutator service.
- `tests/Unit/Mutation/EntityMutatorTest.php` — denied-delete and denied-edit cases (no `remove`/`setValue`/`flush`).
- `tests/Unit/Exception/MutationExceptionTest.php` — 403 mapping for the new exception.

## How to verify

- `composer install`
- `vendor/bin/phpunit` — green (786 tests, including the new denial cases).
- `composer fix` — no style changes required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2XDb66N37YxbuVWZ6eKpc

---
_Generated by [Claude Code](https://claude.ai/code/session_01L2XDb66N37YxbuVWZ6eKpc)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This is a security fix on mutation endpoints (IDOR/mass delete); behavior changes for users who previously could mutate entities without matching Symfony voters.
> 
> **Overview**
> **Closes an authorization gap on AJAX delete and inline boolean edit** by checking Symfony permissions on the loaded entity before any persistence or Mercure publish.
> 
> `EntityMutator` now requires `DELETE` on the entity for `delete()` and `EDIT` for `setProperty()` via the existing `PermissionChecker` (wired as the mutator’s fourth constructor argument in `config/services.php`). Denied requests throw `MutationNotAllowedException`, which maps to HTTP **403** and is handled like other mutation errors by `MutationExceptionListener`. Unit tests cover denied delete/edit (no `remove`, `setValue`, `flush`, or publish) and the new exception’s status/message.
> 
> The optional default `PermissionChecker` on the constructor keeps direct instantiation in tests source-compatible; when no authorization checker is available, `PermissionChecker` still grants all (unchanged for CLI/tests without security).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6460ad0444ef226776c443c2fa8069c6c524d77e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->