### PR TITLE
test(data-provider): cover search + pagination boundary in ArrayDataP…

### DIFF
--- a/tests/Unit/DataProvider/ArrayDataProviderTest.php
+++ b/tests/Unit/DataProvider/ArrayDataProviderTest.php
@@ -123,6 +123,44 @@ final class ArrayDataProviderTest extends TestCase
     }
 
     #[Test]
+    public function it_applies_pagination_to_the_matched_rows_when_a_search_is_active(): void
+    {
+        $mapper = new CountingRowMapper();
+
+        $provider = new ArrayDataProvider(
+            [
+                ['id' => 1, 'name' => 'Alice'],
+                ['id' => 2, 'name' => 'Bob'],
+                ['id' => 3, 'name' => 'Alicia'],
+                ['id' => 4, 'name' => 'Carol'],
+                ['id' => 5, 'name' => 'Alina'],
+            ],
+            $mapper,
+        );
+
+        // Three rows match 'ali'; the page boundary must apply to the matched set.
+        $result = $provider->fetchData(new DataTableRequest(
+            draw: 1,
+            columns: new Columns([]),
+            start: 1,
+            length: 1,
+            search: new Search('ali', false),
+        ));
+
+        $data = iterator_to_array($result->data);
+
+        $this->assertSame(5, $result->recordsTotal);
+        $this->assertSame(3, $result->recordsFiltered);
+        // start: 1, length: 1 selects the second match (Alicia), not the first or all.
+        $this->assertSame([
+            ['id' => 3, 'name' => 'Alicia'],
+        ], $data);
+
+        // Every element is still mapped exactly once, even though only one is returned.
+        $this->assertSame(5, $mapper->calls);
+    }
+
+    #[Test]
     public function it_treats_an_empty_search_value_as_no_search_and_maps_only_the_slice(): void
     {
         $mapper = new CountingRowMapper();


### PR DESCRIPTION
…rovider (#242)

Adds a case where multiple rows match the global search and start/length select a middle page, verifying the page boundary is applied to the matched set (not the full input) and every element is still mapped exactly once. Addresses a review coverage gap on the search+slice interaction.


Claude-Session: https://claude.ai/code/session_01L9sBdCeRV1NVkqFAqTMYkh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code modifications.
> 
> **Overview**
> Adds **`it_applies_pagination_to_the_matched_rows_when_a_search_is_active`** to `ArrayDataProviderTest`, filling a gap next to the existing “search with full page” and “no search slice” cases.
> 
> The scenario uses five rows, three matching global search `ali`, with **`start: 1`** and **`length: 1`**. It asserts **`recordsTotal`** / **`recordsFiltered`**, that the returned row is the **second** match (Alicia), and that **`CountingRowMapper`** still runs **once per input row** (5 calls) even though only one row is returned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60462f3a3788e2f3522aa97bd3a7b43101d0ca2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->