### PR TITLE
ci: require 80% Codecov coverage on pull requests

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 0%
+    patch:
+      default:
+        target: 80%


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add a repository `codecov.yml` so Codecov enforces an 80% coverage floor on pull requests instead of relying on undocumented defaults.

- `coverage.status.project.default.target: 80%` with `threshold: 0%` so overall coverage cannot drop below 80%
- `coverage.status.patch.default.target: 80%` so at least 80% of changed lines must be covered
- CI upload paths are unchanged (PHP Cobertura only)

Current project coverage is about 83.5%, so the project target is already met.

## Follow-up (cannot be done in this PR)

The GitHub `Main ruleset` still does not require `codecov/project` or `codecov/patch`. A failing Codecov check will not block merge until those checks are marked required in Settings → Rulesets.

## Test plan

- [x] Validated with `curl --data-binary @codecov.yml https://codecov.io/validate`
- [ ] Confirm Codecov posts `codecov/project` and `codecov/patch` against this PR using the 80% targets
- [ ] After merge, optionally require those checks in the GitHub ruleset

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1cbcdf6a-c19e-4c6e-98c4-d360a6917859?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1cbcdf6a-c19e-4c6e-98c4-d360a6917859&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

