### PR TITLE
Fix: allow string/UUID identifiers in AjaxEditRequestDto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ node_modules/.vite/
 composer.lock
 _bmad/
 _bmad-output/
+config/reference.php
 
 /docs/superpowers/*
 .omx/

--- a/src/Dto/AjaxEditRequestDto.php
+++ b/src/Dto/AjaxEditRequestDto.php
@@ -9,7 +9,7 @@ final readonly class AjaxEditRequestDto
     public function __construct(
         public string $entity,
         public string $field,
-        public int $id,
+        public int|string $id,
         public bool $newValue,
         public array $topics = [],
     ) {

--- a/tests/Unit/Controller/AjaxEditControllerTest.php
+++ b/tests/Unit/Controller/AjaxEditControllerTest.php
@@ -72,6 +72,28 @@ final class AjaxEditControllerTest extends TestCase
     }
 
     #[Test]
+    public function it_returns_one_when_updating_boolean_field_to_true_with_a_string_id(): void
+    {
+        $entity = new ToggleBooleanEntityFixture();
+
+        $accessor = $this->createMock(PropertyAccessorInterface::class);
+        $accessor->method('isWritable')->with($entity, 'isEmailAuthEnabled')->willReturn(true);
+        $accessor->expects($this->once())->method('setValue')->with($entity, 'isEmailAuthEnabled', true);
+
+        $controller = $this->controller($entity, '018f2c3e-1234-7abc-9def-0123456789ab', $accessor, expectFlush: true);
+
+        $response = $controller(new AjaxEditRequestDto(
+            entity: ToggleBooleanEntityFixture::class,
+            field: 'isEmailAuthEnabled',
+            id: '018f2c3e-1234-7abc-9def-0123456789ab',
+            newValue: true,
+        ));
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('1', (string) $response->getContent());
+    }
+
+    #[Test]
     public function it_lets_a_not_writable_field_bubble_as_an_exception(): void
     {
         $entity = new ToggleBooleanEntityFixture();


### PR DESCRIPTION
## Summary

- `AjaxEditRequestDto::$id` was declared as `int`, unlike the other DTOs (`AjaxDeleteRequestDto`, `AjaxDetailQueryDto`, `AjaxEditFormQueryDto`, `AjaxEditFormRequestDto`) which all use `int|string $id`.
- As a result, `#[MapRequestPayload]` rejected non-integer ids (HTTP 400), so entities with UUID/string primary keys could never be toggled through the boolean-toggle (ajax-edit) endpoint, even though `EntityMutator::setProperty()` already accepted `int|string $id`.
- Changed `AjaxEditRequestDto::$id` to `int|string $id` to match the rest of the DTOs and the underlying mutator.

## Test plan

- [x] Added `AjaxEditControllerTest::it_returns_one_when_updating_boolean_field_to_true_with_a_string_id` covering a successful toggle with a string (UUID-like) id.
- [x] `vendor/bin/phpunit tests/Unit/Controller/AjaxEditControllerTest.php` — 6/6 passing.
- [x] `vendor/bin/phpunit` — full suite, 789/789 passing.
- [x] `composer fix` — no style violations.

Fixes #249

https://claude.ai/code/session_0151RKHM3ELbdosguvNg4f28

---
_Generated by [Claude Code](https://claude.ai/code/session_0151RKHM3ELbdosguvNg4f28)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow DTO typing fix with a new unit test; integer id behavior is unchanged and no auth or persistence logic was modified.
> 
> **Overview**
> **Boolean ajax-edit** requests now accept **string primary keys** (e.g. UUIDs) by widening `AjaxEditRequestDto::$id` from `int` to `int|string`, consistent with the other Ajax DTOs and `EntityMutator`.
> 
> Previously, `#[MapRequestPayload]` could return **HTTP 400** for non-integer ids even though lookup/mutation already supported string ids.
> 
> Adds a controller unit test for a successful toggle with a UUID-like string id. Also ignores generated `config/reference.php` in `.gitignore`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1716f8d8c3a299e98dc7684972361db88e90ec4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->