### PR TITLE
fix(data-provider): use COUNT(DISTINCT) for filtered count to avoid to-many join inflation (#243)

### DIFF
--- a/src/DataProvider/DoctrineDataProvider.php
+++ b/src/DataProvider/DoctrineDataProvider.php
@@ -27,12 +27,11 @@ class DoctrineDataProvider implements DataProviderInterface
 
     public function fetchData(DataTableRequest $request): DataTableResult
     {
-        $alias     = 'e';
-        $countExpr = "COUNT($alias)";
+        $alias = 'e';
 
         $countQb = $this->em
             ->createQueryBuilder()
-            ->select($countExpr)
+            ->select("COUNT($alias)")
             ->from($this->entityClass, $alias);
 
         $recordsTotal = (int) $countQb->getQuery()->getSingleScalarResult();
@@ -46,9 +45,13 @@ class DoctrineDataProvider implements DataProviderInterface
             $qb = ($this->configureQueryBuilder)($qb, $request);
         }
 
+        // Filters supplied by configureQueryBuilder may add joins (e.g. searching over a
+        // relation). When such a join traverses a to-many association, a plain COUNT(e) is
+        // inflated by row multiplication. COUNT(DISTINCT e) counts distinct root entities, so
+        // recordsFiltered stays correct and pagination does not break.
         $filteredCountQb = clone $qb;
         $filteredCount   = (int) $filteredCountQb
-            ->select($countExpr)
+            ->select("COUNT(DISTINCT $alias)")
             ->resetDQLPart('orderBy')
             ->getQuery()
             ->getSingleScalarResult();

--- a/src/DataProvider/DoctrineDataProvider.php
+++ b/src/DataProvider/DoctrineDataProvider.php
@@ -49,6 +49,9 @@ class DoctrineDataProvider implements DataProviderInterface
         // relation). When such a join traverses a to-many association, a plain COUNT(e) is
         // inflated by row multiplication. COUNT(DISTINCT e) counts distinct root entities, so
         // recordsFiltered stays correct and pagination does not break.
+        // Note: this assumes a single-column primary key (Doctrine resolves COUNT(DISTINCT e) to
+        // the first identifier column); entities with composite keys would need a subquery over
+        // the identifiers instead.
         $filteredCountQb = clone $qb;
         $filteredCount   = (int) $filteredCountQb
             ->select("COUNT(DISTINCT $alias)")

--- a/tests/Unit/DataProvider/DoctrineDataProviderFilteredCountTest.php
+++ b/tests/Unit/DataProvider/DoctrineDataProviderFilteredCountTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Unit\DataProvider;
+
+use Doctrine\DBAL\DriverManager;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\ORMSetup;
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\ORM\Tools\SchemaTool;
+use Pentiminax\UX\DataTables\Contracts\RowMapperInterface;
+use Pentiminax\UX\DataTables\DataProvider\DoctrineDataProvider;
+use Pentiminax\UX\DataTables\DataTableRequest\Columns;
+use Pentiminax\UX\DataTables\DataTableRequest\DataTableRequest;
+use Pentiminax\UX\DataTables\Tests\Fixtures\Count\CountCustomer;
+use Pentiminax\UX\DataTables\Tests\Fixtures\Count\CountTag;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+#[CoversClass(DoctrineDataProvider::class)]
+final class DoctrineDataProviderFilteredCountTest extends TestCase
+{
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $config = ORMSetup::createAttributeMetadataConfiguration(
+            paths: [__DIR__.'/../../Fixtures/Count'],
+            isDevMode: true,
+        );
+
+        if (\PHP_VERSION_ID >= 80400) {
+            $config->enableNativeLazyObjects(true);
+        }
+
+        $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true], $config);
+        $this->em   = new EntityManager($connection, $config);
+
+        (new SchemaTool($this->em))->createSchema([
+            $this->em->getClassMetadata(CountCustomer::class),
+            $this->em->getClassMetadata(CountTag::class),
+        ]);
+
+        // Two customers; the first has several tags so a to-many join multiplies its rows.
+        $alpha = new CountCustomer(1, 'Alpha');
+        $alpha->addTag(new CountTag(10, 'red'));
+        $alpha->addTag(new CountTag(11, 'green'));
+        $alpha->addTag(new CountTag(12, 'blue'));
+
+        $beta = new CountCustomer(2, 'Beta');
+        $beta->addTag(new CountTag(20, 'red'));
+
+        $this->em->persist($alpha);
+        $this->em->persist($beta);
+        $this->em->flush();
+        $this->em->clear();
+    }
+
+    #[Test]
+    public function it_counts_distinct_root_entities_when_a_to_many_join_is_applied(): void
+    {
+        $provider = new DoctrineDataProvider(
+            em: $this->em,
+            entityClass: CountCustomer::class,
+            rowMapper: new class implements RowMapperInterface {
+                public function map(mixed $row): array
+                {
+                    return ['id' => $row->id];
+                }
+            },
+            // Simulate a searchable path traversing a to-many association: joining tags
+            // multiplies the customer rows (Alpha appears 3 times, Beta once → 4 joined rows).
+            configureQueryBuilder: static fn (QueryBuilder $qb): QueryBuilder => $qb->leftJoin('e.tags', 't'),
+        );
+
+        $result = $provider->fetchData($this->request());
+
+        // Without DISTINCT the filtered count would be 4 (the inflated joined-row count).
+        // The correct value is the number of distinct root customers: 2.
+        $this->assertSame(2, $result->recordsFiltered);
+        $this->assertSame(2, $result->recordsTotal);
+    }
+
+    private function request(): DataTableRequest
+    {
+        return new DataTableRequest(draw: 1, columns: new Columns([]), start: 0, length: 10);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #243. The filtered count in `DoctrineDataProvider::fetchData()` clones the `QueryBuilder` **after** the user's `configureQueryBuilder` filters run. Those filters can add `leftJoin`s for relation search; when a join traverses a **to-many** association, `COUNT(e)` is inflated by row multiplication, corrupting `recordsFiltered` and breaking pagination.

## Changes
- Filtered count now uses `COUNT(DISTINCT e)` so it counts distinct root entities regardless of to-many joins. A code comment documents the rationale.
- The unfiltered `recordsTotal` count has no joins, so it deliberately keeps `COUNT(e)` — the change stays minimal.

## Tests
Added a regression test (in-memory SQLite EM, `OneToMany` fixtures) where `configureQueryBuilder` adds `leftJoin('e.tags', 't')`, producing row multiplication, and asserts `recordsFiltered` equals the distinct-customer count. Verified it fails on the old `COUNT(e)` code and passes with the fix.

`vendor/bin/phpunit` → **OK (837 tests)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L9sBdCeRV1NVkqFAqTMYkh)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted fix to filtered-count SQL in DoctrineDataProvider with a regression test; unfiltered totals and data fetching are unchanged aside from correct pagination metadata.
> 
> **Overview**
> Fixes incorrect **`recordsFiltered`** (and broken pagination) when `configureQueryBuilder` adds joins over **to-many** relations—the filtered count query now uses **`COUNT(DISTINCT e)`** on the root alias instead of plain **`COUNT(e)`**, which was counting multiplied join rows.
> 
> **`recordsTotal`** is unchanged (**`COUNT(e)`** on a join-free query). Inline comments note the **single-column PK** assumption and that composite keys would need a different approach.
> 
> A regression test drives **`DoctrineDataProvider`** with a **`leftJoin`** on tags so two customers become four joined rows and asserts **`recordsFiltered`** is **2**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1308494cc4e3d1f84bddc38c009cc55a94e529c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->