### PR TITLE
fix(mutation): map Doctrine flush failures to a structured 409 response (#244)

### DIFF
--- a/src/Exception/MutationPersistenceException.php
+++ b/src/Exception/MutationPersistenceException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Exception;
+
+final class MutationPersistenceException extends MutationException
+{
+    public function __construct(string $message = 'The operation could not be completed due to a data conflict.', ?\Throwable $previous = null)
+    {
+        parent::__construct($message, 0, $previous);
+    }
+
+    public function getStatusCode(): int
+    {
+        return 409;
+    }
+}

--- a/src/Mutation/EntityMutator.php
+++ b/src/Mutation/EntityMutator.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Pentiminax\UX\DataTables\Mutation;
 
+use Doctrine\DBAL\Exception as DBALException;
+use Doctrine\Persistence\ObjectManager;
 use Pentiminax\UX\DataTables\Exception\EntityNotFoundException;
 use Pentiminax\UX\DataTables\Exception\FieldNotToggleableException;
 use Pentiminax\UX\DataTables\Exception\MutationNotAllowedException;
+use Pentiminax\UX\DataTables\Exception\MutationPersistenceException;
 use Pentiminax\UX\DataTables\Exception\PropertyNotWritableException;
 use Pentiminax\UX\DataTables\Mercure\MercureConfigResolverInterface;
 use Pentiminax\UX\DataTables\Mercure\MercurePublisherInterface;
@@ -30,6 +33,7 @@ final class EntityMutator
     /**
      * @throws EntityNotFoundException
      * @throws MutationNotAllowedException
+     * @throws MutationPersistenceException
      */
     public function delete(string $entityClass, int|string $id, ?string $dataTableClass = null): void
     {
@@ -40,7 +44,7 @@ final class EntityMutator
         }
 
         $context->manager->remove($context->entity);
-        $context->manager->flush();
+        $this->flush($context->manager);
 
         $this->publisher->publish(MercureTopicResolver::resolve($this->mercureConfigResolver, $entityClass, $this->dataTables, $dataTableClass), [
             'type' => 'delete',
@@ -54,6 +58,7 @@ final class EntityMutator
      * @throws EntityNotFoundException
      * @throws FieldNotToggleableException
      * @throws MutationNotAllowedException
+     * @throws MutationPersistenceException
      * @throws PropertyNotWritableException
      */
     public function setProperty(string $entityClass, int|string $id, string $field, bool $value, ?string $dataTableClass = null): void
@@ -75,12 +80,24 @@ final class EntityMutator
         }
 
         $this->propertyAccessor->setValue($context->entity, $field, $value);
-        $context->manager->flush();
+        $this->flush($context->manager);
 
         $this->publisher->publish(MercureTopicResolver::resolve($this->mercureConfigResolver, $entityClass, $this->dataTables, $dataTableClass), [
             'type'  => 'edit',
             'id'    => $id,
             'field' => $field,
         ]);
+    }
+
+    /**
+     * @throws MutationPersistenceException when the underlying persistence layer rejects the flush
+     */
+    private function flush(ObjectManager $manager): void
+    {
+        try {
+            $manager->flush();
+        } catch (DBALException $exception) {
+            throw new MutationPersistenceException(previous: $exception);
+        }
     }
 }

--- a/src/Mutation/EntityMutator.php
+++ b/src/Mutation/EntityMutator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pentiminax\UX\DataTables\Mutation;
 
 use Doctrine\DBAL\Exception as DBALException;
+use Doctrine\ORM\OptimisticLockException;
 use Doctrine\Persistence\ObjectManager;
 use Pentiminax\UX\DataTables\Exception\EntityNotFoundException;
 use Pentiminax\UX\DataTables\Exception\FieldNotToggleableException;
@@ -96,7 +97,11 @@ final class EntityMutator
     {
         try {
             $manager->flush();
-        } catch (DBALException $exception) {
+        } catch (DBALException|OptimisticLockException $exception) {
+            // The 409 primarily targets constraint/conflict cases — a unique
+            // violation or an optimistic-lock version mismatch. Broader DBAL
+            // failures (e.g. a lost connection) are deliberately mapped here
+            // too rather than leaking as a raw 500.
             throw new MutationPersistenceException(previous: $exception);
         }
     }

--- a/tests/Unit/Mutation/EntityMutatorTest.php
+++ b/tests/Unit/Mutation/EntityMutatorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pentiminax\UX\DataTables\Tests\Unit\Mutation;
 
+use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -14,6 +15,7 @@ use Pentiminax\UX\DataTables\Contracts\DataProviderInterface;
 use Pentiminax\UX\DataTables\Exception\EntityNotFoundException;
 use Pentiminax\UX\DataTables\Exception\FieldNotToggleableException;
 use Pentiminax\UX\DataTables\Exception\MutationNotAllowedException;
+use Pentiminax\UX\DataTables\Exception\MutationPersistenceException;
 use Pentiminax\UX\DataTables\Exception\PropertyNotWritableException;
 use Pentiminax\UX\DataTables\Mercure\MercureConfig;
 use Pentiminax\UX\DataTables\Mercure\MercureConfigResolverInterface;
@@ -447,6 +449,74 @@ final class EntityMutatorTest extends TestCase
     }
 
     #[Test]
+    public function it_maps_a_flush_failure_to_a_persistence_exception_on_delete(): void
+    {
+        $entity = new EntityMutatorFixture();
+
+        $dbalException = $this->dbalException();
+
+        $manager = $this->managerReturning($entity, 5);
+        $manager->expects($this->once())->method('remove')->with($entity);
+        $manager->expects($this->once())->method('flush')->willThrowException($dbalException);
+
+        // A failed persistence must never surface as a published mutation event.
+        $publisher = $this->createMock(MercurePublisherInterface::class);
+        $publisher->expects($this->never())->method('publish');
+
+        $mutator = new EntityMutator(
+            new EntityLocator($this->registry($manager)),
+            $this->createMock(PropertyAccessorInterface::class),
+            $publisher,
+            new PermissionChecker(),
+            mercureConfigResolver: $this->resolverReturning(['/server/entity-mutator-fixtures/{id}']),
+        );
+
+        try {
+            $mutator->delete(EntityMutatorFixture::class, 5);
+            $this->fail('Expected a MutationPersistenceException to be thrown.');
+        } catch (MutationPersistenceException $exception) {
+            $this->assertSame(409, $exception->getStatusCode());
+            $this->assertSame('The operation could not be completed due to a data conflict.', $exception->getClientMessage());
+            $this->assertSame($dbalException, $exception->getPrevious());
+        }
+    }
+
+    #[Test]
+    public function it_maps_a_flush_failure_to_a_persistence_exception_on_set_property(): void
+    {
+        $entity = new EntityMutatorFixture();
+
+        $dbalException = $this->dbalException();
+
+        $manager = $this->managerReturning($entity, 5);
+        $manager->expects($this->once())->method('flush')->willThrowException($dbalException);
+
+        $accessor = $this->createMock(PropertyAccessorInterface::class);
+        $accessor->method('isWritable')->with($entity, 'enabled')->willReturn(true);
+        $accessor->expects($this->once())->method('setValue')->with($entity, 'enabled', true);
+
+        $publisher = $this->createMock(MercurePublisherInterface::class);
+        $publisher->expects($this->never())->method('publish');
+
+        $mutator = new EntityMutator(
+            new EntityLocator($this->registry($manager)),
+            $accessor,
+            $publisher,
+            new PermissionChecker(),
+            mercureConfigResolver: $this->resolverReturning(['/server/entity-mutator-fixtures/{id}']),
+        );
+
+        try {
+            $mutator->setProperty(EntityMutatorFixture::class, 5, 'enabled', true);
+            $this->fail('Expected a MutationPersistenceException to be thrown.');
+        } catch (MutationPersistenceException $exception) {
+            $this->assertSame(409, $exception->getStatusCode());
+            $this->assertSame('The operation could not be completed due to a data conflict.', $exception->getClientMessage());
+            $this->assertSame($dbalException, $exception->getPrevious());
+        }
+    }
+
+    #[Test]
     public function it_propagates_not_found_from_the_locator_on_delete(): void
     {
         $manager    = $this->createMock(EntityManagerInterface::class);
@@ -467,6 +537,11 @@ final class EntityMutatorTest extends TestCase
 
         $this->expectException(EntityNotFoundException::class);
         $mutator->delete(EntityMutatorFixture::class, 404);
+    }
+
+    private function dbalException(): DBALException
+    {
+        return new class('constraint violation') extends \RuntimeException implements DBALException {};
     }
 
     private function managerReturning(object $entity, int|string $id): EntityManagerInterface

--- a/tests/Unit/Mutation/EntityMutatorTest.php
+++ b/tests/Unit/Mutation/EntityMutatorTest.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Pentiminax\UX\DataTables\Tests\Unit\Mutation;
 
+use Doctrine\DBAL\Driver\Exception as DriverException;
 use Doctrine\DBAL\Exception as DBALException;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\OptimisticLockException;
 use Doctrine\Persistence\ManagerRegistry;
 use Pentiminax\UX\DataTables\Attribute\AsDataTable;
 use Pentiminax\UX\DataTables\Column\TextColumn;
@@ -517,6 +520,40 @@ final class EntityMutatorTest extends TestCase
     }
 
     #[Test]
+    public function it_maps_an_optimistic_lock_failure_to_a_persistence_exception_on_delete(): void
+    {
+        $entity = new EntityMutatorFixture();
+
+        // OptimisticLockException is an ORMException, NOT a DBAL\Exception: it is
+        // the canonical 409 "data conflict" and must be mapped, not leaked as 500.
+        $lockException = OptimisticLockException::lockFailed($entity);
+
+        $manager = $this->managerReturning($entity, 5);
+        $manager->expects($this->once())->method('remove')->with($entity);
+        $manager->expects($this->once())->method('flush')->willThrowException($lockException);
+
+        $publisher = $this->createMock(MercurePublisherInterface::class);
+        $publisher->expects($this->never())->method('publish');
+
+        $mutator = new EntityMutator(
+            new EntityLocator($this->registry($manager)),
+            $this->createMock(PropertyAccessorInterface::class),
+            $publisher,
+            new PermissionChecker(),
+            mercureConfigResolver: $this->resolverReturning(['/server/entity-mutator-fixtures/{id}']),
+        );
+
+        try {
+            $mutator->delete(EntityMutatorFixture::class, 5);
+            $this->fail('Expected a MutationPersistenceException to be thrown.');
+        } catch (MutationPersistenceException $exception) {
+            $this->assertSame(409, $exception->getStatusCode());
+            $this->assertSame('The operation could not be completed due to a data conflict.', $exception->getClientMessage());
+            $this->assertSame($lockException, $exception->getPrevious());
+        }
+    }
+
+    #[Test]
     public function it_propagates_not_found_from_the_locator_on_delete(): void
     {
         $manager    = $this->createMock(EntityManagerInterface::class);
@@ -541,7 +578,20 @@ final class EntityMutatorTest extends TestCase
 
     private function dbalException(): DBALException
     {
-        return new class('constraint violation') extends \RuntimeException implements DBALException {};
+        // A genuine Doctrine\DBAL\Exception subtype that exists as such in both
+        // DBAL 3 and 4. It must never `implements Doctrine\DBAL\Exception`,
+        // which is a class in DBAL 3 (fatal) and only an interface in DBAL 4.
+        return new UniqueConstraintViolationException($this->driverException(), null);
+    }
+
+    private function driverException(): DriverException
+    {
+        return new class('constraint violation') extends \RuntimeException implements DriverException {
+            public function getSQLState(): ?string
+            {
+                return '23505';
+            }
+        };
     }
 
     private function managerReturning(object $entity, int|string $id): EntityManagerInterface

--- a/tests/Unit/Mutation/EntityMutatorTest.php
+++ b/tests/Unit/Mutation/EntityMutatorTest.php
@@ -474,14 +474,10 @@ final class EntityMutatorTest extends TestCase
             mercureConfigResolver: $this->resolverReturning(['/server/entity-mutator-fixtures/{id}']),
         );
 
-        try {
-            $mutator->delete(EntityMutatorFixture::class, 5);
-            $this->fail('Expected a MutationPersistenceException to be thrown.');
-        } catch (MutationPersistenceException $exception) {
-            $this->assertSame(409, $exception->getStatusCode());
-            $this->assertSame('The operation could not be completed due to a data conflict.', $exception->getClientMessage());
-            $this->assertSame($dbalException, $exception->getPrevious());
-        }
+        $this->assertMapsToPersistenceException(
+            fn () => $mutator->delete(EntityMutatorFixture::class, 5),
+            $dbalException,
+        );
     }
 
     #[Test]
@@ -509,14 +505,10 @@ final class EntityMutatorTest extends TestCase
             mercureConfigResolver: $this->resolverReturning(['/server/entity-mutator-fixtures/{id}']),
         );
 
-        try {
-            $mutator->setProperty(EntityMutatorFixture::class, 5, 'enabled', true);
-            $this->fail('Expected a MutationPersistenceException to be thrown.');
-        } catch (MutationPersistenceException $exception) {
-            $this->assertSame(409, $exception->getStatusCode());
-            $this->assertSame('The operation could not be completed due to a data conflict.', $exception->getClientMessage());
-            $this->assertSame($dbalException, $exception->getPrevious());
-        }
+        $this->assertMapsToPersistenceException(
+            fn () => $mutator->setProperty(EntityMutatorFixture::class, 5, 'enabled', true),
+            $dbalException,
+        );
     }
 
     #[Test]
@@ -543,14 +535,10 @@ final class EntityMutatorTest extends TestCase
             mercureConfigResolver: $this->resolverReturning(['/server/entity-mutator-fixtures/{id}']),
         );
 
-        try {
-            $mutator->delete(EntityMutatorFixture::class, 5);
-            $this->fail('Expected a MutationPersistenceException to be thrown.');
-        } catch (MutationPersistenceException $exception) {
-            $this->assertSame(409, $exception->getStatusCode());
-            $this->assertSame('The operation could not be completed due to a data conflict.', $exception->getClientMessage());
-            $this->assertSame($lockException, $exception->getPrevious());
-        }
+        $this->assertMapsToPersistenceException(
+            fn () => $mutator->delete(EntityMutatorFixture::class, 5),
+            $lockException,
+        );
     }
 
     #[Test]
@@ -574,6 +562,26 @@ final class EntityMutatorTest extends TestCase
 
         $this->expectException(EntityNotFoundException::class);
         $mutator->delete(EntityMutatorFixture::class, 404);
+    }
+
+    /**
+     * Asserts that running $act maps its underlying failure to a 409
+     * MutationPersistenceException wrapping $expectedPrevious.
+     */
+    private function assertMapsToPersistenceException(callable $act, \Throwable $expectedPrevious): void
+    {
+        $caught = null;
+
+        try {
+            $act();
+        } catch (MutationPersistenceException $exception) {
+            $caught = $exception;
+        }
+
+        $this->assertInstanceOf(MutationPersistenceException::class, $caught);
+        $this->assertSame(409, $caught->getStatusCode());
+        $this->assertSame('The operation could not be completed due to a data conflict.', $caught->getClientMessage());
+        $this->assertSame($expectedPrevious, $caught->getPrevious());
     }
 
     private function dbalException(): DBALException


### PR DESCRIPTION
## Summary

Fixes #244. A Doctrine failure at `flush()` (constraint violation, deadlock — a `Doctrine\DBAL\Exception`) in `EntityMutator::delete()` / `setProperty()` was not caught and bubbled up as a raw HTTP 500, while `MutationExceptionListener` already maps any `MutationException` to a structured JSON error.

## Changes
- **New** `MutationPersistenceException extends MutationException` — client-safe default message, `getStatusCode()` = **409**, preserves the original throwable as `$previous` (no raw DB message leaked to the client).
- Extracted a private `flush(ObjectManager $manager)` helper (DRY across both mutations) that wraps `flush()` in a `try/catch (\Doctrine\DBAL\Exception)` and rethrows as `MutationPersistenceException`.
- Permission/metadata checks, the Mercure publish path, and the success path are untouched. `@throws` docblocks updated.

## Tests
Added tests for `delete()` and `setProperty()` simulating a `flush()` that throws a `Doctrine\DBAL\Exception`, asserting a `MutationPersistenceException` (409, safe message, original as `getPrevious()`) is thrown and no Mercure event is published. Verified they fail against the old code.

`vendor/bin/phpunit` → **OK (838 tests)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L9sBdCeRV1NVkqFAqTMYkh)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error handling for all mutation persistence failures (including non-conflict DB errors mapped to 409), which affects API behavior clients may rely on, but success paths and permissions are unchanged.
> 
> **Overview**
> Doctrine `flush()` failures during inline **delete** and **setProperty** mutations no longer bubble up as raw HTTP 500s. A new **`MutationPersistenceException`** (extends **`MutationException`**) returns **409** with a fixed client-safe message and keeps the original error in `$previous`, so **`MutationExceptionListener`** can emit structured JSON like other mutation errors.
> 
> **`EntityMutator`** routes both mutation paths through a private **`flush()`** helper that catches **`Doctrine\DBAL\Exception`** and **`OptimisticLockException`** (e.g. unique violations, optimistic-lock conflicts) and rethrows as **`MutationPersistenceException`**. Mercure publish only runs after a successful flush.
> 
> Unit tests cover DBAL and optimistic-lock failures on delete/setProperty, assert 409 + safe message + wrapped previous, and verify **no Mercure event** is published when persistence fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c5cb3a6d9fb033fd6979a3cac4ad9a06fe9e366. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->