### PR TITLE
refactor(query): delegate ContainsSearchStrategy to SearchPredicateFactory (#246)

### DIFF
--- a/src/Query/SearchPredicateFactory.php
+++ b/src/Query/SearchPredicateFactory.php
@@ -12,6 +12,9 @@ use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
  *
  * For numeric columns: exact match when the value is numeric, null otherwise.
  * For other columns: LIKE %value% when the field supports search filtering, null otherwise.
+ *
+ * A column is treated as numeric when {@see ColumnInterface::isNumber()} is true or when
+ * the caller forces numeric handling via $forceNumeric (e.g. based on an external type hint).
  */
 final class SearchPredicateFactory
 {
@@ -22,8 +25,9 @@ final class SearchPredicateFactory
         string $field,
         string $value,
         string $paramName,
+        bool $forceNumeric = false,
     ): ?string {
-        if ($column->isNumber()) {
+        if ($column->isNumber() || $forceNumeric) {
             if (!is_numeric($value)) {
                 return null;
             }

--- a/src/Query/Strategy/ContainsSearchStrategy.php
+++ b/src/Query/Strategy/ContainsSearchStrategy.php
@@ -8,42 +8,41 @@ use Doctrine\ORM\QueryBuilder;
 use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
 use Pentiminax\UX\DataTables\Contracts\SearchStrategyInterface;
 use Pentiminax\UX\DataTables\DataTableRequest\ColumnControlSearch;
-use Pentiminax\UX\DataTables\Query\RelationFieldResolver;
-use Pentiminax\UX\DataTables\Query\SearchConditionBuilder;
+use Pentiminax\UX\DataTables\Query\SearchPredicateFactory;
 
 /**
  * Strategy for 'contains' search logic.
  *
  * Performs a case-sensitive substring search using SQL LIKE %value%.
  * For numeric columns, performs exact match if the value is numeric.
+ *
+ * Predicate construction is delegated to {@see SearchPredicateFactory} so the
+ * "numeric → exact / date → skip / text → LIKE" branching lives in a single place.
+ * In addition to the column's own type, a search type hint of number/numeric/num
+ * forces numeric handling.
  */
 final class ContainsSearchStrategy implements SearchStrategyInterface
 {
+    private const array NUMERIC_TYPE_HINTS = ['number', 'numeric', 'num'];
+
     public function apply(QueryBuilder $qb, ColumnInterface $column, ColumnControlSearch $search, int $paramIndex, string $alias): void
     {
         if ('' === trim($search->value)) {
             return;
         }
 
-        $paramName = \sprintf('column_control_param_%d', $paramIndex);
-
-        $isNumeric = $column->isNumber()
-                     || \in_array(strtolower($search->type), ['number', 'numeric', 'num'], true);
-
-        if ($isNumeric) {
-            if (!is_numeric($search->value)) {
-                return;
-            }
-            $qb->andWhere(SearchConditionBuilder::numeric($qb, $alias, $column->getField(), $search->value, $paramName));
-        } elseif ($column->isDate()) {
+        $field = $column->getField();
+        if (null === $field) {
             return;
-        } else {
-            $field = $column->getField();
-            if (null === $field || !RelationFieldResolver::supportsTextSearch($qb, $field)) {
-                return;
-            }
+        }
 
-            $qb->andWhere(SearchConditionBuilder::text($qb, $alias, $field, $search->value, $paramName));
+        $paramName    = \sprintf('column_control_param_%d', $paramIndex);
+        $forceNumeric = \in_array(strtolower($search->type), self::NUMERIC_TYPE_HINTS, true);
+
+        $predicate = SearchPredicateFactory::build($qb, $column, $alias, $field, $search->value, $paramName, $forceNumeric);
+
+        if (null !== $predicate) {
+            $qb->andWhere($predicate);
         }
     }
 

--- a/tests/Unit/Query/SearchPredicateFactoryTest.php
+++ b/tests/Unit/Query/SearchPredicateFactoryTest.php
@@ -81,6 +81,31 @@ final class SearchPredicateFactoryTest extends TestCase
     }
 
     #[Test]
+    public function it_returns_exact_condition_for_non_numeric_column_when_forcing_numeric(): void
+    {
+        $qb = $this->createMock(QueryBuilder::class);
+        $qb->method('getDQLPart')->with('join')->willReturn([]);
+        $qb->expects($this->once())->method('setParameter')->with('p_0', '42');
+
+        $column = TextColumn::new('score', 'Score')->setField('score');
+        $result = SearchPredicateFactory::build($qb, $column, 'e', 'score', '42', 'p_0', true);
+
+        $this->assertSame('e.score = :p_0', $result);
+    }
+
+    #[Test]
+    public function it_returns_null_when_forcing_numeric_with_non_numeric_value(): void
+    {
+        $qb = $this->createMock(QueryBuilder::class);
+        $qb->expects($this->never())->method('setParameter');
+
+        $column = TextColumn::new('score', 'Score')->setField('score');
+        $result = SearchPredicateFactory::build($qb, $column, 'e', 'score', 'abc', 'p_0', true);
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
     public function it_returns_null_for_non_text_field(): void
     {
         $metadata = $this->createMock(ClassMetadata::class);

--- a/tests/Unit/Query/Strategy/ContainsSearchStrategyTest.php
+++ b/tests/Unit/Query/Strategy/ContainsSearchStrategyTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Unit\Query\Strategy;
+
+use Doctrine\ORM\QueryBuilder;
+use Pentiminax\UX\DataTables\Column\NumberColumn;
+use Pentiminax\UX\DataTables\Column\TextColumn;
+use Pentiminax\UX\DataTables\DataTableRequest\ColumnControlSearch;
+use Pentiminax\UX\DataTables\Enum\ColumnControlLogic;
+use Pentiminax\UX\DataTables\Query\Strategy\ContainsSearchStrategy;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+#[CoversClass(ContainsSearchStrategy::class)]
+final class ContainsSearchStrategyTest extends TestCase
+{
+    #[Test]
+    public function it_returns_logic_value(): void
+    {
+        $this->assertSame('contains', (new ContainsSearchStrategy())->getLogic());
+    }
+
+    #[Test]
+    public function it_applies_like_condition_for_text_column(): void
+    {
+        $qb = $this->createMock(QueryBuilder::class);
+        $qb->method('getDQLPart')->with('join')->willReturn([]);
+        $qb->expects($this->once())->method('setParameter')->with('column_control_param_3', '%foo%');
+        $qb->expects($this->once())->method('andWhere')->with('e.name LIKE :column_control_param_3');
+
+        $column = TextColumn::new('name')->setField('name');
+        $search = new ColumnControlSearch('foo', ColumnControlLogic::Contains, 'text');
+
+        (new ContainsSearchStrategy())->apply($qb, $column, $search, 3, 'e');
+    }
+
+    #[Test]
+    public function it_applies_exact_condition_for_numeric_column(): void
+    {
+        $qb = $this->createMock(QueryBuilder::class);
+        $qb->method('getDQLPart')->with('join')->willReturn([]);
+        $qb->expects($this->once())->method('setParameter')->with('column_control_param_1', '42');
+        $qb->expects($this->once())->method('andWhere')->with('e.id = :column_control_param_1');
+
+        $column = NumberColumn::new('id')->setField('id');
+        $search = new ColumnControlSearch('42', ColumnControlLogic::Contains, 'text');
+
+        (new ContainsSearchStrategy())->apply($qb, $column, $search, 1, 'e');
+    }
+
+    /**
+     * Regression guard: a numeric search type hint must force numeric (exact) handling
+     * even when the column itself is not numeric.
+     */
+    #[Test]
+    public function it_applies_exact_condition_when_search_type_is_number(): void
+    {
+        $qb = $this->createMock(QueryBuilder::class);
+        $qb->method('getDQLPart')->with('join')->willReturn([]);
+        $qb->expects($this->once())->method('setParameter')->with('column_control_param_2', '7');
+        $qb->expects($this->once())->method('andWhere')->with('e.score = :column_control_param_2');
+
+        $column = TextColumn::new('score')->setField('score');
+        $search = new ColumnControlSearch('7', ColumnControlLogic::Contains, 'number');
+
+        (new ContainsSearchStrategy())->apply($qb, $column, $search, 2, 'e');
+    }
+
+    #[Test]
+    public function it_does_nothing_when_search_type_is_number_but_value_is_non_numeric(): void
+    {
+        $qb = $this->createMock(QueryBuilder::class);
+        $qb->expects($this->never())->method('setParameter');
+        $qb->expects($this->never())->method('andWhere');
+
+        $column = TextColumn::new('score')->setField('score');
+        $search = new ColumnControlSearch('abc', ColumnControlLogic::Contains, 'numeric');
+
+        (new ContainsSearchStrategy())->apply($qb, $column, $search, 0, 'e');
+    }
+
+    #[Test]
+    public function it_does_nothing_for_blank_value(): void
+    {
+        $qb = $this->createMock(QueryBuilder::class);
+        $qb->expects($this->never())->method('setParameter');
+        $qb->expects($this->never())->method('andWhere');
+
+        $column = TextColumn::new('name')->setField('name');
+        $search = new ColumnControlSearch('   ', ColumnControlLogic::Contains, 'text');
+
+        (new ContainsSearchStrategy())->apply($qb, $column, $search, 0, 'e');
+    }
+}

--- a/tests/Unit/Query/Strategy/ContainsSearchStrategyTest.php
+++ b/tests/Unit/Query/Strategy/ContainsSearchStrategyTest.php
@@ -7,6 +7,7 @@ namespace Pentiminax\UX\DataTables\Tests\Unit\Query\Strategy;
 use Doctrine\ORM\QueryBuilder;
 use Pentiminax\UX\DataTables\Column\NumberColumn;
 use Pentiminax\UX\DataTables\Column\TextColumn;
+use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
 use Pentiminax\UX\DataTables\DataTableRequest\ColumnControlSearch;
 use Pentiminax\UX\DataTables\Enum\ColumnControlLogic;
 use Pentiminax\UX\DataTables\Query\Strategy\ContainsSearchStrategy;
@@ -81,6 +82,26 @@ final class ContainsSearchStrategyTest extends TestCase
 
         $column = TextColumn::new('score')->setField('score');
         $search = new ColumnControlSearch('abc', ColumnControlLogic::Contains, 'numeric');
+
+        (new ContainsSearchStrategy())->apply($qb, $column, $search, 0, 'e');
+    }
+
+    /**
+     * The upfront null-field guard prevents a null field from reaching the predicate
+     * builder (whose $field parameter is a non-null string), which would otherwise
+     * TypeError. This applies to every column type, including forced-numeric.
+     */
+    #[Test]
+    public function it_does_nothing_when_the_column_field_is_null(): void
+    {
+        $qb = $this->createMock(QueryBuilder::class);
+        $qb->expects($this->never())->method('setParameter');
+        $qb->expects($this->never())->method('andWhere');
+
+        $column = $this->createMock(ColumnInterface::class);
+        $column->method('getField')->willReturn(null);
+
+        $search = new ColumnControlSearch('7', ColumnControlLogic::Contains, 'number');
 
         (new ContainsSearchStrategy())->apply($qb, $column, $search, 0, 'e');
     }


### PR DESCRIPTION
## Summary

Fixes #246. The "numeric → exact / date → skip / text → LIKE" branching lived in two near-identical places (`SearchPredicateFactory::build()` and `ContainsSearchStrategy::apply()`) that had already diverged.

## Changes
- `SearchPredicateFactory::build()` gains an optional `bool $forceNumeric = false`; the numeric branch triggers on `$column->isNumber() || $forceNumeric`. The default keeps `GlobalSearchFilter` / `ColumnSearchFilter` call sites byte-for-byte unchanged.
- `ContainsSearchStrategy::apply()` now delegates all predicate construction to `build()`, passing `forceNumeric` computed from the `search->type` hint (`number`/`numeric`/`num`). The factory is now the single source of truth for the branching.

## Behavior preserved
Blank-value early return, `column_control_param_%d` naming, date-skip, text `supportsTextSearch` guard, and the `search->type` numeric signal all preserved. The two existing `build()` callers are untouched (not in the diff) and produce identical DQL.

## Tests
Added `forceNumeric` coverage to `SearchPredicateFactoryTest` and a new `ContainsSearchStrategyTest` (text LIKE, numeric-column exact, `type=number` regression guard, non-numeric-value no-op, blank early return).

`vendor/bin/phpunit` → **OK (844 tests)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L9sBdCeRV1NVkqFAqTMYkh)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with behavior preserved for existing factory callers; search query behavior is covered by new unit tests.
> 
> **Overview**
> **Centralizes column-control “contains” predicate logic** in `SearchPredicateFactory` so numeric exact / date skip / text LIKE branching is no longer duplicated in `ContainsSearchStrategy`.
> 
> `SearchPredicateFactory::build()` gains an optional **`$forceNumeric`** flag (default `false`); numeric handling runs when the column is numeric **or** that flag is set. `ContainsSearchStrategy` now calls `build()` and sets `forceNumeric` from search type hints `number`, `numeric`, or `num`. It also **returns early when the column field is null** before building predicates. Existing callers (`GlobalSearchFilter`, `ColumnSearchFilter`) stay on the default and are unchanged.
> 
> Tests add **`forceNumeric`** cases on the factory and a new **`ContainsSearchStrategyTest`** covering LIKE, numeric column, type-hint regression, blank values, and null field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8e59a935d8bafb88c87c74aa562cb2f825ed2ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->