### PR TITLE
feat: allow per-column ColumnControl content overrides

### DIFF
--- a/docs/src/content/docs/extensions/column-control.mdx
+++ b/docs/src/content/docs/extensions/column-control.mdx
@@ -36,7 +36,7 @@ Override the control content for a single column with `setColumnControl()`, usin
 descriptors as the DataTables `columns.columnControl` option:
 
 ```php
-use Pentiminax\UX\DataTables\Model\Extensions\ColumnControlExtension;
+use Pentiminax\UX\DataTables\Column\TextColumn;
 
 $dataTable->columnControl();
 

--- a/docs/src/content/docs/extensions/column-control.mdx
+++ b/docs/src/content/docs/extensions/column-control.mdx
@@ -30,9 +30,30 @@ test `IS NULL` / `IS NOT NULL` on those columns — they must not compare the id
 empty string. See
 [Searching UUID and ULID columns](/ux-datatables/guide/server-side-processing/#searching-uuid-and-ulid-columns).
 
+## Per-column Overrides
+
+Override the control content for a single column with `setColumnControl()`, using the same content
+descriptors as the DataTables `columns.columnControl` option:
+
+```php
+use Pentiminax\UX\DataTables\Model\Extensions\ColumnControlExtension;
+
+$dataTable->columnControl();
+
+TextColumn::new('name', 'Name')
+    ->setColumnControl(['colvisDropdown']);
+```
+
+`setColumnControl()` takes precedence over `disableColumnControl()` regardless of call order. Both
+require `ColumnControlExtension` to be added to the table — the frontend only loads the
+ColumnControl plugin bundle when the table-level extension is present, so a column-level override
+or a disabled column stays inert without it.
+
 ## Frequent Pitfalls
 
-- Expecting custom control layouts from the default extension payload.
+- Calling `setColumnControl()` or `disableColumnControl()` without also enabling
+  `ColumnControlExtension` on the table (`$table->columnControl()`); the column-level setting is
+  silently inert because the frontend never loads the plugin bundle.
 - Enabling it without ensuring the target columns are searchable/orderable.
 - Expecting partial search (`contains`, `starts`) to work on a UUID or ULID column.
 

--- a/src/Column/AbstractColumn.php
+++ b/src/Column/AbstractColumn.php
@@ -29,6 +29,7 @@ abstract class AbstractColumn implements ColumnInterface, PermissionAwareColumnI
     protected ?string $orderExpression   = null;
     protected bool $globalSearchable     = true;
     protected bool $columnControlEnabled = true;
+    protected ?array $columnControl      = null;
     protected array $customOptions       = [];
     protected ?string $permission        = null;
 
@@ -126,6 +127,33 @@ abstract class AbstractColumn implements ColumnInterface, PermissionAwareColumnI
         $this->columnControlEnabled = false;
 
         return $this;
+    }
+
+    /**
+     * Override the ColumnControl content for this column only, bypassing the table-level
+     * `ColumnControlExtension` default for it.
+     *
+     * Accepts the same content descriptors as the DataTables `columns.columnControl` option: an
+     * array of content items (e.g. `['orderAsc', 'orderDesc']`), nested arrays for multiple
+     * target areas, or extension descriptors such as `['colvisDropdown']`. Takes precedence over
+     * disableColumnControl() regardless of call order.
+     *
+     * Has no visible effect unless `ColumnControlExtension` is also added to the table (e.g. via
+     * `$table->columnControl()`) — the frontend only loads the ColumnControl plugin bundle when
+     * the table-level extension is present, so this column-level content stays inert otherwise.
+     *
+     * @param list<mixed> $columnControl
+     */
+    public function setColumnControl(array $columnControl): static
+    {
+        $this->columnControl = $columnControl;
+
+        return $this;
+    }
+
+    public function getColumnControl(): ?array
+    {
+        return $this->columnControl;
     }
 
     /**
@@ -350,7 +378,9 @@ abstract class AbstractColumn implements ColumnInterface, PermissionAwareColumnI
             'customOptions'  => $this->customOptions,
         ], static fn (mixed $value) => null !== $value && '' !== $value && [] !== $value);
 
-        if (!$this->columnControlEnabled) {
+        if (null !== $this->columnControl) {
+            $options['columnControl'] = $this->columnControl;
+        } elseif (!$this->columnControlEnabled) {
             $options['columnControl'] = [];
         }
 

--- a/tests/Unit/Column/AbstractColumnTest.php
+++ b/tests/Unit/Column/AbstractColumnTest.php
@@ -73,6 +73,40 @@ final class AbstractColumnTest extends TestCase
     }
 
     #[Test]
+    public function it_overrides_column_control_content_for_a_single_column(): void
+    {
+        $column = (new class extends AbstractColumn {})
+            ->setType(ColumnType::STRING)
+            ->setName('actions');
+
+        $this->assertNull($column->getColumnControl());
+
+        $this->assertSame($column, $column->setColumnControl(['colvisDropdown']));
+
+        $this->assertSame(['colvisDropdown'], $column->getColumnControl());
+        $this->assertSame(['colvisDropdown'], $column->jsonSerialize()['columnControl']);
+    }
+
+    #[Test]
+    public function setting_column_control_content_wins_over_disabling_it_regardless_of_call_order(): void
+    {
+        $disableThenOverride = (new class extends AbstractColumn {})
+            ->setType(ColumnType::STRING)
+            ->setName('foo')
+            ->disableColumnControl()
+            ->setColumnControl(['order']);
+
+        $overrideThenDisable = (new class extends AbstractColumn {})
+            ->setType(ColumnType::STRING)
+            ->setName('foo')
+            ->setColumnControl(['order'])
+            ->disableColumnControl();
+
+        $this->assertSame(['order'], $disableThenOverride->jsonSerialize()['columnControl']);
+        $this->assertSame(['order'], $overrideThenDisable->jsonSerialize()['columnControl']);
+    }
+
+    #[Test]
     public function it_exposes_mutated_getter_values(): void
     {
         $column = (new class extends AbstractColumn {})


### PR DESCRIPTION
- Adds AbstractColumn::setColumnControl(array $columnControl) / getColumnControl(): ?array, serializing straight through to the column's columnControl payload key using the same content descriptors as DataTables' columns.columnControl option (e.g. ['colvisDropdown']).
- setColumnControl() takes precedence over disableColumnControl() regardless of call order — deterministic either way.
- No frontend changes needed: normalizeDisabledColumnControls() in columnControl.ts already leaves non-empty columnControl arrays untouched, so custom per-column content flows straight through to DataTables once emitted from PHP.
- Documents in extensions/column-control.mdx that both setColumnControl() and disableColumnControl() require ColumnControlExtension on the table ($table->columnControl()) to have any visible effect — the frontend only loads the plugin bundle when the table-level extension is present, so a column-level setting without it is a silent no-op by design, same as disableColumnControl() today.
Closes #317