### PR TITLE
feat: add ColumnControl's native search-clear Buttons entry

### DIFF
--- a/docs/src/content/docs/extensions/buttons.mdx
+++ b/docs/src/content/docs/extensions/buttons.mdx
@@ -44,6 +44,7 @@ generated.
     ['`ButtonType::PDF`', 'Export PDF file'],
     ['`ButtonType::PRINT`', 'Open print view'],
     ['`ButtonType::COLUMN_VISIBILITY`', 'Toggle column visibility'],
+    ['`ButtonType::COLUMN_CONTROL_SEARCH_CLEAR`', 'Clear every active search — see below'],
   ]}
 />
 
@@ -109,11 +110,36 @@ $dataTable->layout([
 ]);
 ```
 
+## Clearing Every Active Search
+
+`Button::ccSearchClear()` uses the ColumnControl extension's own native Buttons entry to clear the
+global search box and every ColumnControl per-column search in one click:
+
+```php
+use Pentiminax\UX\DataTables\Enum\Feature;
+use Pentiminax\UX\DataTables\Model\Extensions\Button;
+use Pentiminax\UX\DataTables\Model\Extensions\ButtonsExtension;
+
+$dataTable
+    ->columnControl()
+    ->addExtension(new ButtonsExtension([Button::ccSearchClear()]))
+    ->layout([
+        'topStart' => Feature::BUTTONS,
+    ]);
+```
+
+Requires `ColumnControlExtension` on the table (`$table->columnControl()`) — the button reads and
+clears ColumnControl's own search state. It enables and disables itself automatically based on
+whether any search (global or per-column) is currently active, and defaults to the text "Clear
+search" (localized). `ButtonsExtension::withCcSearchClearButton()` is the fluent-collection
+shortcut.
+
 ## Frequent Pitfalls
 
 - Adding `ButtonsExtension` without adding `Feature::BUTTONS` to the layout.
 - Mixing button values as invalid strings.
 - Forgetting that non-column-visibility buttons apply export filtering by default.
+- Using `Button::ccSearchClear()` without also enabling `ColumnControlExtension` on the table.
 
 ## Cross Links
 

--- a/docs/src/content/docs/reference/enums.mdx
+++ b/docs/src/content/docs/reference/enums.mdx
@@ -7,7 +7,7 @@ order: 80
 <Table
   headers={['Enum', 'Values']}
   rows={[
-    ['`ButtonType`', '`COLUMN_VISIBILITY`, `COPY`, `CSV`, `EXCEL`, `PDF`, `PRINT`'],
+    ['`ButtonType`', '`COLUMN_CONTROL_SEARCH_CLEAR`, `COLUMN_VISIBILITY`, `COPY`, `CSV`, `EXCEL`, `PDF`, `PRINT`'],
     ['`SelectStyle`', '`SINGLE`, `MULTI`'],
     ['`SelectItemType`', '`ROW`, `COLUMN`, `CELL`'],
     [

--- a/skills/ux-datatables/references/extensions.md
+++ b/skills/ux-datatables/references/extensions.md
@@ -31,7 +31,7 @@ new ButtonsExtension([
 ]);
 ```
 
-`ButtonType` cases: `COPY`, `CSV`, `EXCEL`, `PDF`, `PRINT`, `COLUMN_VISIBILITY` (value `'colvis'`). The constructor also accepts strings or `Button` objects. Fluent helpers: `withCopyButton()`, `withCsvButton()`, `withExcelButton()`, `withPdfButton()`, `withPrintButton()`, `withColVisButton()`.
+`ButtonType` cases: `COPY`, `CSV`, `EXCEL`, `PDF`, `PRINT`, `COLUMN_VISIBILITY` (value `'colvis'`), `COLUMN_CONTROL_SEARCH_CLEAR` (value `'ccSearchClear'`). The constructor also accepts strings or `Button` objects. Fluent helpers: `withCopyButton()`, `withCsvButton()`, `withExcelButton()`, `withPdfButton()`, `withPrintButton()`, `withColVisButton()`, `withCcSearchClearButton()`.
 
 Fine-grained config via `Button`:
 ```php
@@ -42,6 +42,10 @@ new ButtonsExtension([
 ```
 
 To position buttons, place `Feature::BUTTONS` in `layout()` (see options).
+
+`Button::ccSearchClear()` clears the global search plus every ColumnControl per-column search in
+one click, using ColumnControl's own native Buttons entry (no JS needed). Requires
+`ColumnControlExtension` on the table.
 
 ## Select — row/cell selection
 

--- a/src/Enum/ButtonType.php
+++ b/src/Enum/ButtonType.php
@@ -6,10 +6,11 @@ namespace Pentiminax\UX\DataTables\Enum;
 
 enum ButtonType: string
 {
-    case COLUMN_VISIBILITY = 'colvis';
-    case COPY              = 'copy';
-    case CSV               = 'csv';
-    case EXCEL             = 'excel';
-    case PDF               = 'pdf';
-    case PRINT             = 'print';
+    case COLUMN_CONTROL_SEARCH_CLEAR = 'ccSearchClear';
+    case COLUMN_VISIBILITY           = 'colvis';
+    case COPY                        = 'copy';
+    case CSV                         = 'csv';
+    case EXCEL                       = 'excel';
+    case PDF                         = 'pdf';
+    case PRINT                       = 'print';
 }

--- a/src/Model/Extensions/Button.php
+++ b/src/Model/Extensions/Button.php
@@ -10,6 +10,17 @@ final class Button implements \JsonSerializable
 {
     private const DEFAULT_EXPORT_COLUMNS = ':visible:not(.not-exportable)';
 
+    /**
+     * Utility button types that never export data: no default `exportOptions`, and serialized as
+     * a bare extend string when no other option is set.
+     *
+     * @var list<ButtonType>
+     */
+    private const NON_EXPORT_TYPES = [
+        ButtonType::COLUMN_CONTROL_SEARCH_CLEAR,
+        ButtonType::COLUMN_VISIBILITY,
+    ];
+
     /** @var array<string, mixed> */
     private array $options = [];
 
@@ -53,6 +64,16 @@ final class Button implements \JsonSerializable
         return self::fromType(ButtonType::COLUMN_VISIBILITY);
     }
 
+    /**
+     * Clears the global search and every ColumnControl per-column search, using the ColumnControl
+     * extension's own native Buttons entry. Requires ColumnControlExtension on the table; enables
+     * and disables itself automatically based on whether any search is currently active.
+     */
+    public static function ccSearchClear(): self
+    {
+        return self::fromType(ButtonType::COLUMN_CONTROL_SEARCH_CLEAR);
+    }
+
     public function text(string $text): self
     {
         $this->options['text'] = $text;
@@ -86,7 +107,9 @@ final class Button implements \JsonSerializable
 
     public function jsonSerialize(): array|string
     {
-        if (ButtonType::COLUMN_VISIBILITY === $this->type && [] === $this->options) {
+        $isNonExport = \in_array($this->type, self::NON_EXPORT_TYPES, true);
+
+        if ($isNonExport && [] === $this->options) {
             return $this->type->value;
         }
 
@@ -94,7 +117,7 @@ final class Button implements \JsonSerializable
             'extend' => $this->type->value,
         ];
 
-        if (ButtonType::COLUMN_VISIBILITY !== $this->type && !\array_key_exists('exportOptions', $this->options)) {
+        if (!$isNonExport && !\array_key_exists('exportOptions', $this->options)) {
             $config['exportOptions'] = [
                 'columns' => self::DEFAULT_EXPORT_COLUMNS,
             ];

--- a/src/Model/Extensions/ButtonsExtension.php
+++ b/src/Model/Extensions/ButtonsExtension.php
@@ -47,6 +47,16 @@ final class ButtonsExtension extends AbstractExtension implements LayoutAwareExt
         return $this;
     }
 
+    /**
+     * @see Button::ccSearchClear()
+     */
+    public function withCcSearchClearButton(): self
+    {
+        $this->buttons[] = Button::ccSearchClear();
+
+        return $this;
+    }
+
     public function withCopyButton(): self
     {
         $this->buttons[] = Button::copy();

--- a/tests/Unit/Model/Extensions/ButtonTest.php
+++ b/tests/Unit/Model/Extensions/ButtonTest.php
@@ -75,5 +75,18 @@ final class ButtonTest extends TestCase
                 'text'   => 'Columns',
             ],
         ];
+
+        yield 'plain columncontrol search clear is a string' => [
+            Button::ccSearchClear(),
+            'ccSearchClear',
+        ];
+
+        yield 'customized columncontrol search clear is an object without export options' => [
+            Button::ccSearchClear()->text('Clear filters'),
+            [
+                'extend' => 'ccSearchClear',
+                'text'   => 'Clear filters',
+            ],
+        ];
     }
 }

--- a/tests/Unit/Model/Extensions/ButtonsExtensionTest.php
+++ b/tests/Unit/Model/Extensions/ButtonsExtensionTest.php
@@ -31,6 +31,7 @@ final class ButtonsExtensionTest extends DataTableTestCase
                 ->exportOptions(['columns' => ':visible']),
             Button::excel()->option('filename', 'users-export'),
             Button::colVis()->text('Columns'),
+            Button::ccSearchClear()->text('Clear filters'),
         ]);
 
         $this->assertExtensionPayload([
@@ -66,6 +67,18 @@ final class ButtonsExtensionTest extends DataTableTestCase
                 'extend' => 'colvis',
                 'text'   => 'Columns',
             ],
+            [
+                'extend' => 'ccSearchClear',
+                'text'   => 'Clear filters',
+            ],
         ], $extension);
+    }
+
+    #[Test]
+    public function it_adds_a_columncontrol_search_clear_button_via_the_fluent_helper(): void
+    {
+        $extension = (new ButtonsExtension([]))->withCcSearchClearButton();
+
+        $this->assertExtensionPayload(['ccSearchClear'], $extension);
     }
 }


### PR DESCRIPTION
- Adds ButtonType::COLUMN_CONTROL_SEARCH_CLEAR ('ccSearchClear') and Button::ccSearchClear(), mirroring the existing colVis() factory.
- Generalizes Button::jsonSerialize()'s existing COLUMN_VISIBILITY-only special case (bare-string shorthand, no default exportOptions) into a NON_EXPORT_TYPES set now covering both COLUMN_VISIBILITY and COLUMN_CONTROL_SEARCH_CLEAR — neither is an export button, so default exportOptions must not be injected for either, and both serialize as a bare extend string when no other option is set.
- ButtonsExtension::withCcSearchClearButton() fluent-collection convenience.
No frontend changes: verified ext.buttons is core-initialized independent of the Buttons plugin (dataTables.js:3783), and verified the button's definition (auto enable/disable, i18n default text, clear+redraw action) by reading dataTables.columnControl.mjs directly.
- Docs: new "Clearing Every Active Search" section in extensions/buttons.mdx, ButtonType::COLUMN_CONTROL_SEARCH_CLEAR added to the enums reference and the bundled skill file.
Closes #321