### PR TITLE
fix(security): restrict boolean toggle to mapped boolean fields (#237)

### DIFF
--- a/src/Exception/FieldNotToggleableException.php
+++ b/src/Exception/FieldNotToggleableException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Exception;
+
+final class FieldNotToggleableException extends MutationException
+{
+    public function __construct(string $field)
+    {
+        parent::__construct(\sprintf('The field "%s" is not a toggleable boolean field.', $field));
+    }
+
+    public function getStatusCode(): int
+    {
+        return 403;
+    }
+}

--- a/src/Mutation/EntityMutator.php
+++ b/src/Mutation/EntityMutator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pentiminax\UX\DataTables\Mutation;
 
 use Pentiminax\UX\DataTables\Exception\EntityNotFoundException;
+use Pentiminax\UX\DataTables\Exception\FieldNotToggleableException;
 use Pentiminax\UX\DataTables\Exception\PropertyNotWritableException;
 use Pentiminax\UX\DataTables\Mercure\MercurePublisherInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
@@ -42,11 +43,18 @@ final class EntityMutator
      * @param string|string[] $topics
      *
      * @throws EntityNotFoundException
+     * @throws FieldNotToggleableException
      * @throws PropertyNotWritableException
      */
     public function setProperty(string $entityClass, int|string $id, string $field, bool $value, string|array $topics = []): void
     {
         $context = $this->locator->locate($entityClass, $id);
+
+        $metadata = $context->manager->getClassMetadata($entityClass);
+
+        if (!$metadata->hasField($field) || 'boolean' !== $metadata->getTypeOfField($field)) {
+            throw new FieldNotToggleableException($field);
+        }
 
         if (!$this->propertyAccessor->isWritable($context->entity, $field)) {
             throw new PropertyNotWritableException($field);

--- a/tests/Unit/Controller/AjaxEditControllerTest.php
+++ b/tests/Unit/Controller/AjaxEditControllerTest.php
@@ -6,10 +6,12 @@ namespace Pentiminax\UX\DataTables\Tests\Unit\Controller;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Persistence\ManagerRegistry;
 use Pentiminax\UX\DataTables\Controller\AjaxEditController;
 use Pentiminax\UX\DataTables\Dto\AjaxEditRequestDto;
 use Pentiminax\UX\DataTables\Exception\EntityNotFoundException;
+use Pentiminax\UX\DataTables\Exception\FieldNotToggleableException;
 use Pentiminax\UX\DataTables\Exception\PropertyNotWritableException;
 use Pentiminax\UX\DataTables\Mercure\NullMercurePublisher;
 use Pentiminax\UX\DataTables\Mutation\EntityLocator;
@@ -90,6 +92,25 @@ final class AjaxEditControllerTest extends TestCase
     }
 
     #[Test]
+    public function it_rejects_a_field_that_is_not_a_mapped_boolean(): void
+    {
+        $entity = new ToggleBooleanEntityFixture();
+
+        $accessor = $this->createMock(PropertyAccessorInterface::class);
+        $accessor->expects($this->never())->method('setValue');
+
+        $controller = $this->controller($entity, 799, $accessor, expectFlush: false);
+
+        $this->expectException(FieldNotToggleableException::class);
+        $controller(new AjaxEditRequestDto(
+            entity: ToggleBooleanEntityFixture::class,
+            field: 'admin',
+            id: 799,
+            newValue: true,
+        ));
+    }
+
+    #[Test]
     public function it_lets_a_missing_entity_bubble_as_an_exception(): void
     {
         $accessor = $this->createMock(PropertyAccessorInterface::class);
@@ -115,8 +136,13 @@ final class AjaxEditControllerTest extends TestCase
         $repository = $this->createMock(EntityRepository::class);
         $repository->method('find')->with($id)->willReturn($entity);
 
+        $metadata = $this->createMock(ClassMetadata::class);
+        $metadata->method('hasField')->willReturnCallback(static fn (string $name): bool => 'isEmailAuthEnabled' === $name);
+        $metadata->method('getTypeOfField')->willReturnCallback(static fn (string $name): ?string => 'isEmailAuthEnabled' === $name ? 'boolean' : null);
+
         $manager = $this->createMock(EntityManagerInterface::class);
         $manager->method('getRepository')->with(ToggleBooleanEntityFixture::class)->willReturn($repository);
+        $manager->method('getClassMetadata')->willReturn($metadata);
         $manager->expects($expectFlush ? $this->once() : $this->never())->method('flush');
 
         $registry = $this->createMock(ManagerRegistry::class);

--- a/tests/Unit/Mutation/EntityMutatorTest.php
+++ b/tests/Unit/Mutation/EntityMutatorTest.php
@@ -6,8 +6,10 @@ namespace Pentiminax\UX\DataTables\Tests\Unit\Mutation;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Persistence\ManagerRegistry;
 use Pentiminax\UX\DataTables\Exception\EntityNotFoundException;
+use Pentiminax\UX\DataTables\Exception\FieldNotToggleableException;
 use Pentiminax\UX\DataTables\Exception\PropertyNotWritableException;
 use Pentiminax\UX\DataTables\Mercure\MercurePublisherInterface;
 use Pentiminax\UX\DataTables\Mutation\EntityLocator;
@@ -91,6 +93,26 @@ final class EntityMutatorTest extends TestCase
     }
 
     #[Test]
+    public function it_throws_and_does_not_flush_when_the_field_is_not_a_mapped_boolean(): void
+    {
+        $entity = new EntityMutatorFixture();
+
+        $manager = $this->managerReturning($entity, 5);
+        $manager->expects($this->never())->method('flush');
+
+        $accessor = $this->createMock(PropertyAccessorInterface::class);
+        $accessor->expects($this->never())->method('setValue');
+
+        $publisher = $this->createMock(MercurePublisherInterface::class);
+        $publisher->expects($this->never())->method('publish');
+
+        $mutator = new EntityMutator(new EntityLocator($this->registry($manager)), $accessor, $publisher);
+
+        $this->expectException(FieldNotToggleableException::class);
+        $mutator->setProperty(EntityMutatorFixture::class, 5, 'admin', true, ['/topic/5']);
+    }
+
+    #[Test]
     public function it_propagates_not_found_from_the_locator_on_delete(): void
     {
         $manager    = $this->createMock(EntityManagerInterface::class);
@@ -119,8 +141,18 @@ final class EntityMutatorTest extends TestCase
 
         $manager = $this->createMock(EntityManagerInterface::class);
         $manager->method('getRepository')->with(EntityMutatorFixture::class)->willReturn($repository);
+        $manager->method('getClassMetadata')->willReturn($this->booleanFieldMetadata('enabled'));
 
         return $manager;
+    }
+
+    private function booleanFieldMetadata(string $field): ClassMetadata
+    {
+        $metadata = $this->createMock(ClassMetadata::class);
+        $metadata->method('hasField')->willReturnCallback(static fn (string $name): bool => $name === $field);
+        $metadata->method('getTypeOfField')->willReturnCallback(static fn (string $name): ?string => $name === $field ? 'boolean' : null);
+
+        return $metadata;
     }
 
     private function registry(EntityManagerInterface $manager): ManagerRegistry

--- a/tests/Unit/Mutation/MutationExceptionHandlingTest.php
+++ b/tests/Unit/Mutation/MutationExceptionHandlingTest.php
@@ -6,6 +6,7 @@ namespace Pentiminax\UX\DataTables\Tests\Unit\Mutation;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Persistence\ManagerRegistry;
 use Pentiminax\UX\DataTables\Controller\AjaxDeleteController;
 use Pentiminax\UX\DataTables\Controller\AjaxEditController;
@@ -117,8 +118,13 @@ final class MutationExceptionHandlingTest extends TestCase
         $repository = $this->createMock(EntityRepository::class);
         $repository->method('find')->willReturn($entity);
 
+        $metadata = $this->createMock(ClassMetadata::class);
+        $metadata->method('hasField')->willReturnCallback(static fn (string $name): bool => 'enabled' === $name);
+        $metadata->method('getTypeOfField')->willReturnCallback(static fn (string $name): ?string => 'enabled' === $name ? 'boolean' : null);
+
         $manager = $this->createMock(EntityManagerInterface::class);
         $manager->method('getRepository')->with(MutationExceptionHandlingFixture::class)->willReturn($repository);
+        $manager->method('getClassMetadata')->willReturn($metadata);
 
         $registry = $this->createMock(ManagerRegistry::class);
         $registry->method('getManagerForClass')->with(MutationExceptionHandlingFixture::class)->willReturn($manager);


### PR DESCRIPTION
Closes #237

## Problem

The inline boolean toggle endpoint (`AjaxEditController::__invoke` → `EntityMutator::setProperty`) only verified that the target property was writable via the Symfony `PropertyAccessor` (`isWritable()`). Because the `field` came straight from the request payload, an attacker could flip **any** writable boolean-ish property (`admin`, `enabled`, `isVerified`, …) on **any** entity reachable by the endpoint — a privilege-escalation vector.

## Fix

`EntityMutator::setProperty()` now resolves the target entity's Doctrine `ClassMetadata` (via `$context->manager->getClassMetadata($entityClass)`) and rejects the write unless the requested `field` is a **mapped Doctrine field of type `boolean`**:

- `hasField($field)` must be true, and
- `getTypeOfField($field)` must equal `'boolean'`.

If not, a new `FieldNotToggleableException` (HTTP 403) is thrown. It extends the existing `MutationException`, so `MutationExceptionListener` renders it as a clean JSON error, consistent with the other mutation exceptions. This blocks toggling non-boolean columns, computed/virtual properties, and any property not mapped by Doctrine.

The existing `PropertyNotWritableException` behavior is preserved as a secondary guard for genuinely non-writable boolean fields.

### Files

- `src/Exception/FieldNotToggleableException.php` (new) — 403 mutation exception.
- `src/Mutation/EntityMutator.php` — boolean-field-mapping guard added to `setProperty()`.
- Tests updated/added in `tests/Unit/Mutation/EntityMutatorTest.php`, `tests/Unit/Controller/AjaxEditControllerTest.php`, `tests/Unit/Mutation/MutationExceptionHandlingTest.php`.

## Tests

- `setProperty` with a `field` that is not a mapped boolean → throws `FieldNotToggleableException`, no `setValue`/`flush`.
- `setProperty` with a valid mapped boolean field → writes and flushes as before.
- Controller-level test rejecting a non-boolean field.
- Existing tests adjusted so their manager mocks return `ClassMetadata` describing the boolean field.

## Verification

- `composer install` — OK
- `vendor/bin/phpunit` — 785 tests, 2035 assertions, green
- `php-cs-fixer fix` — no changes (code already conforms)

## Scope / related

This PR is intentionally scoped to the **field restriction** for the boolean toggle only. The general authorization guard (verifying the current user may edit the target entity/field) is tracked separately in #236 and is a complementary/prerequisite hardening step. This diff is standalone and applies cleanly on top of `origin/main` without depending on #236.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2XDb66N37YxbuVWZ6eKpc

---
_Generated by [Claude Code](https://claude.ai/code/session_01L2XDb66N37YxbuVWZ6eKpc)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a targeted security fix on entity mutation, but it changes which fields the toggle endpoint accepts and could break callers that relied on toggling non-mapped or non-boolean properties.
> 
> **Overview**
> **Closes a privilege-escalation gap** on the inline boolean toggle path (`EntityMutator::setProperty`): the request `field` is no longer trusted based only on `PropertyAccessor::isWritable()`.
> 
> Before writing, the mutator loads Doctrine `ClassMetadata` and allows the update only when the field is a **mapped field** with type **`boolean`**. Anything else raises a new **`FieldNotToggleableException`** (HTTP **403**), which extends `MutationException` so `MutationExceptionListener` returns the same JSON error shape as other mutation failures. The existing `PropertyNotWritableException` check still runs for valid boolean fields that are not writable.
> 
> Unit tests add rejection cases (no `setValue` / `flush` / publish) and adjust entity-manager mocks to supply `ClassMetadata` for happy-path boolean toggles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13a68f393c7480456fe71a32de91717a13b83fe8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->