### PR TITLE
fix: give Responsive, KeyTable, and Scroller real constructor options

### DIFF
--- a/docs/src/content/docs/extensions/keytable.mdx
+++ b/docs/src/content/docs/extensions/keytable.mdx
@@ -17,6 +17,29 @@ use Pentiminax\UX\DataTables\Model\Extensions\KeyTableExtension;
 $dataTable->addExtension(new KeyTableExtension());
 ```
 
+## Advanced Example
+
+```php
+$dataTable->addExtension(
+    new KeyTableExtension(
+        blurable: false,
+        className: 'cell-focus',
+        clipboard: true,
+        clipboardOrthogonal: 'display',
+        columns: ':not(:first-child)',
+        editOnFocus: false,
+        focus: [0, 1],
+        keys: [37, 38, 39, 40],
+        tabIndex: 0,
+    )
+);
+```
+
+`columns` is a DataTables column-selector string restricting which columns can be focused (default
+`''` allows every column). `focus` is a `[row, column]` pair to focus on load. `keys` restricts
+which key codes KeyTable listens for; omit either to keep DataTables' defaults (no initial focus,
+every key).
+
 ## Frequent Pitfalls
 
 - Not testing keyboard interactions with Select/Scroller combinations.

--- a/docs/src/content/docs/extensions/responsive.mdx
+++ b/docs/src/content/docs/extensions/responsive.mdx
@@ -20,8 +20,19 @@ $dataTable->responsive();
 ```php
 use Pentiminax\UX\DataTables\Model\Extensions\ResponsiveExtension;
 
-$dataTable->addExtension(new ResponsiveExtension());
+$dataTable->addExtension(
+    new ResponsiveExtension(
+        auto: true,
+        detailsTarget: 0,
+        detailsType: 'inline',
+        orthogonal: 'display',
+    )
+);
 ```
+
+`detailsType` accepts `'inline'`, `'column'`, `'colvis'`, or `false` to disable the hidden-column
+details control entirely. Pass `breakpoints` (a list of `['name' => string, 'width' => int]` pairs)
+to override DataTables' built-in breakpoint list; omit it to keep the defaults.
 
 ## Frequent Pitfalls
 

--- a/docs/src/content/docs/extensions/scroller.mdx
+++ b/docs/src/content/docs/extensions/scroller.mdx
@@ -19,6 +19,24 @@ $dataTable
     ->scrollY('480px');
 ```
 
+## Advanced Example
+
+```php
+$dataTable
+    ->addExtension(
+        new ScrollerExtension(
+            boundaryScale: 0.5,
+            displayBuffer: 9,
+            rowHeight: 'auto',
+            serverWait: 200,
+        )
+    )
+    ->scrollY('480px');
+```
+
+`rowHeight` accepts a pixel integer or `'auto'` to measure it from the rendered rows. `serverWait`
+is the minimum milliseconds Scroller waits between Ajax requests while scrolling quickly.
+
 ## Frequent Pitfalls
 
 - Using Scroller without vertical scroll (`scrollY`).

--- a/skills/ux-datatables/references/extensions.md
+++ b/skills/ux-datatables/references/extensions.md
@@ -73,23 +73,45 @@ new FixedHeaderExtension(header: true, footer: false, headerOffset: 0, footerOff
 
 Not intended to be combined with `ScrollerExtension` or the core `scrollY` / `scrollX` scrolling feature.
 
+## Responsive — collapse columns on small screens
+
+```php
+new ResponsiveExtension(auto: true, detailsTarget: 0, detailsType: 'inline', orthogonal: 'display');
+```
+
+All params optional — `$table->responsive()` uses every default. `detailsType` also accepts
+`'column'`, `'colvis'`, or `false` to disable the hidden-column details control. Pass `breakpoints`
+(list of `['name' => string, 'width' => int]`) to override DataTables' built-in list; omit to keep it.
+
+## KeyTable — keyboard cell navigation
+
+```php
+new KeyTableExtension(blurable: true, className: 'focus', clipboard: true, columns: '', keys: null);
+```
+
+All params optional. `columns` is a column-selector string restricting which columns can be
+focused. `focus` (`[row, column]`) and `keys` (key codes to listen for) default to `null`, omitted
+from the payload unless set.
+
+## Scroller — virtual scrolling for large tables
+
+```php
+new ScrollerExtension(boundaryScale: 0.5, displayBuffer: 9, rowHeight: 'auto', serverWait: 200);
+```
+
+All params optional and match DataTables' own defaults.
+
 ## Toggle-only extensions
 
 No constructor args needed:
 
 | Extension | Effect |
 |-----------|--------|
-| `ResponsiveExtension` | collapse columns on small screens (`$table->responsive()`) |
 | `ColumnControlExtension` | per-column order/search controls (`$table->columnControl()`) |
-| `ScrollerExtension` | virtual scrolling for large tables |
-| `KeyTableExtension` | keyboard cell navigation |
 | `ColReorderExtension` | drag to reorder columns |
 
 ```php
-$extensions
-    ->addExtension(new ScrollerExtension())
-    ->addExtension(new KeyTableExtension())
-    ->addExtension(new ColReorderExtension());
+$extensions->addExtension(new ColReorderExtension());
 ```
 
 See `docs/src/content/docs/extensions/combining-extensions.mdx` for compatible combinations.

--- a/src/Model/Extensions/KeyTableExtension.php
+++ b/src/Model/Extensions/KeyTableExtension.php
@@ -6,13 +6,40 @@ namespace Pentiminax\UX\DataTables\Model\Extensions;
 
 class KeyTableExtension extends AbstractExtension
 {
+    /**
+     * @param array{0: int, 1: int}|null $focus a [row, column] pair to focus on load, or null for none
+     * @param list<int|string>|null      $keys  key codes to listen for, or null for every key
+     */
+    public function __construct(
+        private readonly bool $blurable = true,
+        private readonly string $className = 'focus',
+        private readonly bool $clipboard = true,
+        private readonly string $clipboardOrthogonal = 'display',
+        private readonly string $columns = '',
+        private readonly bool $editOnFocus = false,
+        private readonly ?array $focus = null,
+        private readonly ?array $keys = null,
+        private readonly ?int $tabIndex = null,
+    ) {
+    }
+
     public function getKey(): string
     {
         return 'keys';
     }
 
-    public function jsonSerialize(): bool
+    public function jsonSerialize(): array
     {
-        return true;
+        return array_filter([
+            'blurable'            => $this->blurable,
+            'className'           => $this->className,
+            'clipboard'           => $this->clipboard,
+            'clipboardOrthogonal' => $this->clipboardOrthogonal,
+            'columns'             => $this->columns,
+            'editOnFocus'         => $this->editOnFocus,
+            'focus'               => $this->focus,
+            'keys'                => $this->keys,
+            'tabIndex'            => $this->tabIndex,
+        ], static fn (mixed $value): bool => null !== $value);
     }
 }

--- a/src/Model/Extensions/ResponsiveExtension.php
+++ b/src/Model/Extensions/ResponsiveExtension.php
@@ -6,13 +6,47 @@ namespace Pentiminax\UX\DataTables\Model\Extensions;
 
 class ResponsiveExtension extends AbstractExtension
 {
+    /**
+     * @param list<array{name: string, width: int}>|null $breakpoints   omitted when null, so DataTables
+     *                                                                  keeps its own built-in breakpoint
+     *                                                                  list (its widest entry is not
+     *                                                                  JSON-representable)
+     * @param int|string                                 $detailsTarget column index or selector the
+     *                                                                  hidden-column details control
+     *                                                                  attaches to
+     * @param string|false                               $detailsType   'inline'|'column'|'colvis', or
+     *                                                                  false to disable the details
+     *                                                                  display entirely
+     */
+    public function __construct(
+        private readonly bool $auto = true,
+        private readonly ?array $breakpoints = null,
+        private readonly int|string $detailsTarget = 0,
+        private readonly string|false $detailsType = 'inline',
+        private readonly string $orthogonal = 'display',
+    ) {
+    }
+
     public function getKey(): string
     {
         return 'responsive';
     }
 
-    public function jsonSerialize(): bool
+    public function jsonSerialize(): array
     {
-        return true;
+        $config = [
+            'auto'    => $this->auto,
+            'details' => [
+                'target' => $this->detailsTarget,
+                'type'   => $this->detailsType,
+            ],
+            'orthogonal' => $this->orthogonal,
+        ];
+
+        if (null !== $this->breakpoints) {
+            $config['breakpoints'] = $this->breakpoints;
+        }
+
+        return $config;
     }
 }

--- a/src/Model/Extensions/ScrollerExtension.php
+++ b/src/Model/Extensions/ScrollerExtension.php
@@ -6,13 +6,26 @@ namespace Pentiminax\UX\DataTables\Model\Extensions;
 
 class ScrollerExtension extends AbstractExtension
 {
+    public function __construct(
+        private readonly float $boundaryScale = 0.5,
+        private readonly int $displayBuffer = 9,
+        private readonly int|string $rowHeight = 'auto',
+        private readonly int $serverWait = 200,
+    ) {
+    }
+
     public function getKey(): string
     {
         return 'scroller';
     }
 
-    public function jsonSerialize(): bool
+    public function jsonSerialize(): array
     {
-        return true;
+        return [
+            'boundaryScale' => $this->boundaryScale,
+            'displayBuffer' => $this->displayBuffer,
+            'rowHeight'     => $this->rowHeight,
+            'serverWait'    => $this->serverWait,
+        ];
     }
 }

--- a/tests/Unit/DataCollector/DataTablePanelRenderTest.php
+++ b/tests/Unit/DataCollector/DataTablePanelRenderTest.php
@@ -85,8 +85,6 @@ final class DataTablePanelRenderTest extends TestCase
         $table->data([['name' => 'Sensitive-Row-Value']]);
         $table->setFilters((new Filters())->add(TextFilter::new('name')));
         $table->getExtensionsCollection()->addButtonsExtension([ButtonType::CSV]);
-        // Options serialize to `true`, which is not countable: the panel must
-        // dump them without testing their emptiness.
         $table->getExtensionsCollection()->addResponsiveExtension();
 
         return $table;

--- a/tests/Unit/Model/DataTableTest.php
+++ b/tests/Unit/Model/DataTableTest.php
@@ -9,6 +9,7 @@ use Pentiminax\UX\DataTables\Enum\Feature;
 use Pentiminax\UX\DataTables\Enum\Language;
 use Pentiminax\UX\DataTables\Model\DataTable;
 use Pentiminax\UX\DataTables\Model\Extensions\ColumnControlExtension;
+use Pentiminax\UX\DataTables\Model\Extensions\ResponsiveExtension;
 use Pentiminax\UX\DataTables\Model\Extensions\SelectExtension;
 use Pentiminax\UX\DataTables\Model\Options\SearchOption;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -58,7 +59,7 @@ final class DataTableTest extends TestCase
         $expectedExtensions = [
             'columnControl' => (new ColumnControlExtension())->jsonSerialize(),
             'select'        => $selectExtension->jsonSerialize(),
-            'responsive'    => true,
+            'responsive'    => (new ResponsiveExtension())->jsonSerialize(),
         ];
 
         $this->assertEquals($expectedExtensions, $table->getExtensions());

--- a/tests/Unit/Model/Extensions/KeyTableExtensionTest.php
+++ b/tests/Unit/Model/Extensions/KeyTableExtensionTest.php
@@ -16,10 +16,45 @@ use PHPUnit\Framework\TestCase;
 final class KeyTableExtensionTest extends TestCase
 {
     #[Test]
-    public function it_serializes_to_true(): void
+    public function it_serializes_with_default_options(): void
     {
         $extension = new KeyTableExtension();
 
-        $this->assertTrue($extension->jsonSerialize());
+        $this->assertSame([
+            'blurable'            => true,
+            'className'           => 'focus',
+            'clipboard'           => true,
+            'clipboardOrthogonal' => 'display',
+            'columns'             => '',
+            'editOnFocus'         => false,
+        ], $extension->jsonSerialize());
+    }
+
+    #[Test]
+    public function it_serializes_custom_options(): void
+    {
+        $extension = new KeyTableExtension(
+            blurable: false,
+            className: 'cell-focus',
+            clipboard: false,
+            clipboardOrthogonal: 'filter',
+            columns: ':not(:first-child)',
+            editOnFocus: true,
+            focus: [0, 1],
+            keys: [37, 38, 39, 40],
+            tabIndex: 0,
+        );
+
+        $this->assertSame([
+            'blurable'            => false,
+            'className'           => 'cell-focus',
+            'clipboard'           => false,
+            'clipboardOrthogonal' => 'filter',
+            'columns'             => ':not(:first-child)',
+            'editOnFocus'         => true,
+            'focus'               => [0, 1],
+            'keys'                => [37, 38, 39, 40],
+            'tabIndex'            => 0,
+        ], $extension->jsonSerialize());
     }
 }

--- a/tests/Unit/Model/Extensions/ResponsiveExtensionTest.php
+++ b/tests/Unit/Model/Extensions/ResponsiveExtensionTest.php
@@ -16,10 +16,58 @@ use PHPUnit\Framework\TestCase;
 final class ResponsiveExtensionTest extends TestCase
 {
     #[Test]
-    public function it_serializes_to_true(): void
+    public function it_serializes_with_default_options(): void
     {
         $extension = new ResponsiveExtension();
 
-        $this->assertTrue($extension->jsonSerialize());
+        $this->assertSame([
+            'auto'    => true,
+            'details' => [
+                'target' => 0,
+                'type'   => 'inline',
+            ],
+            'orthogonal' => 'display',
+        ], $extension->jsonSerialize());
+    }
+
+    #[Test]
+    public function it_serializes_custom_options(): void
+    {
+        $extension = new ResponsiveExtension(
+            auto: false,
+            detailsTarget: -1,
+            detailsType: false,
+            orthogonal: 'sort',
+        );
+
+        $this->assertSame([
+            'auto'    => false,
+            'details' => [
+                'target' => -1,
+                'type'   => false,
+            ],
+            'orthogonal' => 'sort',
+        ], $extension->jsonSerialize());
+    }
+
+    #[Test]
+    public function it_omits_breakpoints_when_not_set(): void
+    {
+        $extension = new ResponsiveExtension();
+
+        $this->assertArrayNotHasKey('breakpoints', $extension->jsonSerialize());
+    }
+
+    #[Test]
+    public function it_includes_explicit_breakpoints(): void
+    {
+        $breakpoints = [
+            ['name' => 'desktop', 'width' => 1200],
+            ['name' => 'mobile', 'width' => 480],
+        ];
+
+        $extension = new ResponsiveExtension(breakpoints: $breakpoints);
+
+        $this->assertSame($breakpoints, $extension->jsonSerialize()['breakpoints']);
     }
 }

--- a/tests/Unit/Model/Extensions/ScrollerExtensionTest.php
+++ b/tests/Unit/Model/Extensions/ScrollerExtensionTest.php
@@ -16,10 +16,33 @@ use PHPUnit\Framework\TestCase;
 final class ScrollerExtensionTest extends TestCase
 {
     #[Test]
-    public function it_serializes_to_true(): void
+    public function it_serializes_with_default_options(): void
     {
         $extension = new ScrollerExtension();
 
-        $this->assertTrue($extension->jsonSerialize());
+        $this->assertSame([
+            'boundaryScale' => 0.5,
+            'displayBuffer' => 9,
+            'rowHeight'     => 'auto',
+            'serverWait'    => 200,
+        ], $extension->jsonSerialize());
+    }
+
+    #[Test]
+    public function it_serializes_custom_options(): void
+    {
+        $extension = new ScrollerExtension(
+            boundaryScale: 0.75,
+            displayBuffer: 12,
+            rowHeight: 32,
+            serverWait: 500,
+        );
+
+        $this->assertSame([
+            'boundaryScale' => 0.75,
+            'displayBuffer' => 12,
+            'rowHeight'     => 32,
+            'serverWait'    => 500,
+        ], $extension->jsonSerialize());
     }
 }


### PR DESCRIPTION
Same fix as #325, applied to the three remaining extensions still frozen at jsonSerialize(): bool.

- ResponsiveExtension: auto, breakpoints, detailsTarget, detailsType, orthogonal. breakpoints stays nullable and is omitted unless set — DataTables' own default breakpoint list has a width: Infinity entry with no JSON representation, and an explicit null there would clobber the default via config merging instead of falling through to it.
- KeyTableExtension: blurable, className, clipboard, clipboardOrthogonal, columns, editOnFocus, focus, keys, tabIndex. focus/keys/tabIndex are nullable and omitted when unset; the boolean fields and the empty-string columns default are always present (only actual nulls are stripped).
- ScrollerExtension: boundaryScale, displayBuffer, rowHeight, serverWait — always fully present, nothing conditionally omitted.
Every default value was read directly from the vendored dataTables.*.mjs source (not docs or memory) to guarantee new XExtension() stays behavior-identical to the current bare-true payload.
- Two existing tests (DataTableTest, DataTablePanelRenderTest) hard-asserted the old literal true/bare-bool payload shape for ResponsiveExtension and needed updating to the new array shape — both fixed here.
Closes #326 

You'll probably get tired of me, but I'm porting a ... very large ... project from a different datatables bundle and datatables v2 to v3 and so I need full feature parity :)