### PR TITLE
fix: give ColReorderExtension real constructor options

### DIFF
--- a/docs/src/content/docs/extensions/col-reorder.mdx
+++ b/docs/src/content/docs/extensions/col-reorder.mdx
@@ -30,6 +30,16 @@ $dataTable->addExtension(
 reordering at runtime. `columns` is a DataTables column-selector string restricting which columns
 can be dragged; the default `''` allows every column.
 
+```php
+$dataTable->addExtension(
+    new ColReorderExtension(headerRows: [0], order: [2, 0, 1])
+);
+```
+
+`headerRows` restricts reordering to specific header row indexes in a multi-row header; omit it (or
+pass `null`) to allow every row. `order` sets the initial column order on load — a list of the
+original column indexes in their new positions; omit it to keep document order.
+
 ## Frequent Pitfalls
 
 - Not validating interactions with fixed columns and saved states.

--- a/docs/src/content/docs/extensions/col-reorder.mdx
+++ b/docs/src/content/docs/extensions/col-reorder.mdx
@@ -17,6 +17,19 @@ use Pentiminax\UX\DataTables\Model\Extensions\ColReorderExtension;
 $dataTable->addExtension(new ColReorderExtension());
 ```
 
+## Advanced Example
+
+```php
+$dataTable->addExtension(
+    new ColReorderExtension(enable: false, columns: ':not(:first-child)')
+);
+```
+
+`enable: false` loads ColReorder but leaves it initially disabled — pair with the DataTables API
+(`dt.colReorder.enable()` / `.disable()`, e.g. from a `Button::custom()` toggle) to lock and unlock
+reordering at runtime. `columns` is a DataTables column-selector string restricting which columns
+can be dragged; the default `''` allows every column.
+
 ## Frequent Pitfalls
 
 - Not validating interactions with fixed columns and saved states.

--- a/skills/ux-datatables/references/extensions.md
+++ b/skills/ux-datatables/references/extensions.md
@@ -76,12 +76,15 @@ Not intended to be combined with `ScrollerExtension` or the core `scrollY` / `sc
 ## ColReorder — drag to reorder columns
 
 ```php
-new ColReorderExtension(enable: true, columns: '');  // both are defaults
+new ColReorderExtension(enable: true, columns: '', headerRows: null, order: null);  // all defaults
 ```
 
 `enable: false` loads ColReorder locked; toggle at runtime with the JS API
 (`dt.colReorder.enable()`/`.disable()`, e.g. via `Button::custom()`). `columns` is a DataTables
-column-selector string restricting which columns can be dragged.
+column-selector string restricting which columns can be dragged. `headerRows` restricts reordering
+to specific header row indexes (multi-row headers); `order` sets the initial column order (original
+indexes in their new positions). Both default to `null` (every row / document order) and are
+omitted from the payload unless set.
 
 ## Responsive — collapse columns on small screens
 

--- a/skills/ux-datatables/references/extensions.md
+++ b/skills/ux-datatables/references/extensions.md
@@ -73,6 +73,16 @@ new FixedHeaderExtension(header: true, footer: false, headerOffset: 0, footerOff
 
 Not intended to be combined with `ScrollerExtension` or the core `scrollY` / `scrollX` scrolling feature.
 
+## ColReorder — drag to reorder columns
+
+```php
+new ColReorderExtension(enable: true, columns: '');  // both are defaults
+```
+
+`enable: false` loads ColReorder locked; toggle at runtime with the JS API
+(`dt.colReorder.enable()`/`.disable()`, e.g. via `Button::custom()`). `columns` is a DataTables
+column-selector string restricting which columns can be dragged.
+
 ## Responsive — collapse columns on small screens
 
 ```php
@@ -108,10 +118,9 @@ No constructor args needed:
 | Extension | Effect |
 |-----------|--------|
 | `ColumnControlExtension` | per-column order/search controls (`$table->columnControl()`) |
-| `ColReorderExtension` | drag to reorder columns |
 
 ```php
-$extensions->addExtension(new ColReorderExtension());
+$extensions->addExtension(new ColumnControlExtension());
 ```
 
 See `docs/src/content/docs/extensions/combining-extensions.mdx` for compatible combinations.

--- a/src/Model/Extensions/ColReorderExtension.php
+++ b/src/Model/Extensions/ColReorderExtension.php
@@ -6,9 +6,17 @@ namespace Pentiminax\UX\DataTables\Model\Extensions;
 
 class ColReorderExtension extends AbstractExtension
 {
+    /**
+     * @param list<int>|null $headerRows restricts reordering to these header row indexes, or null
+     *                                   for every row
+     * @param list<int>|null $order      initial column order (original column indexes in their new
+     *                                   positions), or null to keep document order
+     */
     public function __construct(
         private readonly bool $enable = true,
         private readonly string $columns = '',
+        private readonly ?array $headerRows = null,
+        private readonly ?array $order = null,
     ) {
     }
 
@@ -19,9 +27,11 @@ class ColReorderExtension extends AbstractExtension
 
     public function jsonSerialize(): array
     {
-        return [
-            'enable'  => $this->enable,
-            'columns' => $this->columns,
-        ];
+        return array_filter([
+            'enable'     => $this->enable,
+            'columns'    => $this->columns,
+            'headerRows' => $this->headerRows,
+            'order'      => $this->order,
+        ], static fn (mixed $value): bool => null !== $value);
     }
 }

--- a/src/Model/Extensions/ColReorderExtension.php
+++ b/src/Model/Extensions/ColReorderExtension.php
@@ -6,13 +6,22 @@ namespace Pentiminax\UX\DataTables\Model\Extensions;
 
 class ColReorderExtension extends AbstractExtension
 {
+    public function __construct(
+        private readonly bool $enable = true,
+        private readonly string $columns = '',
+    ) {
+    }
+
     public function getKey(): string
     {
         return 'colReorder';
     }
 
-    public function jsonSerialize(): bool
+    public function jsonSerialize(): array
     {
-        return true;
+        return [
+            'enable'  => $this->enable,
+            'columns' => $this->columns,
+        ];
     }
 }

--- a/tests/Unit/Model/Extensions/ColReorderExtensionTest.php
+++ b/tests/Unit/Model/Extensions/ColReorderExtensionTest.php
@@ -36,4 +36,27 @@ final class ColReorderExtensionTest extends TestCase
             'columns' => ':not(:first-child)',
         ], $extension->jsonSerialize());
     }
+
+    #[Test]
+    public function it_omits_header_rows_and_order_when_not_set(): void
+    {
+        $extension = new ColReorderExtension();
+        $payload   = $extension->jsonSerialize();
+
+        $this->assertArrayNotHasKey('headerRows', $payload);
+        $this->assertArrayNotHasKey('order', $payload);
+    }
+
+    #[Test]
+    public function it_serializes_restricted_header_rows_and_an_initial_order(): void
+    {
+        $extension = new ColReorderExtension(headerRows: [0], order: [2, 0, 1]);
+
+        $this->assertSame([
+            'enable'     => true,
+            'columns'    => '',
+            'headerRows' => [0],
+            'order'      => [2, 0, 1],
+        ], $extension->jsonSerialize());
+    }
 }

--- a/tests/Unit/Model/Extensions/ColReorderExtensionTest.php
+++ b/tests/Unit/Model/Extensions/ColReorderExtensionTest.php
@@ -16,10 +16,24 @@ use PHPUnit\Framework\TestCase;
 final class ColReorderExtensionTest extends TestCase
 {
     #[Test]
-    public function it_serializes_to_true(): void
+    public function it_serializes_with_default_options(): void
     {
         $extension = new ColReorderExtension();
 
-        $this->assertTrue($extension->jsonSerialize());
+        $this->assertSame([
+            'enable'  => true,
+            'columns' => '',
+        ], $extension->jsonSerialize());
+    }
+
+    #[Test]
+    public function it_serializes_starting_disabled_with_a_restricted_column_selector(): void
+    {
+        $extension = new ColReorderExtension(enable: false, columns: ':not(:first-child)');
+
+        $this->assertSame([
+            'enable'  => false,
+            'columns' => ':not(:first-child)',
+        ], $extension->jsonSerialize());
     }
 }


### PR DESCRIPTION
- Adds enable, columns, headerRows, order constructor params to ColReorderExtension, matching ColReorder.defaults in the vendored dataTables.colReorder.js exactly (verified by reading the plugin source directly, including the consumption sites — headerRows.includes(rowIdx) and order passed to setOrder() — not just the defaults object).
- jsonSerialize() now returns array instead of a hardcoded bool — ExtensionInterface only requires \JsonSerializable's unconstrained jsonSerialize(): mixed, so this narrower array return type is still fully compatible, and it's what lets a downstream subclass safely override the method (the whole point of this fix).
- headerRows and order stay nullable and are omitted from the payload when unset, rather than serialized as literal null — both mean "no restriction" in DataTables' own defaults, and an explicit null in the config would clobber that default via DataTables' config merge instead of falling through to it.
- enable/columns are always present (including the meaningful columns: '' default) — only headerRows/order are conditionally omitted.
Closes #324