### PR TITLE
chore: add missing use statement

### DIFF
--- a/src/Model/DataTableExtensions.php
+++ b/src/Model/DataTableExtensions.php
@@ -8,6 +8,7 @@ use Pentiminax\UX\DataTables\Contracts\ExtensionInterface;
 use Pentiminax\UX\DataTables\Contracts\LayoutAwareExtensionInterface;
 use Pentiminax\UX\DataTables\Enum\ButtonType;
 use Pentiminax\UX\DataTables\Enum\SelectStyle;
+use Pentiminax\UX\DataTables\Model\Extensions\Button;
 use Pentiminax\UX\DataTables\Model\Extensions\ButtonsExtension;
 use Pentiminax\UX\DataTables\Model\Extensions\ColumnControlExtension;
 use Pentiminax\UX\DataTables\Model\Extensions\KeyTableExtension;


### PR DESCRIPTION
IDE was triggering a warning for this missing use statement