### PR TITLE
fix(mercure): address PR #255 review feedback on mutation topic resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ vendor/
 .phpunit.cache/
 .phpunit.result.cache
 .php_cs.cache
+config/reference.php
 
 assets/package-lock.json
 assets/node_modules/

--- a/assets/src/controller.ts
+++ b/assets/src/controller.ts
@@ -282,6 +282,7 @@ export default class extends Controller {
                     const response = await deleteEntity({
                         entity,
                         id,
+                        dataTableClass: payload.dataTableClass ?? null,
                     })
 
                     if (response.ok) {
@@ -369,6 +370,7 @@ export default class extends Controller {
                     entity,
                     newValue: target.checked,
                     method,
+                    dataTableClass: payload.dataTableClass ?? null,
                 })
 
                 if (!response.ok) {

--- a/assets/src/controller.ts
+++ b/assets/src/controller.ts
@@ -282,7 +282,6 @@ export default class extends Controller {
                     const response = await deleteEntity({
                         entity,
                         id,
-                        topics: this.getMercureTopics(payload),
                     })
 
                     if (response.ok) {
@@ -312,7 +311,6 @@ export default class extends Controller {
                                     entity,
                                     id,
                                     formData,
-                                    topics: this.getMercureTopics(payload),
                                     dataTableClass: payload.dataTableClass ?? null,
                                 })
 
@@ -371,7 +369,6 @@ export default class extends Controller {
                     entity,
                     newValue: target.checked,
                     method,
-                    topics: this.getMercureTopics(payload),
                 })
 
                 if (!response.ok) {

--- a/assets/src/functions/deleteEntity.ts
+++ b/assets/src/functions/deleteEntity.ts
@@ -1,11 +1,17 @@
 export async function deleteEntity({
     entity,
     id,
+    dataTableClass,
 }: {
     entity: string
     id: string
+    dataTableClass?: string | null
 }): Promise<Response> {
     const body: Record<string, unknown> = { entity, id: isNaN(Number(id)) ? id : Number(id) }
+
+    if (dataTableClass) {
+        body.dataTableClass = dataTableClass
+    }
 
     return await fetch('/datatables/ajax/delete', {
         method: 'DELETE',

--- a/assets/src/functions/deleteEntity.ts
+++ b/assets/src/functions/deleteEntity.ts
@@ -1,17 +1,11 @@
 export async function deleteEntity({
     entity,
     id,
-    topics,
 }: {
     entity: string
     id: string
-    topics?: string[]
 }): Promise<Response> {
     const body: Record<string, unknown> = { entity, id: isNaN(Number(id)) ? id : Number(id) }
-
-    if (topics && topics.length > 0) {
-        body.topics = topics
-    }
 
     return await fetch('/datatables/ajax/delete', {
         method: 'DELETE',

--- a/assets/src/functions/submitEditForm.ts
+++ b/assets/src/functions/submitEditForm.ts
@@ -2,7 +2,6 @@ type SubmitEditFormPayload = {
     entity: string
     id: string
     formData: Record<string, any>
-    topics?: string[]
     dataTableClass: string | null
 }
 
@@ -24,7 +23,6 @@ export async function submitEditForm(
             entity: payload.entity,
             id: payload.id,
             formData: payload.formData,
-            topics: payload.topics ?? [],
             dataTableClass: payload.dataTableClass,
         }),
     })

--- a/assets/src/functions/toggleBooleanValue.ts
+++ b/assets/src/functions/toggleBooleanValue.ts
@@ -5,7 +5,6 @@ type ToggleBooleanPayload = {
     newValue: boolean
     url: string
     method?: string
-    topics?: string[]
 }
 
 export async function toggleBooleanValue({
@@ -15,7 +14,6 @@ export async function toggleBooleanValue({
     newValue,
     url,
     method = 'PATCH',
-    topics,
 }: ToggleBooleanPayload): Promise<Response> {
     const numericId = Number(id)
     const body: Record<string, unknown> = {
@@ -23,10 +21,6 @@ export async function toggleBooleanValue({
         entity,
         field,
         newValue,
-    }
-
-    if (Array.isArray(topics) && topics.length > 0) {
-        body.topics = topics
     }
 
     return await fetch(url, {

--- a/assets/src/functions/toggleBooleanValue.ts
+++ b/assets/src/functions/toggleBooleanValue.ts
@@ -5,6 +5,7 @@ type ToggleBooleanPayload = {
     newValue: boolean
     url: string
     method?: string
+    dataTableClass?: string | null
 }
 
 export async function toggleBooleanValue({
@@ -14,6 +15,7 @@ export async function toggleBooleanValue({
     newValue,
     url,
     method = 'PATCH',
+    dataTableClass,
 }: ToggleBooleanPayload): Promise<Response> {
     const numericId = Number(id)
     const body: Record<string, unknown> = {
@@ -21,6 +23,10 @@ export async function toggleBooleanValue({
         entity,
         field,
         newValue,
+    }
+
+    if (dataTableClass) {
+        body.dataTableClass = dataTableClass
     }
 
     return await fetch(url, {

--- a/config/form.php
+++ b/config/form.php
@@ -10,8 +10,8 @@ use Pentiminax\UX\DataTables\Form\EditFormBuilder;
 use Pentiminax\UX\DataTables\Form\EditFormService;
 use Pentiminax\UX\DataTables\Form\EditModalRenderer;
 use Pentiminax\UX\DataTables\Form\EditModalTemplateResolver;
-use Pentiminax\UX\DataTables\Mercure\MercureConfigResolverInterface;
 use Pentiminax\UX\DataTables\Mercure\MercurePublisherInterface;
+use Pentiminax\UX\DataTables\Mercure\MercureTopicResolverInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
@@ -49,7 +49,7 @@ return static function (ContainerConfigurator $container): void {
         ->arg(2, service('datatables.form.edit_modal_renderer'))
         ->arg(3, service('datatables.form.edit_modal_template_resolver'))
         ->arg(4, service(MercurePublisherInterface::class))
-        ->arg(5, service(MercureConfigResolverInterface::class)->nullOnInvalid())
+        ->arg(5, service(MercureTopicResolverInterface::class)->nullOnInvalid())
         ->private();
 
     $services->set('datatables.controller.ajax_edit_form', AjaxEditFormController::class)

--- a/config/form.php
+++ b/config/form.php
@@ -10,6 +10,7 @@ use Pentiminax\UX\DataTables\Form\EditFormBuilder;
 use Pentiminax\UX\DataTables\Form\EditFormService;
 use Pentiminax\UX\DataTables\Form\EditModalRenderer;
 use Pentiminax\UX\DataTables\Form\EditModalTemplateResolver;
+use Pentiminax\UX\DataTables\Mercure\MercureConfigResolverInterface;
 use Pentiminax\UX\DataTables\Mercure\MercurePublisherInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
@@ -48,6 +49,7 @@ return static function (ContainerConfigurator $container): void {
         ->arg(2, service('datatables.form.edit_modal_renderer'))
         ->arg(3, service('datatables.form.edit_modal_template_resolver'))
         ->arg(4, service(MercurePublisherInterface::class))
+        ->arg(5, service(MercureConfigResolverInterface::class)->nullOnInvalid())
         ->private();
 
     $services->set('datatables.controller.ajax_edit_form', AjaxEditFormController::class)

--- a/config/mercure.php
+++ b/config/mercure.php
@@ -7,10 +7,13 @@ use Pentiminax\UX\DataTables\Mercure\MercureConfigResolverInterface;
 use Pentiminax\UX\DataTables\Mercure\MercureHubUrlResolver;
 use Pentiminax\UX\DataTables\Mercure\MercureHubUrlResolverInterface;
 use Pentiminax\UX\DataTables\Mercure\MercurePublisherInterface;
+use Pentiminax\UX\DataTables\Mercure\MercureTopicResolver;
+use Pentiminax\UX\DataTables\Mercure\MercureTopicResolverInterface;
 use Pentiminax\UX\DataTables\Mercure\MercureUpdatePublisher;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_locator;
 
 return static function (ContainerConfigurator $container): void {
     $services = $container->services();
@@ -28,6 +31,14 @@ return static function (ContainerConfigurator $container): void {
         ->private();
 
     $services->alias(MercureConfigResolverInterface::class, 'datatables.mercure.config_resolver')
+        ->private();
+
+    $services->set('datatables.mercure.topic_resolver', MercureTopicResolver::class)
+        ->arg(0, tagged_locator('datatables.data_table'))
+        ->arg(1, service('datatables.mercure.config_resolver')->nullOnInvalid())
+        ->private();
+
+    $services->alias(MercureTopicResolverInterface::class, 'datatables.mercure.topic_resolver')
         ->private();
 
     $services->set('datatables.mercure.publisher', MercureUpdatePublisher::class)

--- a/config/services.php
+++ b/config/services.php
@@ -112,6 +112,7 @@ return static function (ContainerConfigurator $container): void {
         ->arg(0, service('datatables.mutation.locator'))
         ->arg(1, service('property_accessor'))
         ->arg(2, service(MercurePublisherInterface::class))
+        ->arg(3, service(MercureConfigResolverInterface::class)->nullOnInvalid())
         ->private();
 
     $services->set('datatables.event_listener.mutation_exception', MutationExceptionListener::class)

--- a/config/services.php
+++ b/config/services.php
@@ -25,6 +25,7 @@ use Pentiminax\UX\DataTables\EventListener\MutationExceptionListener;
 use Pentiminax\UX\DataTables\Mercure\MercureConfigResolverInterface;
 use Pentiminax\UX\DataTables\Mercure\MercureHubUrlResolverInterface;
 use Pentiminax\UX\DataTables\Mercure\MercurePublisherInterface;
+use Pentiminax\UX\DataTables\Mercure\MercureTopicResolverInterface;
 use Pentiminax\UX\DataTables\Mercure\NullMercurePublisher;
 use Pentiminax\UX\DataTables\Mutation\EntityLocator;
 use Pentiminax\UX\DataTables\Mutation\EntityMutator;
@@ -112,7 +113,7 @@ return static function (ContainerConfigurator $container): void {
         ->arg(0, service('datatables.mutation.locator'))
         ->arg(1, service('property_accessor'))
         ->arg(2, service(MercurePublisherInterface::class))
-        ->arg(3, service(MercureConfigResolverInterface::class)->nullOnInvalid())
+        ->arg(3, service(MercureTopicResolverInterface::class)->nullOnInvalid())
         ->private();
 
     $services->set('datatables.event_listener.mutation_exception', MutationExceptionListener::class)

--- a/src/Controller/AjaxDeleteController.php
+++ b/src/Controller/AjaxDeleteController.php
@@ -19,7 +19,7 @@ final class AjaxDeleteController
 
     public function __invoke(#[MapRequestPayload] AjaxDeleteRequestDto $payload): Response
     {
-        $this->mutator->delete($payload->entity, $payload->id);
+        $this->mutator->delete($payload->entity, $payload->id, $payload->dataTableClass);
 
         return new JsonResponse(['success' => true]);
     }

--- a/src/Controller/AjaxDeleteController.php
+++ b/src/Controller/AjaxDeleteController.php
@@ -19,7 +19,7 @@ final class AjaxDeleteController
 
     public function __invoke(#[MapRequestPayload] AjaxDeleteRequestDto $payload): Response
     {
-        $this->mutator->delete($payload->entity, $payload->id, $payload->topics);
+        $this->mutator->delete($payload->entity, $payload->id);
 
         return new JsonResponse(['success' => true]);
     }

--- a/src/Controller/AjaxEditController.php
+++ b/src/Controller/AjaxEditController.php
@@ -23,6 +23,7 @@ final class AjaxEditController
             id: $payload->id,
             field: $payload->field,
             value: $payload->newValue,
+            dataTableClass: $payload->dataTableClass,
         );
 
         return new Response($payload->newValue ? '1' : '0');

--- a/src/Controller/AjaxEditController.php
+++ b/src/Controller/AjaxEditController.php
@@ -23,7 +23,6 @@ final class AjaxEditController
             id: $payload->id,
             field: $payload->field,
             value: $payload->newValue,
-            topics: $payload->topics,
         );
 
         return new Response($payload->newValue ? '1' : '0');

--- a/src/Dto/AjaxDeleteRequestDto.php
+++ b/src/Dto/AjaxDeleteRequestDto.php
@@ -9,6 +9,7 @@ final readonly class AjaxDeleteRequestDto
     public function __construct(
         public string $entity,
         public int|string $id,
+        public ?string $dataTableClass = null,
     ) {
     }
 }

--- a/src/Dto/AjaxDeleteRequestDto.php
+++ b/src/Dto/AjaxDeleteRequestDto.php
@@ -9,7 +9,6 @@ final readonly class AjaxDeleteRequestDto
     public function __construct(
         public string $entity,
         public int|string $id,
-        public array $topics = [],
     ) {
     }
 }

--- a/src/Dto/AjaxEditFormRequestDto.php
+++ b/src/Dto/AjaxEditFormRequestDto.php
@@ -10,7 +10,6 @@ final readonly class AjaxEditFormRequestDto
         public string $entity,
         public int|string $id,
         public array $formData = [],
-        public array $topics = [],
         public ?string $dataTableClass = null,
     ) {
     }

--- a/src/Dto/AjaxEditRequestDto.php
+++ b/src/Dto/AjaxEditRequestDto.php
@@ -11,6 +11,7 @@ final readonly class AjaxEditRequestDto
         public string $field,
         public int $id,
         public bool $newValue,
+        public ?string $dataTableClass = null,
     ) {
     }
 }

--- a/src/Dto/AjaxEditRequestDto.php
+++ b/src/Dto/AjaxEditRequestDto.php
@@ -11,7 +11,6 @@ final readonly class AjaxEditRequestDto
         public string $field,
         public int $id,
         public bool $newValue,
-        public array $topics = [],
     ) {
     }
 }

--- a/src/Form/EditFormService.php
+++ b/src/Form/EditFormService.php
@@ -8,6 +8,7 @@ use Pentiminax\UX\DataTables\Contracts\EditModalTemplateResolverInterface;
 use Pentiminax\UX\DataTables\Dto\AjaxEditFormQueryDto;
 use Pentiminax\UX\DataTables\Dto\AjaxEditFormRequestDto;
 use Pentiminax\UX\DataTables\Exception\EntityNotFoundException;
+use Pentiminax\UX\DataTables\Mercure\MercureConfigResolverInterface;
 use Pentiminax\UX\DataTables\Mercure\MercurePublisherInterface;
 use Pentiminax\UX\DataTables\Mutation\EntityLocator;
 use Pentiminax\UX\DataTables\Mutation\MutationContext;
@@ -21,6 +22,7 @@ final class EditFormService
         private readonly EditModalRenderer $renderer,
         private readonly EditModalTemplateResolverInterface $templateResolver,
         private readonly MercurePublisherInterface $publisher,
+        private readonly ?MercureConfigResolverInterface $mercureConfigResolver = null,
     ) {
     }
 
@@ -87,7 +89,7 @@ final class EditFormService
 
         $context->manager->flush();
 
-        $this->publisher->publish($payload->topics, [
+        $this->publisher->publish($this->resolveTopics($payload->entity), [
             'type' => 'edit',
             'id'   => $payload->id,
         ]);
@@ -101,6 +103,19 @@ final class EditFormService
     private function identifierFields(MutationContext $context, string $entityClass): array
     {
         return $context->manager->getClassMetadata($entityClass)->getIdentifierFieldNames();
+    }
+
+    /**
+     * Resolves the authoritative Mercure topics for the target entity server-side.
+     *
+     * Topics are never taken from the client request: they are derived from the
+     * entity configuration through the same resolver used by the render path.
+     *
+     * @return string[]
+     */
+    private function resolveTopics(string $entityClass): array
+    {
+        return $this->mercureConfigResolver?->resolveMercureConfig($entityClass)?->topics ?? [];
     }
 
     private function createRenderRequest(

--- a/src/Form/EditFormService.php
+++ b/src/Form/EditFormService.php
@@ -8,8 +8,8 @@ use Pentiminax\UX\DataTables\Contracts\EditModalTemplateResolverInterface;
 use Pentiminax\UX\DataTables\Dto\AjaxEditFormQueryDto;
 use Pentiminax\UX\DataTables\Dto\AjaxEditFormRequestDto;
 use Pentiminax\UX\DataTables\Exception\EntityNotFoundException;
-use Pentiminax\UX\DataTables\Mercure\MercureConfigResolverInterface;
 use Pentiminax\UX\DataTables\Mercure\MercurePublisherInterface;
+use Pentiminax\UX\DataTables\Mercure\MercureTopicResolverInterface;
 use Pentiminax\UX\DataTables\Mutation\EntityLocator;
 use Pentiminax\UX\DataTables\Mutation\MutationContext;
 use Symfony\Component\Form\FormInterface;
@@ -22,7 +22,7 @@ final class EditFormService
         private readonly EditModalRenderer $renderer,
         private readonly EditModalTemplateResolverInterface $templateResolver,
         private readonly MercurePublisherInterface $publisher,
-        private readonly ?MercureConfigResolverInterface $mercureConfigResolver = null,
+        private readonly ?MercureTopicResolverInterface $mercureTopicResolver = null,
     ) {
     }
 
@@ -89,7 +89,7 @@ final class EditFormService
 
         $context->manager->flush();
 
-        $this->publisher->publish($this->resolveTopics($payload->entity), [
+        $this->publisher->publish($this->resolveTopics($payload->entity, $payload->dataTableClass), [
             'type' => 'edit',
             'id'   => $payload->id,
         ]);
@@ -106,16 +106,11 @@ final class EditFormService
     }
 
     /**
-     * Resolves the authoritative Mercure topics for the target entity server-side.
-     *
-     * Topics are never taken from the client request: they are derived from the
-     * entity configuration through the same resolver used by the render path.
-     *
      * @return string[]
      */
-    private function resolveTopics(string $entityClass): array
+    private function resolveTopics(string $entityClass, ?string $dataTableClass): array
     {
-        return $this->mercureConfigResolver?->resolveMercureConfig($entityClass)?->topics ?? [];
+        return $this->mercureTopicResolver?->resolve($entityClass, $dataTableClass) ?? [];
     }
 
     private function createRenderRequest(

--- a/src/Mercure/MercureTopicResolver.php
+++ b/src/Mercure/MercureTopicResolver.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Mercure;
+
+use Pentiminax\UX\DataTables\Model\AbstractDataTable;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Resolves the authoritative Mercure topics for a mutation (delete, boolean
+ * toggle, edit-form submit) server-side, mirroring the priority order used by
+ * the render path (RenderingPreparer::configureMercure): manual DataTable
+ * configuration, then the explicit AsDataTable attribute, then the
+ * entity-based resolver fallback.
+ *
+ * Topics are never taken from the client request.
+ */
+final class MercureTopicResolver implements MercureTopicResolverInterface
+{
+    public function __construct(
+        private readonly ContainerInterface $dataTables,
+        private readonly ?MercureConfigResolverInterface $mercureConfigResolver = null,
+    ) {
+    }
+
+    /**
+     * @return string[]
+     */
+    public function resolve(string $entityClass, ?string $dataTableClass = null): array
+    {
+        $topics = $this->resolveFromDataTable($dataTableClass);
+
+        if (null !== $topics) {
+            return $topics;
+        }
+
+        return $this->mercureConfigResolver?->resolveMercureConfig($entityClass)?->topics ?? [];
+    }
+
+    /**
+     * @return string[]|null
+     */
+    private function resolveFromDataTable(?string $dataTableClass): ?array
+    {
+        if (null === $dataTableClass || !$this->dataTables->has($dataTableClass)) {
+            return null;
+        }
+
+        $dataTable = $this->dataTables->get($dataTableClass);
+
+        if (!$dataTable instanceof AbstractDataTable) {
+            return null;
+        }
+
+        $manualConfig = $dataTable->getConfiguredDataTable()->getMercureConfig();
+        if (null !== $manualConfig) {
+            return $manualConfig->topics;
+        }
+
+        return $this->resolveFromAttribute($dataTable);
+    }
+
+    /**
+     * @return string[]|null
+     */
+    private function resolveFromAttribute(AbstractDataTable $dataTable): ?array
+    {
+        $asDataTable = $dataTable->getAsDataTableAttribute();
+
+        if (null === $asDataTable || !\is_array($asDataTable->mercure)) {
+            return null;
+        }
+
+        $topics = $asDataTable->mercure['topics'] ?? [];
+
+        if (\is_string($topics)) {
+            $topics = [$topics];
+        }
+
+        if (!\is_array($topics) || [] === $topics) {
+            return null;
+        }
+
+        return $topics;
+    }
+}

--- a/src/Mercure/MercureTopicResolverInterface.php
+++ b/src/Mercure/MercureTopicResolverInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Mercure;
+
+interface MercureTopicResolverInterface
+{
+    /**
+     * @return string[]
+     */
+    public function resolve(string $entityClass, ?string $dataTableClass = null): array;
+}

--- a/src/Model/AbstractDataTable.php
+++ b/src/Model/AbstractDataTable.php
@@ -172,6 +172,13 @@ abstract class AbstractDataTable
         return $this->asDataTable?->entityClass;
     }
 
+    final public function getAsDataTableAttribute(): ?AsDataTable
+    {
+        $this->initialize();
+
+        return $this->asDataTable;
+    }
+
     /**
      * @return iterable<ColumnInterface>
      */

--- a/src/Mutation/EntityMutator.php
+++ b/src/Mutation/EntityMutator.php
@@ -6,8 +6,8 @@ namespace Pentiminax\UX\DataTables\Mutation;
 
 use Pentiminax\UX\DataTables\Exception\EntityNotFoundException;
 use Pentiminax\UX\DataTables\Exception\PropertyNotWritableException;
-use Pentiminax\UX\DataTables\Mercure\MercureConfigResolverInterface;
 use Pentiminax\UX\DataTables\Mercure\MercurePublisherInterface;
+use Pentiminax\UX\DataTables\Mercure\MercureTopicResolverInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 final class EntityMutator
@@ -16,21 +16,21 @@ final class EntityMutator
         private readonly EntityLocator $locator,
         private readonly PropertyAccessorInterface $propertyAccessor,
         private readonly MercurePublisherInterface $publisher,
-        private readonly ?MercureConfigResolverInterface $mercureConfigResolver = null,
+        private readonly ?MercureTopicResolverInterface $mercureTopicResolver = null,
     ) {
     }
 
     /**
      * @throws EntityNotFoundException
      */
-    public function delete(string $entityClass, int|string $id): void
+    public function delete(string $entityClass, int|string $id, ?string $dataTableClass = null): void
     {
         $context = $this->locator->locate($entityClass, $id);
 
         $context->manager->remove($context->entity);
         $context->manager->flush();
 
-        $this->publisher->publish($this->resolveTopics($entityClass), [
+        $this->publisher->publish($this->resolveTopics($entityClass, $dataTableClass), [
             'type' => 'delete',
             'id'   => $id,
         ]);
@@ -42,7 +42,7 @@ final class EntityMutator
      * @throws EntityNotFoundException
      * @throws PropertyNotWritableException
      */
-    public function setProperty(string $entityClass, int|string $id, string $field, bool $value): void
+    public function setProperty(string $entityClass, int|string $id, string $field, bool $value, ?string $dataTableClass = null): void
     {
         $context = $this->locator->locate($entityClass, $id);
 
@@ -53,7 +53,7 @@ final class EntityMutator
         $this->propertyAccessor->setValue($context->entity, $field, $value);
         $context->manager->flush();
 
-        $this->publisher->publish($this->resolveTopics($entityClass), [
+        $this->publisher->publish($this->resolveTopics($entityClass, $dataTableClass), [
             'type'  => 'edit',
             'id'    => $id,
             'field' => $field,
@@ -61,15 +61,10 @@ final class EntityMutator
     }
 
     /**
-     * Resolves the authoritative Mercure topics for the target entity server-side.
-     *
-     * Topics are never taken from the client request: they are derived from the
-     * entity configuration through the same resolver used by the render path.
-     *
      * @return string[]
      */
-    private function resolveTopics(string $entityClass): array
+    private function resolveTopics(string $entityClass, ?string $dataTableClass): array
     {
-        return $this->mercureConfigResolver?->resolveMercureConfig($entityClass)?->topics ?? [];
+        return $this->mercureTopicResolver?->resolve($entityClass, $dataTableClass) ?? [];
     }
 }

--- a/src/Mutation/EntityMutator.php
+++ b/src/Mutation/EntityMutator.php
@@ -6,6 +6,7 @@ namespace Pentiminax\UX\DataTables\Mutation;
 
 use Pentiminax\UX\DataTables\Exception\EntityNotFoundException;
 use Pentiminax\UX\DataTables\Exception\PropertyNotWritableException;
+use Pentiminax\UX\DataTables\Mercure\MercureConfigResolverInterface;
 use Pentiminax\UX\DataTables\Mercure\MercurePublisherInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
@@ -15,22 +16,21 @@ final class EntityMutator
         private readonly EntityLocator $locator,
         private readonly PropertyAccessorInterface $propertyAccessor,
         private readonly MercurePublisherInterface $publisher,
+        private readonly ?MercureConfigResolverInterface $mercureConfigResolver = null,
     ) {
     }
 
     /**
-     * @param string|string[] $topics
-     *
      * @throws EntityNotFoundException
      */
-    public function delete(string $entityClass, int|string $id, string|array $topics = []): void
+    public function delete(string $entityClass, int|string $id): void
     {
         $context = $this->locator->locate($entityClass, $id);
 
         $context->manager->remove($context->entity);
         $context->manager->flush();
 
-        $this->publisher->publish($topics, [
+        $this->publisher->publish($this->resolveTopics($entityClass), [
             'type' => 'delete',
             'id'   => $id,
         ]);
@@ -39,12 +39,10 @@ final class EntityMutator
     /**
      * Writes a boolean field on the entity (inline toggle use case).
      *
-     * @param string|string[] $topics
-     *
      * @throws EntityNotFoundException
      * @throws PropertyNotWritableException
      */
-    public function setProperty(string $entityClass, int|string $id, string $field, bool $value, string|array $topics = []): void
+    public function setProperty(string $entityClass, int|string $id, string $field, bool $value): void
     {
         $context = $this->locator->locate($entityClass, $id);
 
@@ -55,10 +53,23 @@ final class EntityMutator
         $this->propertyAccessor->setValue($context->entity, $field, $value);
         $context->manager->flush();
 
-        $this->publisher->publish($topics, [
+        $this->publisher->publish($this->resolveTopics($entityClass), [
             'type'  => 'edit',
             'id'    => $id,
             'field' => $field,
         ]);
+    }
+
+    /**
+     * Resolves the authoritative Mercure topics for the target entity server-side.
+     *
+     * Topics are never taken from the client request: they are derived from the
+     * entity configuration through the same resolver used by the render path.
+     *
+     * @return string[]
+     */
+    private function resolveTopics(string $entityClass): array
+    {
+        return $this->mercureConfigResolver?->resolveMercureConfig($entityClass)?->topics ?? [];
     }
 }

--- a/tests/Unit/Controller/AjaxDeleteControllerTest.php
+++ b/tests/Unit/Controller/AjaxDeleteControllerTest.php
@@ -10,9 +10,8 @@ use Doctrine\Persistence\ManagerRegistry;
 use Pentiminax\UX\DataTables\Controller\AjaxDeleteController;
 use Pentiminax\UX\DataTables\Dto\AjaxDeleteRequestDto;
 use Pentiminax\UX\DataTables\Exception\EntityNotFoundException;
-use Pentiminax\UX\DataTables\Mercure\MercureConfig;
-use Pentiminax\UX\DataTables\Mercure\MercureConfigResolverInterface;
 use Pentiminax\UX\DataTables\Mercure\MercurePublisherInterface;
+use Pentiminax\UX\DataTables\Mercure\MercureTopicResolverInterface;
 use Pentiminax\UX\DataTables\Mercure\NullMercurePublisher;
 use Pentiminax\UX\DataTables\Mutation\EntityLocator;
 use Pentiminax\UX\DataTables\Mutation\EntityMutator;
@@ -48,13 +47,10 @@ final class AjaxDeleteControllerTest extends TestCase
             ->method('publish')
             ->with(['/server/deletable-entity-fixtures/{id}'], ['type' => 'delete', 'id' => 12]);
 
-        $resolver = $this->createMock(MercureConfigResolverInterface::class);
-        $resolver->method('resolveMercureConfig')
-            ->with(DeletableEntityFixture::class)
-            ->willReturn(new MercureConfig(
-                topics: ['/server/deletable-entity-fixtures/{id}'],
-                hubUrl: 'https://hub.example/.well-known/mercure',
-            ));
+        $resolver = $this->createMock(MercureTopicResolverInterface::class);
+        $resolver->method('resolve')
+            ->with(DeletableEntityFixture::class, null)
+            ->willReturn(['/server/deletable-entity-fixtures/{id}']);
 
         $mutator    = new EntityMutator(new EntityLocator($registry), $this->createMock(PropertyAccessorInterface::class), $publisher, $resolver);
         $controller = new AjaxDeleteController($mutator);
@@ -67,6 +63,38 @@ final class AjaxDeleteControllerTest extends TestCase
         $this->assertSame(200, $response->getStatusCode());
         $payload = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
         $this->assertTrue($payload['success']);
+    }
+
+    #[Test]
+    public function it_forwards_the_data_table_class_to_the_topic_resolver(): void
+    {
+        $entity = new DeletableEntityFixture();
+
+        $repository = $this->createMock(EntityRepository::class);
+        $repository->method('find')->with(12)->willReturn($entity);
+
+        $manager = $this->createMock(EntityManagerInterface::class);
+        $manager->method('getRepository')->with(DeletableEntityFixture::class)->willReturn($repository);
+        $manager->expects($this->once())->method('remove')->with($entity);
+        $manager->expects($this->once())->method('flush');
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getManagerForClass')->with(DeletableEntityFixture::class)->willReturn($manager);
+
+        $resolver = $this->createMock(MercureTopicResolverInterface::class);
+        $resolver->expects($this->once())
+            ->method('resolve')
+            ->with(DeletableEntityFixture::class, 'SomeDataTable')
+            ->willReturn([]);
+
+        $mutator    = new EntityMutator(new EntityLocator($registry), $this->createMock(PropertyAccessorInterface::class), new NullMercurePublisher(), $resolver);
+        $controller = new AjaxDeleteController($mutator);
+
+        $controller(new AjaxDeleteRequestDto(
+            entity: DeletableEntityFixture::class,
+            id: 12,
+            dataTableClass: 'SomeDataTable',
+        ));
     }
 
     #[Test]

--- a/tests/Unit/Controller/AjaxDeleteControllerTest.php
+++ b/tests/Unit/Controller/AjaxDeleteControllerTest.php
@@ -10,6 +10,8 @@ use Doctrine\Persistence\ManagerRegistry;
 use Pentiminax\UX\DataTables\Controller\AjaxDeleteController;
 use Pentiminax\UX\DataTables\Dto\AjaxDeleteRequestDto;
 use Pentiminax\UX\DataTables\Exception\EntityNotFoundException;
+use Pentiminax\UX\DataTables\Mercure\MercureConfig;
+use Pentiminax\UX\DataTables\Mercure\MercureConfigResolverInterface;
 use Pentiminax\UX\DataTables\Mercure\MercurePublisherInterface;
 use Pentiminax\UX\DataTables\Mercure\NullMercurePublisher;
 use Pentiminax\UX\DataTables\Mutation\EntityLocator;
@@ -44,15 +46,22 @@ final class AjaxDeleteControllerTest extends TestCase
         $publisher = $this->createMock(MercurePublisherInterface::class);
         $publisher->expects($this->once())
             ->method('publish')
-            ->with(['/topic/12'], ['type' => 'delete', 'id' => 12]);
+            ->with(['/server/deletable-entity-fixtures/{id}'], ['type' => 'delete', 'id' => 12]);
 
-        $mutator    = new EntityMutator(new EntityLocator($registry), $this->createMock(PropertyAccessorInterface::class), $publisher);
+        $resolver = $this->createMock(MercureConfigResolverInterface::class);
+        $resolver->method('resolveMercureConfig')
+            ->with(DeletableEntityFixture::class)
+            ->willReturn(new MercureConfig(
+                topics: ['/server/deletable-entity-fixtures/{id}'],
+                hubUrl: 'https://hub.example/.well-known/mercure',
+            ));
+
+        $mutator    = new EntityMutator(new EntityLocator($registry), $this->createMock(PropertyAccessorInterface::class), $publisher, $resolver);
         $controller = new AjaxDeleteController($mutator);
 
         $response = $controller(new AjaxDeleteRequestDto(
             entity: DeletableEntityFixture::class,
             id: 12,
-            topics: ['/topic/12'],
         ));
 
         $this->assertSame(200, $response->getStatusCode());

--- a/tests/Unit/Controller/AjaxEditControllerTest.php
+++ b/tests/Unit/Controller/AjaxEditControllerTest.php
@@ -11,6 +11,7 @@ use Pentiminax\UX\DataTables\Controller\AjaxEditController;
 use Pentiminax\UX\DataTables\Dto\AjaxEditRequestDto;
 use Pentiminax\UX\DataTables\Exception\EntityNotFoundException;
 use Pentiminax\UX\DataTables\Exception\PropertyNotWritableException;
+use Pentiminax\UX\DataTables\Mercure\MercureTopicResolverInterface;
 use Pentiminax\UX\DataTables\Mercure\NullMercurePublisher;
 use Pentiminax\UX\DataTables\Mutation\EntityLocator;
 use Pentiminax\UX\DataTables\Mutation\EntityMutator;
@@ -86,6 +87,42 @@ final class AjaxEditControllerTest extends TestCase
             field: 'isEmailAuthEnabled',
             id: 799,
             newValue: false,
+        ));
+    }
+
+    #[Test]
+    public function it_forwards_the_data_table_class_to_the_topic_resolver(): void
+    {
+        $entity = new ToggleBooleanEntityFixture();
+
+        $accessor = $this->createMock(PropertyAccessorInterface::class);
+        $accessor->method('isWritable')->with($entity, 'isEmailAuthEnabled')->willReturn(true);
+
+        $repository = $this->createMock(EntityRepository::class);
+        $repository->method('find')->with(799)->willReturn($entity);
+
+        $manager = $this->createMock(EntityManagerInterface::class);
+        $manager->method('getRepository')->with(ToggleBooleanEntityFixture::class)->willReturn($repository);
+        $manager->expects($this->once())->method('flush');
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getManagerForClass')->with(ToggleBooleanEntityFixture::class)->willReturn($manager);
+
+        $resolver = $this->createMock(MercureTopicResolverInterface::class);
+        $resolver->expects($this->once())
+            ->method('resolve')
+            ->with(ToggleBooleanEntityFixture::class, 'SomeDataTable')
+            ->willReturn([]);
+
+        $mutator    = new EntityMutator(new EntityLocator($registry), $accessor, new NullMercurePublisher(), $resolver);
+        $controller = new AjaxEditController($mutator);
+
+        $controller(new AjaxEditRequestDto(
+            entity: ToggleBooleanEntityFixture::class,
+            field: 'isEmailAuthEnabled',
+            id: 799,
+            newValue: false,
+            dataTableClass: 'SomeDataTable',
         ));
     }
 

--- a/tests/Unit/Controller/AjaxEditFormSubmitControllerTest.php
+++ b/tests/Unit/Controller/AjaxEditFormSubmitControllerTest.php
@@ -16,6 +16,8 @@ use Pentiminax\UX\DataTables\Form\ColumnToFormTypeMapper;
 use Pentiminax\UX\DataTables\Form\EditFormBuilder;
 use Pentiminax\UX\DataTables\Form\EditFormService;
 use Pentiminax\UX\DataTables\Form\EditModalRenderer;
+use Pentiminax\UX\DataTables\Mercure\MercureConfig;
+use Pentiminax\UX\DataTables\Mercure\MercureConfigResolverInterface;
 use Pentiminax\UX\DataTables\Mercure\MercureUpdatePublisher;
 use Pentiminax\UX\DataTables\Mercure\NullMercurePublisher;
 use Pentiminax\UX\DataTables\Mutation\EntityLocator;
@@ -113,57 +115,37 @@ final class AjaxEditFormSubmitControllerTest extends TestCase
     }
 
     #[Test]
-    public function it_only_publishes_mercure_updates_when_topics_are_provided(): void
+    public function it_publishes_to_the_server_resolved_topics_ignoring_the_client(): void
     {
-        $entityManager = $this->createEntityManagerWithEntity(new AjaxEditFormSubmitControllerFixture(), 2);
-        $entityManager->expects($this->exactly(2))->method('flush');
+        $entityManager = $this->createEntityManagerWithEntity(new AjaxEditFormSubmitControllerFixture(), 1);
+        $entityManager->expects($this->once())->method('flush');
 
-        $registry = $this->createMock(ManagerRegistry::class);
-        $registry->expects($this->exactly(2))
-            ->method('getManagerForClass')
-            ->with(AjaxEditFormSubmitControllerFixture::class)
-            ->willReturn($entityManager);
+        $registry = $this->createRegistry($entityManager);
 
         $hub = $this->createMock(HubInterface::class);
         $hub->expects($this->once())
             ->method('publish')
             ->with($this->callback(function (Update $update) {
-                return ['/topic/42']             === $update->getTopics()
+                return ['/server/topic/42']      === $update->getTopics()
                     && '{"type":"edit","id":42}' === $update->getData();
             }))
             ->willReturn('urn:uuid:published');
 
-        $forms = [
+        [$formFactory, $renderer, $templateResolver] = $this->createFormFactoryRendererAndResolver(
             $this->createValidFormMock(),
-            $this->createValidFormMock(),
-        ];
+            '',
+            1,
+            false,
+            'SomeDataTable',
+        );
 
-        $formBuilder = $this->createMock(FormBuilderInterface::class);
-        $formBuilder->expects($this->exactly(2))
-            ->method('add')
-            ->with('name', $this->isType('string'), $this->isType('array'))
-            ->willReturnSelf();
-        $formBuilder->expects($this->exactly(2))
-            ->method('getForm')
-            ->willReturnOnConsecutiveCalls(...$forms);
-
-        $formFactory = $this->createMock(FormFactoryInterface::class);
-        $formFactory->expects($this->exactly(2))
-            ->method('createBuilder')
-            ->with($this->isType('string'), $this->isType('object'))
-            ->willReturn($formBuilder);
-
-        $renderer = $this->createMock(EditModalRenderer::class);
-        $renderer->expects($this->never())->method('render');
-        $renderer->expects($this->never())->method('renderBody');
-
-        $templateResolver = $this->createMock(EditModalTemplateResolverInterface::class);
-        $templateResolver->expects($this->never())->method('resolveChromeTemplate');
-        $templateResolver->expects($this->never())->method('resolveBodyTemplate');
-        $templateResolver->expects($this->exactly(2))
-            ->method('resolveColumns')
-            ->with('SomeDataTable')
-            ->willReturn([TextColumn::new('name', 'Name')]);
+        $resolver = $this->createMock(MercureConfigResolverInterface::class);
+        $resolver->method('resolveMercureConfig')
+            ->with(AjaxEditFormSubmitControllerFixture::class)
+            ->willReturn(new MercureConfig(
+                topics: ['/server/topic/42'],
+                hubUrl: 'https://hub.example/.well-known/mercure',
+            ));
 
         $controller = new AjaxEditFormSubmitController(new EditFormService(
             new EntityLocator($registry),
@@ -171,28 +153,66 @@ final class AjaxEditFormSubmitControllerTest extends TestCase
             $renderer,
             $templateResolver,
             new MercureUpdatePublisher($hub),
+            $resolver,
         ));
 
-        $responseWithoutTopics = $controller(new AjaxEditFormRequestDto(
+        // The DTO no longer carries a topics field, so the client cannot influence
+        // the publish target: only the server-resolved topic is ever used.
+        $response = $controller(new AjaxEditFormRequestDto(
             entity: AjaxEditFormSubmitControllerFixture::class,
             id: 42,
             formData: ['name' => 'Alice'],
             dataTableClass: 'SomeDataTable',
         ));
 
-        $responseWithTopics = $controller(new AjaxEditFormRequestDto(
+        $payload = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+
+        $this->assertTrue($payload['success']);
+    }
+
+    #[Test]
+    public function it_does_not_publish_when_no_mercure_config_is_resolved(): void
+    {
+        $entityManager = $this->createEntityManagerWithEntity(new AjaxEditFormSubmitControllerFixture(), 1);
+        $entityManager->expects($this->once())->method('flush');
+
+        $registry = $this->createRegistry($entityManager);
+
+        $hub = $this->createMock(HubInterface::class);
+        $hub->expects($this->never())->method('publish');
+
+        [$formFactory, $renderer, $templateResolver] = $this->createFormFactoryRendererAndResolver(
+            $this->createValidFormMock(),
+            '',
+            1,
+            false,
+            'SomeDataTable',
+        );
+
+        $resolver = $this->createMock(MercureConfigResolverInterface::class);
+        $resolver->method('resolveMercureConfig')
+            ->with(AjaxEditFormSubmitControllerFixture::class)
+            ->willReturn(null);
+
+        $controller = new AjaxEditFormSubmitController(new EditFormService(
+            new EntityLocator($registry),
+            new EditFormBuilder($formFactory, new ColumnToFormTypeMapper()),
+            $renderer,
+            $templateResolver,
+            new MercureUpdatePublisher($hub),
+            $resolver,
+        ));
+
+        $response = $controller(new AjaxEditFormRequestDto(
             entity: AjaxEditFormSubmitControllerFixture::class,
             id: 42,
             formData: ['name' => 'Alice'],
-            topics: ['/topic/42'],
             dataTableClass: 'SomeDataTable',
         ));
 
-        $payloadWithoutTopics = json_decode((string) $responseWithoutTopics->getContent(), true, 512, \JSON_THROW_ON_ERROR);
-        $payloadWithTopics    = json_decode((string) $responseWithTopics->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        $payload = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
-        $this->assertTrue($payloadWithoutTopics['success']);
-        $this->assertTrue($payloadWithTopics['success']);
+        $this->assertTrue($payload['success']);
     }
 
     private function createRegistry(EntityManagerInterface $entityManager): ManagerRegistry

--- a/tests/Unit/Controller/AjaxEditFormSubmitControllerTest.php
+++ b/tests/Unit/Controller/AjaxEditFormSubmitControllerTest.php
@@ -16,8 +16,7 @@ use Pentiminax\UX\DataTables\Form\ColumnToFormTypeMapper;
 use Pentiminax\UX\DataTables\Form\EditFormBuilder;
 use Pentiminax\UX\DataTables\Form\EditFormService;
 use Pentiminax\UX\DataTables\Form\EditModalRenderer;
-use Pentiminax\UX\DataTables\Mercure\MercureConfig;
-use Pentiminax\UX\DataTables\Mercure\MercureConfigResolverInterface;
+use Pentiminax\UX\DataTables\Mercure\MercureTopicResolverInterface;
 use Pentiminax\UX\DataTables\Mercure\MercureUpdatePublisher;
 use Pentiminax\UX\DataTables\Mercure\NullMercurePublisher;
 use Pentiminax\UX\DataTables\Mutation\EntityLocator;
@@ -139,13 +138,10 @@ final class AjaxEditFormSubmitControllerTest extends TestCase
             'SomeDataTable',
         );
 
-        $resolver = $this->createMock(MercureConfigResolverInterface::class);
-        $resolver->method('resolveMercureConfig')
-            ->with(AjaxEditFormSubmitControllerFixture::class)
-            ->willReturn(new MercureConfig(
-                topics: ['/server/topic/42'],
-                hubUrl: 'https://hub.example/.well-known/mercure',
-            ));
+        $resolver = $this->createMock(MercureTopicResolverInterface::class);
+        $resolver->method('resolve')
+            ->with(AjaxEditFormSubmitControllerFixture::class, 'SomeDataTable')
+            ->willReturn(['/server/topic/42']);
 
         $controller = new AjaxEditFormSubmitController(new EditFormService(
             new EntityLocator($registry),
@@ -189,10 +185,10 @@ final class AjaxEditFormSubmitControllerTest extends TestCase
             'SomeDataTable',
         );
 
-        $resolver = $this->createMock(MercureConfigResolverInterface::class);
-        $resolver->method('resolveMercureConfig')
-            ->with(AjaxEditFormSubmitControllerFixture::class)
-            ->willReturn(null);
+        $resolver = $this->createMock(MercureTopicResolverInterface::class);
+        $resolver->method('resolve')
+            ->with(AjaxEditFormSubmitControllerFixture::class, 'SomeDataTable')
+            ->willReturn([]);
 
         $controller = new AjaxEditFormSubmitController(new EditFormService(
             new EntityLocator($registry),

--- a/tests/Unit/Form/EditFormServiceTest.php
+++ b/tests/Unit/Form/EditFormServiceTest.php
@@ -17,6 +17,8 @@ use Pentiminax\UX\DataTables\Form\EditFormBuilder;
 use Pentiminax\UX\DataTables\Form\EditFormService;
 use Pentiminax\UX\DataTables\Form\EditModalRenderer;
 use Pentiminax\UX\DataTables\Form\EditModalRenderRequest;
+use Pentiminax\UX\DataTables\Mercure\MercureConfig;
+use Pentiminax\UX\DataTables\Mercure\MercureConfigResolverInterface;
 use Pentiminax\UX\DataTables\Mercure\MercureUpdatePublisher;
 use Pentiminax\UX\DataTables\Mercure\NullMercurePublisher;
 use Pentiminax\UX\DataTables\Mutation\EntityLocator;
@@ -255,13 +257,13 @@ final class EditFormServiceTest extends TestCase
             $renderer,
             $templateResolver,
             new MercureUpdatePublisher($hub),
+            $this->resolverReturning(['/topic/42']),
         );
 
         $result = $service->handleSubmit(new AjaxEditFormRequestDto(
             entity: EditFormServiceFixture::class,
             id: 42,
             formData: ['name' => 'Alice'],
-            topics: ['/topic/42'],
             dataTableClass: EditFormServiceFixtureDataTable::class,
         ));
 
@@ -305,13 +307,13 @@ final class EditFormServiceTest extends TestCase
             $renderer,
             $templateResolver,
             new MercureUpdatePublisher($hub, $logger),
+            $this->resolverReturning(['/topic/42']),
         );
 
         $result = $service->handleSubmit(new AjaxEditFormRequestDto(
             entity: EditFormServiceFixture::class,
             id: 42,
             formData: ['name' => 'Alice'],
-            topics: ['/topic/42'],
             dataTableClass: EditFormServiceFixtureDataTable::class,
         ));
 
@@ -388,6 +390,19 @@ final class EditFormServiceTest extends TestCase
             ->willReturn($entityManager);
 
         return $registry;
+    }
+
+    /**
+     * @param string[] $topics
+     */
+    private function resolverReturning(array $topics): MercureConfigResolverInterface
+    {
+        $resolver = $this->createMock(MercureConfigResolverInterface::class);
+        $resolver->method('resolveMercureConfig')
+            ->with(EditFormServiceFixture::class)
+            ->willReturn(new MercureConfig(topics: $topics, hubUrl: 'https://hub.example/.well-known/mercure'));
+
+        return $resolver;
     }
 
     private function createEntityManagerWithEntity(object $entity, int|string $id): EntityManagerInterface

--- a/tests/Unit/Form/EditFormServiceTest.php
+++ b/tests/Unit/Form/EditFormServiceTest.php
@@ -17,8 +17,7 @@ use Pentiminax\UX\DataTables\Form\EditFormBuilder;
 use Pentiminax\UX\DataTables\Form\EditFormService;
 use Pentiminax\UX\DataTables\Form\EditModalRenderer;
 use Pentiminax\UX\DataTables\Form\EditModalRenderRequest;
-use Pentiminax\UX\DataTables\Mercure\MercureConfig;
-use Pentiminax\UX\DataTables\Mercure\MercureConfigResolverInterface;
+use Pentiminax\UX\DataTables\Mercure\MercureTopicResolverInterface;
 use Pentiminax\UX\DataTables\Mercure\MercureUpdatePublisher;
 use Pentiminax\UX\DataTables\Mercure\NullMercurePublisher;
 use Pentiminax\UX\DataTables\Mutation\EntityLocator;
@@ -395,12 +394,12 @@ final class EditFormServiceTest extends TestCase
     /**
      * @param string[] $topics
      */
-    private function resolverReturning(array $topics): MercureConfigResolverInterface
+    private function resolverReturning(array $topics): MercureTopicResolverInterface
     {
-        $resolver = $this->createMock(MercureConfigResolverInterface::class);
-        $resolver->method('resolveMercureConfig')
-            ->with(EditFormServiceFixture::class)
-            ->willReturn(new MercureConfig(topics: $topics, hubUrl: 'https://hub.example/.well-known/mercure'));
+        $resolver = $this->createMock(MercureTopicResolverInterface::class);
+        $resolver->method('resolve')
+            ->with(EditFormServiceFixture::class, EditFormServiceFixtureDataTable::class)
+            ->willReturn($topics);
 
         return $resolver;
     }

--- a/tests/Unit/Mercure/MercureTopicResolverTest.php
+++ b/tests/Unit/Mercure/MercureTopicResolverTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Unit\Mercure;
+
+use Pentiminax\UX\DataTables\Mercure\MercureConfig;
+use Pentiminax\UX\DataTables\Mercure\MercureConfigResolverInterface;
+use Pentiminax\UX\DataTables\Mercure\MercureTopicResolver;
+use Pentiminax\UX\DataTables\Tests\Fixtures\DataTable\TestDataTableWithManualMercure;
+use Pentiminax\UX\DataTables\Tests\Fixtures\DataTable\TestDataTableWithMercureTopicsAttribute;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+/**
+ * @internal
+ */
+#[CoversClass(MercureTopicResolver::class)]
+final class MercureTopicResolverTest extends TestCase
+{
+    #[Test]
+    public function it_prefers_the_manual_data_table_configuration_over_the_entity_fallback(): void
+    {
+        $dataTable = new TestDataTableWithManualMercure();
+
+        $dataTables = $this->createMock(ContainerInterface::class);
+        $dataTables->method('has')->with(TestDataTableWithManualMercure::class)->willReturn(true);
+        $dataTables->method('get')->with(TestDataTableWithManualMercure::class)->willReturn($dataTable);
+
+        $entityFallback = $this->createMock(MercureConfigResolverInterface::class);
+        $entityFallback->expects($this->never())->method('resolveMercureConfig');
+
+        $resolver = new MercureTopicResolver($dataTables, $entityFallback);
+
+        $this->assertSame(
+            ['manual/topic'],
+            $resolver->resolve(\stdClass::class, TestDataTableWithManualMercure::class)
+        );
+    }
+
+    #[Test]
+    public function it_falls_back_to_the_explicit_as_data_table_attribute_topics(): void
+    {
+        $dataTable = new TestDataTableWithMercureTopicsAttribute();
+
+        $dataTables = $this->createMock(ContainerInterface::class);
+        $dataTables->method('has')->with(TestDataTableWithMercureTopicsAttribute::class)->willReturn(true);
+        $dataTables->method('get')->with(TestDataTableWithMercureTopicsAttribute::class)->willReturn($dataTable);
+
+        $entityFallback = $this->createMock(MercureConfigResolverInterface::class);
+        $entityFallback->expects($this->never())->method('resolveMercureConfig');
+
+        $resolver = new MercureTopicResolver($dataTables, $entityFallback);
+
+        $this->assertSame(
+            ['https://example.com/books'],
+            $resolver->resolve(\stdClass::class, TestDataTableWithMercureTopicsAttribute::class)
+        );
+    }
+
+    #[Test]
+    public function it_falls_back_to_the_entity_based_resolver_when_the_data_table_class_is_unknown(): void
+    {
+        $dataTables = $this->createMock(ContainerInterface::class);
+        $dataTables->method('has')->willReturn(false);
+
+        $entityFallback = $this->createMock(MercureConfigResolverInterface::class);
+        $entityFallback->expects($this->once())
+            ->method('resolveMercureConfig')
+            ->with(\stdClass::class)
+            ->willReturn(new MercureConfig(topics: ['/entity/{id}'], hubUrl: 'https://hub.example/.well-known/mercure'));
+
+        $resolver = new MercureTopicResolver($dataTables, $entityFallback);
+
+        $this->assertSame(['/entity/{id}'], $resolver->resolve(\stdClass::class));
+    }
+
+    #[Test]
+    public function it_returns_an_empty_array_when_nothing_can_be_resolved(): void
+    {
+        $dataTables = $this->createMock(ContainerInterface::class);
+        $dataTables->method('has')->willReturn(false);
+
+        $resolver = new MercureTopicResolver($dataTables);
+
+        $this->assertSame([], $resolver->resolve(\stdClass::class));
+    }
+}

--- a/tests/Unit/Mutation/EntityMutatorTest.php
+++ b/tests/Unit/Mutation/EntityMutatorTest.php
@@ -9,6 +9,8 @@ use Doctrine\ORM\EntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 use Pentiminax\UX\DataTables\Exception\EntityNotFoundException;
 use Pentiminax\UX\DataTables\Exception\PropertyNotWritableException;
+use Pentiminax\UX\DataTables\Mercure\MercureConfig;
+use Pentiminax\UX\DataTables\Mercure\MercureConfigResolverInterface;
 use Pentiminax\UX\DataTables\Mercure\MercurePublisherInterface;
 use Pentiminax\UX\DataTables\Mutation\EntityLocator;
 use Pentiminax\UX\DataTables\Mutation\EntityMutator;
@@ -35,7 +37,57 @@ final class EntityMutatorTest extends TestCase
         $publisher = $this->createMock(MercurePublisherInterface::class);
         $publisher->expects($this->once())
             ->method('publish')
-            ->with(['/topic/5'], ['type' => 'delete', 'id' => 5]);
+            ->with(['/server/entity-mutator-fixtures/{id}'], ['type' => 'delete', 'id' => 5]);
+
+        $mutator = new EntityMutator(
+            new EntityLocator($this->registry($manager)),
+            $this->createMock(PropertyAccessorInterface::class),
+            $publisher,
+            $this->resolverReturning(['/server/entity-mutator-fixtures/{id}']),
+        );
+
+        $mutator->delete(EntityMutatorFixture::class, 5);
+    }
+
+    #[Test]
+    public function it_publishes_only_the_server_resolved_topics_and_never_client_input(): void
+    {
+        $entity = new EntityMutatorFixture();
+
+        $manager = $this->managerReturning($entity, 5);
+        $manager->expects($this->once())->method('remove')->with($entity);
+        $manager->expects($this->once())->method('flush');
+
+        $publisher = $this->createMock(MercurePublisherInterface::class);
+        $publisher->expects($this->once())
+            ->method('publish')
+            ->with(['/server/only'], ['type' => 'delete', 'id' => 5]);
+
+        $mutator = new EntityMutator(
+            new EntityLocator($this->registry($manager)),
+            $this->createMock(PropertyAccessorInterface::class),
+            $publisher,
+            $this->resolverReturning(['/server/only']),
+        );
+
+        // The delete() signature no longer accepts client topics: the only
+        // possible publish target is the server-resolved configuration.
+        $mutator->delete(EntityMutatorFixture::class, 5);
+    }
+
+    #[Test]
+    public function it_does_not_publish_when_no_mercure_resolver_is_available(): void
+    {
+        $entity = new EntityMutatorFixture();
+
+        $manager = $this->managerReturning($entity, 5);
+        $manager->expects($this->once())->method('remove')->with($entity);
+        $manager->expects($this->once())->method('flush');
+
+        $publisher = $this->createMock(MercurePublisherInterface::class);
+        $publisher->expects($this->once())
+            ->method('publish')
+            ->with([], ['type' => 'delete', 'id' => 5]);
 
         $mutator = new EntityMutator(
             new EntityLocator($this->registry($manager)),
@@ -43,7 +95,7 @@ final class EntityMutatorTest extends TestCase
             $publisher,
         );
 
-        $mutator->delete(EntityMutatorFixture::class, 5, ['/topic/5']);
+        $mutator->delete(EntityMutatorFixture::class, 5);
     }
 
     #[Test]
@@ -62,11 +114,16 @@ final class EntityMutatorTest extends TestCase
         $publisher = $this->createMock(MercurePublisherInterface::class);
         $publisher->expects($this->once())
             ->method('publish')
-            ->with(['/topic/5'], ['type' => 'edit', 'id' => 5, 'field' => 'enabled']);
+            ->with(['/server/entity-mutator-fixtures/{id}'], ['type' => 'edit', 'id' => 5, 'field' => 'enabled']);
 
-        $mutator = new EntityMutator(new EntityLocator($this->registry($manager)), $accessor, $publisher);
+        $mutator = new EntityMutator(
+            new EntityLocator($this->registry($manager)),
+            $accessor,
+            $publisher,
+            $this->resolverReturning(['/server/entity-mutator-fixtures/{id}']),
+        );
 
-        $mutator->setProperty(EntityMutatorFixture::class, 5, 'enabled', true, ['/topic/5']);
+        $mutator->setProperty(EntityMutatorFixture::class, 5, 'enabled', true);
     }
 
     #[Test]
@@ -87,7 +144,7 @@ final class EntityMutatorTest extends TestCase
         $mutator = new EntityMutator(new EntityLocator($this->registry($manager)), $accessor, $publisher);
 
         $this->expectException(PropertyNotWritableException::class);
-        $mutator->setProperty(EntityMutatorFixture::class, 5, 'enabled', true, ['/topic/5']);
+        $mutator->setProperty(EntityMutatorFixture::class, 5, 'enabled', true);
     }
 
     #[Test]
@@ -109,7 +166,7 @@ final class EntityMutatorTest extends TestCase
         );
 
         $this->expectException(EntityNotFoundException::class);
-        $mutator->delete(EntityMutatorFixture::class, 404, ['/topic/x']);
+        $mutator->delete(EntityMutatorFixture::class, 404);
     }
 
     private function managerReturning(object $entity, int|string $id): EntityManagerInterface
@@ -129,6 +186,19 @@ final class EntityMutatorTest extends TestCase
         $registry->method('getManagerForClass')->with(EntityMutatorFixture::class)->willReturn($manager);
 
         return $registry;
+    }
+
+    /**
+     * @param string[] $topics
+     */
+    private function resolverReturning(array $topics): MercureConfigResolverInterface
+    {
+        $resolver = $this->createMock(MercureConfigResolverInterface::class);
+        $resolver->method('resolveMercureConfig')
+            ->with(EntityMutatorFixture::class)
+            ->willReturn(new MercureConfig(topics: $topics, hubUrl: 'https://hub.example/.well-known/mercure'));
+
+        return $resolver;
     }
 }
 

--- a/tests/Unit/Mutation/EntityMutatorTest.php
+++ b/tests/Unit/Mutation/EntityMutatorTest.php
@@ -9,9 +9,8 @@ use Doctrine\ORM\EntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 use Pentiminax\UX\DataTables\Exception\EntityNotFoundException;
 use Pentiminax\UX\DataTables\Exception\PropertyNotWritableException;
-use Pentiminax\UX\DataTables\Mercure\MercureConfig;
-use Pentiminax\UX\DataTables\Mercure\MercureConfigResolverInterface;
 use Pentiminax\UX\DataTables\Mercure\MercurePublisherInterface;
+use Pentiminax\UX\DataTables\Mercure\MercureTopicResolverInterface;
 use Pentiminax\UX\DataTables\Mutation\EntityLocator;
 use Pentiminax\UX\DataTables\Mutation\EntityMutator;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -191,12 +190,12 @@ final class EntityMutatorTest extends TestCase
     /**
      * @param string[] $topics
      */
-    private function resolverReturning(array $topics): MercureConfigResolverInterface
+    private function resolverReturning(array $topics): MercureTopicResolverInterface
     {
-        $resolver = $this->createMock(MercureConfigResolverInterface::class);
-        $resolver->method('resolveMercureConfig')
-            ->with(EntityMutatorFixture::class)
-            ->willReturn(new MercureConfig(topics: $topics, hubUrl: 'https://hub.example/.well-known/mercure'));
+        $resolver = $this->createMock(MercureTopicResolverInterface::class);
+        $resolver->method('resolve')
+            ->with(EntityMutatorFixture::class, null)
+            ->willReturn($topics);
 
         return $resolver;
     }


### PR DESCRIPTION
Addresses the two outstanding review comments on #255 (this branch is based on #255's head commit, since it hasn't merged yet).

## Problem

1. **Bugbot (medium):** `EntityMutator` / `EditFormService` resolved Mercure topics only through `MercureConfigResolver::resolveMercureConfig($entityClass)`, ignoring a table's manual `DataTable::mercure()` configuration or an explicit `AsDataTable(mercure: [...])` attribute — both of which the render path (and thus the subscribing browser) can use instead. Mutation publishes could land on different topics than the client is actually subscribed to, silently breaking live reload for those tables.
2. **Greptile (duplication):** `EntityMutator::resolveTopics()` and `EditFormService::resolveTopics()` were byte-for-byte identical.

## Fix

- Extracted a new `MercureTopicResolver` (behind `MercureTopicResolverInterface`) that both `EntityMutator` and `EditFormService` now depend on, eliminating the duplication.
- The resolver mirrors the render path's priority order: manual `DataTable::mercure()` config → explicit `AsDataTable` attribute topics → entity-based `MercureConfigResolver` fallback. It only needs `AbstractDataTable::initialize()` (already invoked via `getConfiguredDataTable()`), so no data hydration/query side effects are introduced during a mutation request.
- Added a public `AbstractDataTable::getAsDataTableAttribute()` accessor so the resolver can read the attribute for the explicit-topics case.
- `delete` (AJAX) and boolean-toggle requests now optionally forward `dataTableClass` (mirroring what `edit-form` already did), so the resolver can look up the correct DataTable configuration. It stays entity-based-only when absent, same as before.
- Client input still never influences the publish target — this is additive to the existing security fix, not a relaxation of it.

## Verification

- `vendor/bin/phpunit` — 792 tests, 2092 assertions, green (adds `MercureTopicResolverTest` plus coverage for `dataTableClass` forwarding).
- `vendor/bin/php-cs-fixer fix` — 0 files changed.
- `npm test` (assets) — 176 tests, green.
- `tsc --noEmit` — no type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KRHLNeXE7dV2xXaM5ZyWAx)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes real-time reload behavior for tables whose subscribe topics differ from the old entity-only mutation path; security improves by ignoring client topics, but misconfigured or missing `dataTableClass` can still publish to empty or fallback topics.
> 
> **Overview**
> **Mercure publish targets for table mutations are now resolved on the server** instead of accepting `topics` from the browser. Delete, boolean toggle, and edit-form AJAX payloads send optional `dataTableClass` (aligned with edit-form); client-supplied topics are removed from DTOs and TypeScript helpers.
> 
> A shared **`MercureTopicResolver`** (wired into `EntityMutator` and `EditFormService`) picks topics using the same order as the render path: manual `DataTable` Mercure config → `AsDataTable` attribute topics → entity `MercureConfigResolver` fallback. **`AbstractDataTable::getAsDataTableAttribute()`** exposes the attribute for that lookup.
> 
> Unit tests cover resolver priority, `dataTableClass` forwarding, and that publishes use server-resolved topics only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 190cbe3c9ffcaf41ef4ba00824a3aef515e8921a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->