### PR TITLE
feat: expose table and Ajax request details in the profiler panel

### DIFF
--- a/src/Controller/AjaxDataController.php
+++ b/src/Controller/AjaxDataController.php
@@ -56,6 +56,8 @@ final class AjaxDataController
         $payload = json_decode((string) $response->getContent(), true);
         $payload = \is_array($payload) ? $payload : [];
 
+        $provider = $table->getDataProvider();
+
         $this->profiler->collectAjaxQuery(
             class: $table::class,
             token: $token,
@@ -63,6 +65,11 @@ final class AjaxDataController
             recordsTotal: (int) ($payload['recordsTotal'] ?? 0),
             recordsFiltered: (int) ($payload['recordsFiltered'] ?? 0),
             durationMs: $durationMs,
+            providerClass: null !== $provider ? $provider::class : null,
+            entityClass: $table->getEntityClass(),
+            rowCount: \is_array($payload['data'] ?? null) ? \count($payload['data']) : 0,
+            payloadBytes: \strlen((string) $response->getContent()),
+            httpStatus: $response->getStatusCode(),
         );
     }
 }

--- a/src/DataCollector/DataTableCollector.php
+++ b/src/DataCollector/DataTableCollector.php
@@ -18,12 +18,24 @@ final class DataTableCollector extends AbstractDataCollector
 
     public function collect(Request $request, Response $response, ?\Throwable $exception = null): void
     {
-        $tables = $this->profiler->getRenderedTables();
+        $tables = array_map(function (array $table): array {
+            $table['ajax'] = null === $table['ajax'] ? null : $this->cloneVar($table['ajax']);
 
-        // Rendered-table records hold only scalars/arrays, so they serialize as-is.
-        // AJAX query records carry a DataTableRequest object -> clone that field only.
+            $table['extensions'] = array_map(function (array $extension): array {
+                $extension['options'] = $this->cloneVar($extension['options']);
+
+                return $extension;
+            }, $table['extensions']);
+
+            return $table;
+        }, $this->profiler->getRenderedTables());
+
         $queries = array_map(function (array $query): array {
             $query['request'] = $this->cloneVar($query['request']);
+
+            if (isset($query['requestSummary']['filters'])) {
+                $query['requestSummary']['filters'] = $this->cloneVar($query['requestSummary']['filters']);
+            }
 
             return $query;
         }, $this->profiler->getAjaxQueries());

--- a/src/DataTableRequest/Columns.php
+++ b/src/DataTableRequest/Columns.php
@@ -24,6 +24,14 @@ final readonly class Columns
         return new self($columns);
     }
 
+    /**
+     * @return array<string, Column> request columns keyed by column name
+     */
+    public function all(): array
+    {
+        return $this->columns;
+    }
+
     public function getColumnByName(string $name): ?Column
     {
         return $this->columns[$name] ?? null;

--- a/src/Model/DataTableExtensions.php
+++ b/src/Model/DataTableExtensions.php
@@ -91,6 +91,17 @@ class DataTableExtensions implements \JsonSerializable
         return $this;
     }
 
+    /**
+     * Every registered extension, including layout-aware ones that
+     * {@see self::jsonSerialize()} deliberately omits from the client payload.
+     *
+     * @return array<string, ExtensionInterface>
+     */
+    public function all(): array
+    {
+        return $this->extensions;
+    }
+
     public function getButtonsExtension(): ?ButtonsExtension
     {
         return $this->extensions['buttons'] ?? null;

--- a/src/Profiler/DataTableProfiler.php
+++ b/src/Profiler/DataTableProfiler.php
@@ -4,7 +4,12 @@ declare(strict_types=1);
 
 namespace Pentiminax\UX\DataTables\Profiler;
 
+use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
+use Pentiminax\UX\DataTables\Contracts\ExtensionInterface;
+use Pentiminax\UX\DataTables\Contracts\LayoutAwareExtensionInterface;
+use Pentiminax\UX\DataTables\DataTableRequest\Column;
 use Pentiminax\UX\DataTables\DataTableRequest\DataTableRequest;
+use Pentiminax\UX\DataTables\DataTableRequest\Order;
 use Pentiminax\UX\DataTables\Model\DataTable;
 
 /**
@@ -13,6 +18,9 @@ use Pentiminax\UX\DataTables\Model\DataTable;
  * Registered with the `kernel.reset` tag so its state is cleared between
  * requests — required for FrankenPHP worker mode, where the process (and this
  * shared service) survives across requests.
+ *
+ * Records hold scalars and plain arrays only: row data never reaches the
+ * profile, so business values are not copied into var/cache/dev/profiler.
  */
 final class DataTableProfiler
 {
@@ -22,18 +30,35 @@ final class DataTableProfiler
     /** @var array<int, array<string, mixed>> */
     private array $ajaxQueries = [];
 
-    public function collectRenderedTable(string $class, DataTable $table): void
+    /**
+     * @param array{entityClass?: string|null, originalColumns?: list<ColumnInterface>, allowedColumns?: list<ColumnInterface>} $context
+     *                                                                                                                                   Rendering context only available to the caller, such as the columns removed
+     *                                                                                                                                   by static permission filtering
+     */
+    public function collectRenderedTable(string $class, DataTable $table, array $context = []): void
     {
         $options = $table->getOptions();
 
         $this->renderedTables[] = [
-            'id'          => $table->getId(),
-            'class'       => $class,
-            'serverSide'  => $table->isServerSide(),
-            'columnCount' => \count($table->getColumns()),
-            'extensions'  => array_keys($table->getExtensions()),
-            'ajax'        => $table->getOption('ajax'),
-            'hasData'     => !empty($options['data']),
+            'id'                       => $table->getId(),
+            'class'                    => $class,
+            'entityClass'              => $context['entityClass'] ?? null,
+            'serverSide'               => $table->isServerSide(),
+            'columnCount'              => \count($table->getColumns()),
+            'extensions'               => $this->describeExtensions($table),
+            'ajax'                     => $table->getOption('ajax'),
+            'hasData'                  => !empty($options['data']),
+            'rowCount'                 => \is_array($options['data'] ?? null) ? \count($options['data']) : 0,
+            'dataController'           => $table->getDataController(),
+            'forwardedQueryParameters' => $table->getForwardedQueryParameters(),
+            'columns'                  => $this->describeColumns($table->getColumns()),
+            'deniedColumns'            => $this->describeDeniedColumns($context),
+            'filters'                  => $table->getFilters()?->jsonSerialize() ?? [],
+            'mercure'                  => $this->describeMercure($table),
+            'editModal'                => [
+                'template' => $table->getEditModalTemplate(),
+                'adapter'  => $table->getEditModalAdapter(),
+            ],
         ];
     }
 
@@ -44,14 +69,25 @@ final class DataTableProfiler
         int $recordsTotal,
         int $recordsFiltered,
         float $durationMs,
+        ?string $providerClass = null,
+        ?string $entityClass = null,
+        int $rowCount = 0,
+        int $payloadBytes = 0,
+        ?int $httpStatus = null,
     ): void {
         $this->ajaxQueries[] = [
             'class'           => $class,
             'token'           => $token,
             'request'         => $request,
+            'requestSummary'  => $this->summarizeRequest($request),
             'recordsTotal'    => $recordsTotal,
             'recordsFiltered' => $recordsFiltered,
             'durationMs'      => $durationMs,
+            'providerClass'   => $providerClass,
+            'entityClass'     => $entityClass,
+            'rowCount'        => $rowCount,
+            'payloadBytes'    => $payloadBytes,
+            'httpStatus'      => $httpStatus,
         ];
     }
 
@@ -71,5 +107,135 @@ final class DataTableProfiler
     {
         $this->renderedTables = [];
         $this->ajaxQueries    = [];
+    }
+
+    /**
+     * Reads the mutable collection instead of DataTable::getExtensions(), whose
+     * JSON payload drops layout-aware extensions such as Buttons.
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function describeExtensions(DataTable $table): array
+    {
+        return array_values(array_map(
+            static fn (ExtensionInterface $extension): array => [
+                'key'         => $extension->getKey(),
+                'class'       => $extension::class,
+                'layoutAware' => $extension instanceof LayoutAwareExtensionInterface,
+                'options'     => $extension->jsonSerialize(),
+            ],
+            $table->getExtensionsCollection()->all(),
+        ));
+    }
+
+    /**
+     * @param array<string, ColumnInterface> $columns
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function describeColumns(array $columns): array
+    {
+        return array_values(array_map(
+            static fn (ColumnInterface $column): array => $column->jsonSerialize(),
+            $columns,
+        ));
+    }
+
+    /**
+     * @param array{originalColumns?: list<ColumnInterface>, allowedColumns?: list<ColumnInterface>} $context
+     *
+     * @return list<string>
+     */
+    private function describeDeniedColumns(array $context): array
+    {
+        $original = $context['originalColumns'] ?? null;
+        $allowed  = $context['allowedColumns']  ?? null;
+
+        if (!\is_array($original) || !\is_array($allowed)) {
+            return [];
+        }
+
+        $names = static fn (array $columns): array => array_map(
+            static fn (ColumnInterface $column): string => $column->getName(),
+            $columns,
+        );
+
+        return array_values(array_diff($names($original), $names($allowed)));
+    }
+
+    /** @return array<string, mixed>|null */
+    private function describeMercure(DataTable $table): ?array
+    {
+        $config = $table->getMercureConfig();
+
+        if (null === $config) {
+            return null;
+        }
+
+        // Not jsonSerialize(): it throws until the hub URL has been resolved.
+        return [
+            'topics'          => $config->topics,
+            'hubUrl'          => $config->hubUrl,
+            'withCredentials' => $config->withCredentials,
+            'debounceMs'      => $config->debounceMs,
+        ];
+    }
+
+    /**
+     * Flattens the request into scalars so the panel can render real tables
+     * instead of a collapsed variable dump.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function summarizeRequest(?DataTableRequest $request): ?array
+    {
+        if (null === $request) {
+            return null;
+        }
+
+        $length = $request->length;
+
+        return [
+            'draw'   => $request->draw,
+            'start'  => $request->start,
+            'length' => $length,
+            'page'   => $length > 0 ? intdiv($request->start, $length) + 1 : 1,
+            'search' => null === $request->search ? null : [
+                'value' => $request->search->value,
+                'regex' => $request->search->regex,
+            ],
+            'order' => array_values(array_map(
+                static fn (Order $order): array => [
+                    'column' => $order->column,
+                    'name'   => $order->name,
+                    'dir'    => $order->dir,
+                ],
+                $request->order,
+            )),
+            'columns' => $this->summarizeRequestColumns($request),
+            'filters' => $request->filters,
+        ];
+    }
+
+    /** @return list<array<string, mixed>> */
+    private function summarizeRequestColumns(DataTableRequest $request): array
+    {
+        $columns = [];
+        $index   = 0;
+
+        foreach ($request->columns->all() as $column) {
+            \assert($column instanceof Column);
+
+            $columns[] = [
+                'index'       => $index++,
+                'data'        => $column->data,
+                'name'        => $column->name,
+                'searchable'  => $column->searchable,
+                'orderable'   => $column->orderable,
+                'searchValue' => $column->search?->value,
+            ];
+        }
+
+        return $columns;
     }
 }

--- a/src/Twig/DataTablesExtension.php
+++ b/src/Twig/DataTablesExtension.php
@@ -44,6 +44,7 @@ class DataTablesExtension extends AbstractExtension
     public function renderDataTable(AbstractDataTable|DataTable $table, array $attributes = []): string
     {
         $dataTableClass = $table instanceof AbstractDataTable ? $table::class : $table->getDataTableClass();
+        $abstractTable  = $table instanceof AbstractDataTable ? $table : null;
 
         if ($table instanceof AbstractDataTable) {
             $table = $table->getDataTable();
@@ -120,7 +121,11 @@ class DataTablesExtension extends AbstractExtension
             }
         }
 
-        $this->profiler?->collectRenderedTable($dataTableClass ?? $table->getId(), $table);
+        $this->profiler?->collectRenderedTable($dataTableClass ?? $table->getId(), $table, [
+            'entityClass'     => $abstractTable?->getEntityClass(),
+            'originalColumns' => $originalColumns,
+            'allowedColumns'  => $columns,
+        ]);
 
         return \sprintf('<table id="%s" %s></table>', $table->getId(), $stimulusAttributes);
     }

--- a/templates/Collector/data_collector.html.twig
+++ b/templates/Collector/data_collector.html.twig
@@ -2,6 +2,8 @@
 
 {% block toolbar %}
     {% if collector.tableCount > 0 or collector.queryCount > 0 %}
+        {% set totalDuration = collector.queries|reduce((carry, query) => carry + query.durationMs, 0) %}
+
         {% set icon %}
             {{ source('@DataTables/Collector/icon.svg') }}
             <span class="sf-toolbar-value">{{ collector.tableCount }}</span>
@@ -16,6 +18,12 @@
                 <b class="sf-toolbar-label">AJAX queries</b>
                 <span class="sf-toolbar-status">{{ collector.queryCount }}</span>
             </div>
+            {% if collector.queryCount > 0 %}
+                <div class="sf-toolbar-info-piece">
+                    <b class="sf-toolbar-label">AJAX duration</b>
+                    <span>{{ totalDuration|number_format(2) }} ms</span>
+                </div>
+            {% endif %}
         {% endset %}
 
         {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: profiler_url }) }}
@@ -42,7 +50,7 @@
                     <th>Server side</th>
                     <th>Columns</th>
                     <th>Extensions</th>
-                    <th>Inline data</th>
+                    <th>Inline rows</th>
                 </tr>
             </thead>
             <tbody>
@@ -52,12 +60,167 @@
                         <td><code>{{ table.class }}</code></td>
                         <td>{{ table.serverSide ? 'yes' : 'no' }}</td>
                         <td>{{ table.columnCount }}</td>
-                        <td>{{ table.extensions is empty ? '—' : table.extensions|join(', ') }}</td>
-                        <td>{{ table.hasData ? 'yes' : 'no' }}</td>
+                        <td>
+                            {%- if table.extensions is empty -%}
+                                —
+                            {%- else -%}
+                                {{ table.extensions|map(extension => extension.key)|join(', ') }}
+                            {%- endif -%}
+                        </td>
+                        <td>{{ table.hasData ? table.rowCount : 'no' }}</td>
                     </tr>
                 {% endfor %}
             </tbody>
         </table>
+
+        {% for table in collector.tables %}
+            <h3>
+                {{ table.id }}
+                <a class="sf-toggle" data-toggle-selector="#datatable-detail-{{ loop.index }}" data-toggle-alt-content="[-] Collapse">[+] Expand</a>
+            </h3>
+
+            <div id="datatable-detail-{{ loop.index }}" class="sf-toggle-content sf-toggle-hidden">
+                <table>
+                    <tbody>
+                        <tr><th>Class</th><td><code>{{ table.class }}</code></td></tr>
+                        {% if table.entityClass %}
+                            <tr><th>Entity</th><td><code>{{ table.entityClass }}</code></td></tr>
+                        {% endif %}
+                        <tr><th>Server side</th><td>{{ table.serverSide ? 'yes' : 'no' }}</td></tr>
+                        <tr><th>Inline rows</th><td>{{ table.rowCount }}</td></tr>
+                        {% if table.dataController %}
+                            <tr><th>Data controller</th><td><code>{{ table.dataController }}</code></td></tr>
+                        {% endif %}
+                        {% if table.ajax %}
+                            <tr><th>Ajax</th><td>{{ profiler_dump(table.ajax, 3) }}</td></tr>
+                        {% endif %}
+                        {% if table.forwardedQueryParameters is not empty %}
+                            <tr><th>Forwarded query parameters</th><td><code>{{ table.forwardedQueryParameters|join(', ') }}</code></td></tr>
+                        {% endif %}
+                        {% if table.editModal.template or table.editModal.adapter %}
+                            <tr>
+                                <th>Edit modal</th>
+                                <td>
+                                    adapter: <code>{{ table.editModal.adapter ?? 'default' }}</code>
+                                    {% if table.editModal.template %} — template: <code>{{ table.editModal.template }}</code>{% endif %}
+                                </td>
+                            </tr>
+                        {% endif %}
+                        {% if table.mercure %}
+                            <tr>
+                                <th>Mercure</th>
+                                <td>
+                                    topics: <code>{{ table.mercure.topics|join(', ') }}</code>
+                                    {% if table.mercure.hubUrl %} — hub: <code>{{ table.mercure.hubUrl }}</code>{% endif %}
+                                    {% if table.mercure.debounceMs is not null %} — debounce: {{ table.mercure.debounceMs }} ms{% endif %}
+                                    {% if table.mercure.withCredentials %} — with credentials{% endif %}
+                                </td>
+                            </tr>
+                        {% endif %}
+                    </tbody>
+                </table>
+
+                {% if table.serverSide %}
+                    <p class="help">
+                        This table fetches its rows over AJAX. Its query details are collected in the
+                        profile of the AJAX request itself, reachable from the toolbar's AJAX tab, not in
+                        this page profile.
+                    </p>
+                {% endif %}
+
+                <h4>Columns</h4>
+                {% if table.columns is empty %}
+                    <div class="empty"><p>This table declares no column.</p></div>
+                {% else %}
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>#</th>
+                                <th>Name</th>
+                                <th>Data</th>
+                                <th>Type</th>
+                                <th>Field</th>
+                                <th>Orderable</th>
+                                <th>Searchable</th>
+                                <th>Visible</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for column in table.columns %}
+                                <tr>
+                                    <td>{{ loop.index0 }}</td>
+                                    <td><code>{{ column.name ?? '—' }}</code></td>
+                                    <td>{{ column.data ?? '—' }}</td>
+                                    <td>{{ column.type ?? '—' }}</td>
+                                    <td>{{ column.field ?? '—' }}</td>
+                                    <td>{{ (column.orderable ?? true) ? 'yes' : 'no' }}</td>
+                                    <td>{{ (column.searchable ?? true) ? 'yes' : 'no' }}</td>
+                                    <td>{{ (column.visible ?? true) ? 'yes' : 'no' }}</td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                {% endif %}
+
+                {% if table.deniedColumns is not empty %}
+                    <p class="help">
+                        Removed by static permission filtering:
+                        <code>{{ table.deniedColumns|join(', ') }}</code>
+                    </p>
+                {% endif %}
+
+                <h4>Extensions</h4>
+                {% if table.extensions is empty %}
+                    <div class="empty"><p>No DataTables.net extension is enabled on this table.</p></div>
+                {% else %}
+                    {% for extension in table.extensions %}
+                        <table>
+                            <tbody>
+                                <tr><th>Key</th><td><code>{{ extension.key }}</code></td></tr>
+                                <tr><th>Class</th><td><code>{{ extension.class }}</code></td></tr>
+                                <tr>
+                                    <th>Layout aware</th>
+                                    <td>
+                                        {{ extension.layoutAware ? 'yes' : 'no' }}
+                                        {%- if extension.layoutAware %} (injected into the table layout, absent from the extensions payload){% endif %}
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>Options</th>
+                                    <td>{{ profiler_dump(extension.options, 3) }}</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    {% endfor %}
+                {% endif %}
+
+                <h4>Filters</h4>
+                {% if table.filters is empty %}
+                    <div class="empty"><p>This table declares no filter.</p></div>
+                {% else %}
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Name</th>
+                                <th>Type</th>
+                                <th>Label</th>
+                                <th>Placeholder</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for filter in table.filters %}
+                                <tr>
+                                    <td><code>{{ filter.name }}</code></td>
+                                    <td>{{ filter.type ?? '—' }}</td>
+                                    <td>{{ filter.label ?? '—' }}</td>
+                                    <td>{{ filter.placeholder ?? '—' }}</td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                {% endif %}
+            </div>
+        {% endfor %}
     {% endif %}
 
     <h2>AJAX queries</h2>
@@ -69,12 +232,117 @@
             <table>
                 <tbody>
                     <tr><th>Token</th><td><code>{{ query.token }}</code></td></tr>
+                    {% if query.providerClass %}
+                        <tr><th>Data provider</th><td><code>{{ query.providerClass }}</code></td></tr>
+                    {% endif %}
+                    {% if query.entityClass %}
+                        <tr><th>Entity</th><td><code>{{ query.entityClass }}</code></td></tr>
+                    {% endif %}
                     <tr><th>Records total</th><td>{{ query.recordsTotal }}</td></tr>
                     <tr><th>Records filtered</th><td>{{ query.recordsFiltered }}</td></tr>
+                    <tr><th>Returned rows</th><td>{{ query.rowCount }}</td></tr>
+                    <tr><th>Payload size</th><td>{{ query.payloadBytes }} B</td></tr>
+                    {% if query.httpStatus %}
+                        <tr><th>HTTP status</th><td>{{ query.httpStatus }}</td></tr>
+                    {% endif %}
                     <tr><th>Duration</th><td>{{ query.durationMs|number_format(2) }} ms</td></tr>
-                    <tr><th>Request</th><td>{{ profiler_dump(query.request) }}</td></tr>
+                    {% if query.requestSummary %}
+                        <tr><th>Draw</th><td>{{ query.requestSummary.draw ?? '—' }}</td></tr>
+                        <tr>
+                            <th>Pagination</th>
+                            <td>
+                                page {{ query.requestSummary.page }} — start {{ query.requestSummary.start }},
+                                length {{ query.requestSummary.length }}
+                            </td>
+                        </tr>
+                    {% endif %}
                 </tbody>
             </table>
+
+            {% if query.requestSummary %}
+                <h4>Global search</h4>
+                {% if query.requestSummary.search is null or query.requestSummary.search.value is empty %}
+                    <div class="empty"><p>No global search term was submitted.</p></div>
+                {% else %}
+                    <table>
+                        <tbody>
+                            <tr><th>Value</th><td><code>{{ query.requestSummary.search.value }}</code></td></tr>
+                            <tr><th>Regex</th><td>{{ query.requestSummary.search.regex ? 'yes' : 'no' }}</td></tr>
+                        </tbody>
+                    </table>
+                {% endif %}
+
+                <h4>Order</h4>
+                {% if query.requestSummary.order is empty %}
+                    <div class="empty"><p>No ordering was requested.</p></div>
+                {% else %}
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Priority</th>
+                                <th>Column index</th>
+                                <th>Column name</th>
+                                <th>Direction</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for order in query.requestSummary.order %}
+                                <tr>
+                                    <td>{{ loop.index }}</td>
+                                    <td>{{ order.column }}</td>
+                                    <td><code>{{ order.name }}</code></td>
+                                    <td>{{ order.dir }}</td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                {% endif %}
+
+                <h4>Request columns</h4>
+                {% if query.requestSummary.columns is empty %}
+                    <div class="empty"><p>The request carried no column definition.</p></div>
+                {% else %}
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>#</th>
+                                <th>Name</th>
+                                <th>Data</th>
+                                <th>Searchable</th>
+                                <th>Orderable</th>
+                                <th>Column search</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for column in query.requestSummary.columns %}
+                                <tr>
+                                    <td>{{ column.index }}</td>
+                                    <td><code>{{ column.name }}</code></td>
+                                    <td>{{ column.data }}</td>
+                                    <td>{{ column.searchable ? 'yes' : 'no' }}</td>
+                                    <td>{{ column.orderable ? 'yes' : 'no' }}</td>
+                                    <td>{{ column.searchValue is empty ? '—' : column.searchValue }}</td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                {% endif %}
+
+                <h4>Filters</h4>
+                <table>
+                    <tbody>
+                        <tr><th>Submitted values</th><td>{{ profiler_dump(query.requestSummary.filters, 3) }}</td></tr>
+                    </tbody>
+                </table>
+            {% endif %}
+
+            <h4>
+                Raw DataTableRequest
+                <a class="sf-toggle" data-toggle-selector="#datatable-raw-request-{{ loop.index }}" data-toggle-alt-content="[-] Collapse">[+] Expand</a>
+            </h4>
+            <div id="datatable-raw-request-{{ loop.index }}" class="sf-toggle-content sf-toggle-hidden">
+                {{ profiler_dump(query.request, 3) }}
+            </div>
         {% endfor %}
     {% endif %}
 {% endblock %}

--- a/tests/Kernel/ProfilerPanelAppKernel.php
+++ b/tests/Kernel/ProfilerPanelAppKernel.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Kernel;
+
+use Pentiminax\UX\DataTables\DataTablesBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Bundle\MercureBundle\MercureBundle;
+use Symfony\Bundle\TwigBundle\TwigBundle;
+use Symfony\Bundle\WebProfilerBundle\WebProfilerBundle;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+use Symfony\UX\StimulusBundle\StimulusBundle;
+
+/**
+ * Boots the bundle together with WebProfilerBundle so the collector panel
+ * template can be compiled and rendered in a test.
+ */
+class ProfilerPanelAppKernel extends Kernel
+{
+    use MicroKernelTrait;
+
+    public function registerBundles(): iterable
+    {
+        return [new FrameworkBundle(), new TwigBundle(), new StimulusBundle(), new DataTablesBundle(), new MercureBundle(), new WebProfilerBundle()];
+    }
+
+    public function getCacheDir(): string
+    {
+        return sys_get_temp_dir().'/ux_datatables/profiler_panel_cache/'.$this->environment;
+    }
+
+    public function getLogDir(): string
+    {
+        return sys_get_temp_dir().'/ux_datatables/profiler_panel_log';
+    }
+
+    protected function configureContainer(ContainerConfigurator $container): void
+    {
+        $container->extension('framework', [
+            'secret'               => '$ecret',
+            'test'                 => true,
+            'http_method_override' => false,
+            'router'               => ['utf8' => true],
+            'profiler'             => ['enabled' => true, 'collect' => true],
+        ]);
+
+        $container->extension('twig', ['strict_variables' => true]);
+
+        $container->extension('mercure', [
+            'hubs' => ['default' => [
+                'url' => 'http://localhost:3000/.well-known/mercure',
+                'jwt' => [
+                    'secret'  => 'jwt_secret',
+                    'publish' => '*',
+                ],
+            ]],
+        ]);
+
+        $container->extension('web_profiler', [
+            'toolbar'             => false,
+            'intercept_redirects' => false,
+        ]);
+
+        $container->services()
+            ->alias('test.datatables.profiler', 'datatables.profiler')->public();
+        $container->services()
+            ->alias('test.datatables.data_collector', 'datatables.data_collector')->public();
+        $container->services()
+            ->alias('test.twig', 'twig')->public();
+    }
+
+    protected function configureRoutes(RoutingConfigurator $routes): void
+    {
+    }
+}

--- a/tests/Unit/Controller/AjaxDataControllerTest.php
+++ b/tests/Unit/Controller/AjaxDataControllerTest.php
@@ -56,6 +56,11 @@ final class AjaxDataControllerTest extends TestCase
         $dataTable->expects($this->once())->method('isRequestHandled')->willReturn(true);
         $dataTable->expects($this->once())->method('getResponse')->willReturn($expectedResponse);
 
+        // The profiler reads the resolved provider, which boots the runtime.
+        $dataTable->method('configureActions')->willReturnArgument(0);
+        $dataTable->method('configureFilters')->willReturnArgument(0);
+        $dataTable->method('configureDataTable')->willReturnArgument(0);
+
         $registry = $this->createRegistry($dataTable);
         $token    = $registry->getToken('App\\UserDataTable');
 

--- a/tests/Unit/DataCollector/DataTableCollectorTest.php
+++ b/tests/Unit/DataCollector/DataTableCollectorTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Pentiminax\UX\DataTables\Tests\Unit\DataCollector;
 
+use Pentiminax\UX\DataTables\Column\TextColumn;
 use Pentiminax\UX\DataTables\DataCollector\DataTableCollector;
+use Pentiminax\UX\DataTables\DataTableRequest\DataTableRequest;
 use Pentiminax\UX\DataTables\Model\DataTable;
 use Pentiminax\UX\DataTables\Profiler\DataTableProfiler;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -12,6 +14,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\VarDumper\Cloner\Data;
 
 /**
  * @internal
@@ -36,5 +39,64 @@ final class DataTableCollectorTest extends TestCase
         $this->assertCount(1, $collector->getQueries());
         $this->assertSame('products', $collector->getTables()[0]['id']);
         $this->assertSame(42, $collector->getQueries()[0]['recordsTotal']);
+    }
+
+    #[Test]
+    public function it_keeps_the_request_summary_flattened_to_scalars(): void
+    {
+        $profiler = new DataTableProfiler();
+        $profiler->collectAjaxQuery(
+            class: 'App\\ProductDataTable',
+            token: 'token',
+            request: DataTableRequest::fromRequest(Request::create('/datatables', 'GET', [
+                'draw'    => '2',
+                'start'   => '10',
+                'length'  => '10',
+                'search'  => ['value' => 'foo', 'regex' => 'false'],
+                'order'   => [['column' => '0', 'dir' => 'asc']],
+                'columns' => [['data' => '0', 'name' => 'name', 'searchable' => 'true', 'orderable' => 'true']],
+                'filters' => ['status' => 'active'],
+            ])),
+            recordsTotal: 42,
+            recordsFiltered: 10,
+            durationMs: 1.5,
+        );
+
+        $collector = new DataTableCollector($profiler);
+        $collector->collect(Request::create('/'), new Response());
+
+        $summary = $collector->getQueries()[0]['requestSummary'];
+
+        // Everything the panel renders as a table must survive as a scalar, so
+        // the template never depends on expanding a dump node.
+        $this->assertSame(2, $summary['draw']);
+        $this->assertSame(2, $summary['page']);
+        $this->assertSame('foo', $summary['search']['value']);
+        $this->assertSame([['column' => 0, 'name' => 'name', 'dir' => 'asc']], $summary['order']);
+        $this->assertSame('name', $summary['columns'][0]['name']);
+        $this->assertTrue($summary['columns'][0]['searchable']);
+
+        // Submitted filter values stay a dump: they are arbitrary user input.
+        $this->assertInstanceOf(Data::class, $summary['filters']);
+    }
+
+    #[Test]
+    public function it_never_copies_row_values_into_the_profile(): void
+    {
+        $table = new DataTable('products');
+        $table->columns([TextColumn::new('name')]);
+        $table->data([['name' => 'Sensitive-Row-Value']]);
+
+        $profiler = new DataTableProfiler();
+        $profiler->collectRenderedTable('App\\ProductDataTable', $table);
+        $profiler->collectAjaxQuery('App\\ProductDataTable', 'token', null, 1, 1, 0.5, rowCount: 1, payloadBytes: 128);
+
+        $collector = new DataTableCollector($profiler);
+        $collector->collect(Request::create('/'), new Response());
+
+        $this->assertStringNotContainsString('Sensitive-Row-Value', serialize($collector->getTables()));
+        $this->assertSame(1, $collector->getTables()[0]['rowCount']);
+        $this->assertSame(1, $collector->getQueries()[0]['rowCount']);
+        $this->assertSame(128, $collector->getQueries()[0]['payloadBytes']);
     }
 }

--- a/tests/Unit/DataCollector/DataTablePanelRenderTest.php
+++ b/tests/Unit/DataCollector/DataTablePanelRenderTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Unit\DataCollector;
+
+use Pentiminax\UX\DataTables\Column\TextColumn;
+use Pentiminax\UX\DataTables\DataCollector\DataTableCollector;
+use Pentiminax\UX\DataTables\DataTableRequest\DataTableRequest;
+use Pentiminax\UX\DataTables\Enum\ButtonType;
+use Pentiminax\UX\DataTables\Filter\TextFilter;
+use Pentiminax\UX\DataTables\Model\DataTable;
+use Pentiminax\UX\DataTables\Model\Filters;
+use Pentiminax\UX\DataTables\Profiler\DataTableProfiler;
+use Pentiminax\UX\DataTables\Tests\Kernel\ProfilerPanelAppKernel;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Twig\Environment;
+
+/**
+ * @internal
+ */
+final class DataTablePanelRenderTest extends TestCase
+{
+    #[Test]
+    public function the_panel_renders_every_collected_section(): void
+    {
+        $kernel = new ProfilerPanelAppKernel('test', true);
+        $kernel->boot();
+        $container = $kernel->getContainer()->get('test.service_container');
+
+        /** @var DataTableProfiler $profiler */
+        $profiler = $container->get('test.datatables.profiler');
+        $profiler->collectRenderedTable('App\\ProductDataTable', $this->createTable(), [
+            'entityClass'     => 'App\\Entity\\Product',
+            'originalColumns' => [TextColumn::new('name'), TextColumn::new('secret')],
+            'allowedColumns'  => [TextColumn::new('name')],
+        ]);
+        $profiler->collectAjaxQuery(
+            class: 'App\\ProductDataTable',
+            token: 'token',
+            request: DataTableRequest::fromRequest(Request::create('/datatables', 'GET', [
+                'draw'    => '2',
+                'start'   => '10',
+                'length'  => '10',
+                'search'  => ['value' => 'foo', 'regex' => 'false'],
+                'order'   => [['column' => '0', 'dir' => 'asc']],
+                'columns' => [['data' => '0', 'name' => 'name', 'searchable' => 'true', 'orderable' => 'true']],
+                'filters' => ['status' => 'active'],
+            ])),
+            recordsTotal: 42,
+            recordsFiltered: 10,
+            durationMs: 1.5,
+            providerClass: 'App\\Provider',
+            entityClass: 'App\\Entity\\Product',
+            rowCount: 10,
+            payloadBytes: 2048,
+            httpStatus: 200,
+        );
+
+        /** @var DataTableCollector $collector */
+        $collector = $container->get('test.datatables.data_collector');
+        $collector->collect(Request::create('/'), new Response());
+
+        /** @var Environment $twig */
+        $twig  = $container->get('test.twig');
+        $panel = $twig->load('@DataTables/Collector/data_collector.html.twig')
+            ->renderBlock('panel', ['collector' => $collector]);
+
+        $this->assertStringContainsString('Extensions', $panel);
+        $this->assertStringContainsString('buttons', $panel);
+        $this->assertStringContainsString('responsive', $panel);
+        $this->assertStringContainsString('Removed by static permission filtering', $panel);
+        $this->assertStringContainsString('Request columns', $panel);
+        $this->assertStringContainsString('2048 B', $panel);
+        $this->assertStringNotContainsString('Sensitive-Row-Value', $panel);
+    }
+
+    private function createTable(): DataTable
+    {
+        $table = new DataTable('products');
+        $table->columns([TextColumn::new('name')]);
+        $table->data([['name' => 'Sensitive-Row-Value']]);
+        $table->setFilters((new Filters())->add(TextFilter::new('name')));
+        $table->getExtensionsCollection()->addButtonsExtension([ButtonType::CSV]);
+        // Options serialize to `true`, which is not countable: the panel must
+        // dump them without testing their emptiness.
+        $table->getExtensionsCollection()->addResponsiveExtension();
+
+        return $table;
+    }
+}

--- a/tests/Unit/Profiler/DataTableProfilerTest.php
+++ b/tests/Unit/Profiler/DataTableProfilerTest.php
@@ -4,11 +4,18 @@ declare(strict_types=1);
 
 namespace Pentiminax\UX\DataTables\Tests\Unit\Profiler;
 
+use Pentiminax\UX\DataTables\Column\TextColumn;
+use Pentiminax\UX\DataTables\DataTableRequest\DataTableRequest;
+use Pentiminax\UX\DataTables\Enum\ButtonType;
+use Pentiminax\UX\DataTables\Filter\TextFilter;
 use Pentiminax\UX\DataTables\Model\DataTable;
+use Pentiminax\UX\DataTables\Model\Extensions\SelectExtension;
+use Pentiminax\UX\DataTables\Model\Filters;
 use Pentiminax\UX\DataTables\Profiler\DataTableProfiler;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @internal
@@ -23,14 +30,74 @@ final class DataTableProfilerTest extends TestCase
         $profiler->collectRenderedTable('App\\ProductDataTable', new DataTable('products'));
 
         $this->assertSame([[
-            'id'          => 'products',
-            'class'       => 'App\\ProductDataTable',
-            'serverSide'  => false,
-            'columnCount' => 0,
-            'extensions'  => [],
-            'ajax'        => null,
-            'hasData'     => false,
+            'id'                       => 'products',
+            'class'                    => 'App\\ProductDataTable',
+            'entityClass'              => null,
+            'serverSide'               => false,
+            'columnCount'              => 0,
+            'extensions'               => [],
+            'ajax'                     => null,
+            'hasData'                  => false,
+            'rowCount'                 => 0,
+            'dataController'           => null,
+            'forwardedQueryParameters' => [],
+            'columns'                  => [],
+            'deniedColumns'            => [],
+            'filters'                  => [],
+            'mercure'                  => null,
+            'editModal'                => ['template' => null, 'adapter' => null],
         ]], $profiler->getRenderedTables());
+    }
+
+    #[Test]
+    public function it_collects_every_extension_including_layout_aware_ones(): void
+    {
+        $table = new DataTable('products');
+        $table->getExtensionsCollection()
+            ->addButtonsExtension([ButtonType::CSV])
+            ->addSelectExtension(static fn (SelectExtension $extension) => $extension->withCheckbox());
+
+        $profiler = new DataTableProfiler();
+        $profiler->collectRenderedTable('App\\ProductDataTable', $table);
+
+        $extensions = $profiler->getRenderedTables()[0]['extensions'];
+
+        $this->assertSame(['buttons', 'select'], array_column($extensions, 'key'));
+
+        $buttons = $extensions[0];
+        $this->assertTrue($buttons['layoutAware'], 'Buttons is layout aware and absent from the client payload.');
+        $this->assertNotEmpty($buttons['options'], 'Extension options must reach the profiler.');
+
+        $select = $extensions[1];
+        $this->assertFalse($select['layoutAware']);
+        $this->assertTrue($select['options']['withCheckbox']);
+    }
+
+    #[Test]
+    public function it_collects_columns_filters_and_denied_columns(): void
+    {
+        $name   = TextColumn::new('name');
+        $secret = TextColumn::new('secret');
+
+        $table = new DataTable('products');
+        $table->columns([$name, $secret]);
+        $table->setFilters((new Filters())->add(TextFilter::new('name')));
+        $table->data([['name' => 'Foo', 'secret' => 'hidden']]);
+
+        $profiler = new DataTableProfiler();
+        $profiler->collectRenderedTable('App\\ProductDataTable', $table, [
+            'entityClass'     => 'App\\Entity\\Product',
+            'originalColumns' => [$name, $secret],
+            'allowedColumns'  => [$name],
+        ]);
+
+        $record = $profiler->getRenderedTables()[0];
+
+        $this->assertSame('App\\Entity\\Product', $record['entityClass']);
+        $this->assertSame(['name', 'secret'], array_column($record['columns'], 'name'));
+        $this->assertSame(['secret'], $record['deniedColumns']);
+        $this->assertSame(['name'], array_column($record['filters'], 'name'));
+        $this->assertSame(1, $record['rowCount']);
     }
 
     #[Test]
@@ -43,10 +110,60 @@ final class DataTableProfilerTest extends TestCase
             'class'           => 'App\\ProductDataTable',
             'token'           => 'token',
             'request'         => null,
+            'requestSummary'  => null,
             'recordsTotal'    => 42,
             'recordsFiltered' => 10,
             'durationMs'      => 1.5,
+            'providerClass'   => null,
+            'entityClass'     => null,
+            'rowCount'        => 0,
+            'payloadBytes'    => 0,
+            'httpStatus'      => null,
         ]], $profiler->getAjaxQueries());
+    }
+
+    #[Test]
+    public function it_flattens_the_ajax_request_into_scalars(): void
+    {
+        $request = DataTableRequest::fromRequest(Request::create('/datatables', 'GET', [
+            'draw'    => '3',
+            'start'   => '20',
+            'length'  => '10',
+            'search'  => ['value' => 'foo', 'regex' => 'false'],
+            'order'   => [['column' => '1', 'dir' => 'desc']],
+            'columns' => [
+                ['data' => '0', 'name' => 'id', 'searchable' => 'false', 'orderable' => 'true'],
+                ['data' => '1', 'name' => 'name', 'searchable' => 'true', 'orderable' => 'true', 'search' => ['value' => 'bar', 'regex' => 'false']],
+            ],
+            'filters' => ['status' => 'active'],
+        ]));
+
+        $profiler = new DataTableProfiler();
+        $profiler->collectAjaxQuery(
+            class: 'App\\ProductDataTable',
+            token: 'token',
+            request: $request,
+            recordsTotal: 100,
+            recordsFiltered: 25,
+            durationMs: 1.5,
+            providerClass: 'App\\Provider',
+            entityClass: 'App\\Entity\\Product',
+            rowCount: 10,
+            payloadBytes: 2048,
+            httpStatus: 200,
+        );
+
+        $summary = $profiler->getAjaxQueries()[0]['requestSummary'];
+
+        $this->assertSame(3, $summary['draw']);
+        $this->assertSame(3, $summary['page']);
+        $this->assertSame(['value' => 'foo', 'regex' => false], $summary['search']);
+        $this->assertSame([['column' => 1, 'name' => 'name', 'dir' => 'desc']], $summary['order']);
+        $this->assertSame(['status' => 'active'], $summary['filters']);
+        $this->assertSame([
+            ['index' => 0, 'data' => '0', 'name' => 'id', 'searchable' => false, 'orderable' => true, 'searchValue' => null],
+            ['index' => 1, 'data' => '1', 'name' => 'name', 'searchable' => true, 'orderable' => true, 'searchValue' => 'bar'],
+        ], $summary['columns']);
     }
 
     #[Test]


### PR DESCRIPTION
## Why

The profiler panel answered almost nothing a developer asks:

- Rendered tables were six scalar columns. Extension **options** were invisible, and `ButtonsExtension` never appeared at all because `DataTableExtensions::jsonSerialize()` skips every `LayoutAwareExtensionInterface`.
- The Ajax section was a single `profiler_dump(query.request)`. Nested nodes render collapsed at the default display depth, and `Columns` kept its `Column[]` in a private property with no accessor, so per-column searchable/orderable/search values were unreachable from the panel.

## What changed

Everything is flattened to scalars at collection time, so the panel renders real profiler tables instead of relying on expanding a dump.

**Rendered tables** — per-table collapsible detail block with entity, data controller, ajax options, forwarded query parameters, edit modal, Mercure, a **Columns** table, the columns removed by static permission filtering, a **Filters** table, and a dedicated **Extensions** section (key, class, layout-aware, options) that includes layout-aware extensions.

**Ajax queries** — metadata table (token, data provider, entity, records total/filtered, returned rows, payload size, HTTP status, duration, pagination), plus Global search, Order and Request columns tables. Submitted filter values stay a dump (arbitrary user input); the raw `DataTableRequest` remains behind a toggle as a fallback.

**Toolbar** — total Ajax duration alongside the two counters.

New read accessors: `Columns::all()` and `DataTableExtensions::all()`. New `collectRenderedTable()` / `collectAjaxQuery()` parameters are additive with defaults, so the public surface stays backward compatible.

## Security

Row values never reach the profile: only counters and the response byte size are collected, so business data is not copied into `var/cache/dev/profiler`. `DataTablesExtension` deliberately does not collect the `$view` payload, which carries the CSRF token and resolved rows. A test asserts a sentinel row value is absent from the collected data and from the rendered panel.

## Notes

- `MercureConfig` is reduced to its four public properties instead of `jsonSerialize()`, which throws until the hub URL is resolved.
- Extension options are dumped unconditionally: `ColReorder`, `KeyTable`, `Scroller` and `Responsive` serialize to `true`, and `is empty` on the cloned `Data` calls `count()` on a non-countable value.
- `ExtensionInterface::isEnabled()` is deliberately not surfaced — nothing in `src/` ever calls `enabled()`, so the column would read "no" for every configured extension.
- `AjaxDataController::collect()` now reads `getDataProvider()`, which boots the runtime the response already built; `AjaxDataControllerTest` needed three `configure*()` stubs on its mock as a result.

## Tests

The panel template had no coverage at all. It is now rendered through `WebProfilerBundle` in `DataTablePanelRenderTest`, which reproduced the `count(): Argument #1 ($value) must be of type Countable|array, true given` failure before the fix.

Also added: profiler records for the layout-aware extension, the flattened request summary, columns/filters/denied columns, and the no-row-data guarantee.

- `composer fix`
- `composer audit` — no advisories
- `vendor/bin/phpunit` — 963 tests, 3144 assertions

Not covered: a manual browser pass on the rendered panel in a consuming app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are dev-only profiler/debug tooling with explicit avoidance of row data in profiles; the only runtime tweak is `getDataProvider()` during Ajax collection for metadata, which may boot the table runtime once per Ajax request in development.
> 
> **Overview**
> **Expands the UX DataTables Web Profiler collector** so developers can inspect configuration and server-side Ajax behavior without digging through collapsed dumps.
> 
> `DataTableProfiler` now records **rich rendered-table snapshots** (entity, columns, filters, Mercure/edit-modal hints, denied permission columns, and **all extensions—including layout-aware ones like Buttons** via `DataTableExtensions::all()`). Ajax handling adds **flattened `requestSummary`** (pagination, search, order, per-column flags) plus provider/entity, returned row count, payload size, and HTTP status; `AjaxDataController` supplies these from the JSON response. `render_datatable` passes entity and static column-filter context into collection.
> 
> The **profiler Twig panel** gains expandable per-table sections, structured Ajax tables (with raw `DataTableRequest` behind a toggle), and **total Ajax duration** in the toolbar. `DataTableCollector` clones complex values (ajax config, extension options, filter dumps) for safe display.
> 
> **Security:** only scalars/counters are stored—**row cell values are not copied** into profiler storage (tests assert this). New `Columns::all()` supports summarizing request columns.
> 
> **Tests** cover profiler shape, collector cloning, panel rendering via `WebProfilerBundle`, and updated `AjaxDataController` mocks for `getDataProvider()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3d8fa1b4c26ccd5dd1d88ebe3145449e6ce27d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->