### PR TITLE
feat: reset shared DataTable services between requests (#313 phase 1)

### DIFF
--- a/docs/src/content/docs/reference/abstract-datatable.mdx
+++ b/docs/src/content/docs/reference/abstract-datatable.mdx
@@ -293,6 +293,28 @@ into each action. See the [Action Columns](../action-columns/) reference for the
   ]}
 />
 
+#### Configuration Methods Must Be Pure
+
+DataTable services are shared in the container: `configure*()` runs once and its
+result is reused. Under PHP-FPM the process dies after each request, so the
+configuration is rebuilt anyway. Under a worker runtime (FrankenPHP worker mode,
+Swoole, RoadRunner) the same instance serves many requests, for many users.
+
+The bundle tags every autoconfigured table with `kernel.reset`, so Symfony's
+`ServicesResetter` clears the per-request state between requests and the
+configuration is rebuilt each time. Still, treat `configure*()` as pure: define
+columns, actions, filters, extensions, and table options, and nothing else.
+
+Do not read the current HTTP request, the security token, the session, the
+locale, or any other per-request service from a `configure*()` method. Configure
+the table declaratively and let the request-scoped boundaries do the rest:
+
+- `permission()` on columns and actions for authorization -- it is evaluated per
+  request, per row, at the output boundary.
+- `customizeQueryBuilder()` and `getRequest()` for anything that depends on the
+  incoming request.
+- `setData()` for data resolved by the controller.
+
 ### Data Methods
 
 <Table

--- a/src/DataTablesBundle.php
+++ b/src/DataTablesBundle.php
@@ -93,7 +93,7 @@ class DataTablesBundle extends AbstractBundle
     {
         $builder->registerForAutoconfiguration(AbstractDataTable::class)
             ->addTag('datatables.data_table')
-            ->addTag('kernel.reset', ['method' => 'reset'])
+            ->addTag('kernel.reset', ['method' => 'resetDataTableState'])
             ->addMethodCall('setDataTableInfrastructure', [new Reference('datatables.infrastructure')]);
 
         $formAvailable    = interface_exists(FormFactoryInterface::class);

--- a/src/DataTablesBundle.php
+++ b/src/DataTablesBundle.php
@@ -93,6 +93,7 @@ class DataTablesBundle extends AbstractBundle
     {
         $builder->registerForAutoconfiguration(AbstractDataTable::class)
             ->addTag('datatables.data_table')
+            ->addTag('kernel.reset', ['method' => 'reset'])
             ->addMethodCall('setDataTableInfrastructure', [new Reference('datatables.infrastructure')]);
 
         $formAvailable    = interface_exists(FormFactoryInterface::class);

--- a/src/Model/AbstractDataTable.php
+++ b/src/Model/AbstractDataTable.php
@@ -74,11 +74,17 @@ abstract class AbstractDataTable
      * rows instead of re-serving the previous request's payload -- along with the
      * action URLs and CSRF tokens resolved for the previous user.
      *
+     * Deliberately not named `reset()`: that name is common enough on user tables
+     * (`ResetInterface`, filter resets) that adding it as a final method would break
+     * existing subclasses on upgrade. A subclass method must never win here either,
+     * since silently skipping this would reintroduce the cross-request leak, hence
+     * both the distinctive name and `final`.
+     *
      * `$infrastructure` is deliberately kept: it is injected once by a
      * construction-time method call that is never replayed. `static::$attributeCache`
      * is kept too, being keyed by class and holding an immutable value object.
      */
-    final public function reset(): void
+    final public function resetDataTableState(): void
     {
         unset($this->table, $this->columns, $this->filters);
 

--- a/src/Model/AbstractDataTable.php
+++ b/src/Model/AbstractDataTable.php
@@ -64,26 +64,6 @@ abstract class AbstractDataTable
         $this->infrastructure = $infrastructure;
     }
 
-    /**
-     * Clear every piece of per-request state so a container-shared table behaves
-     * identically under PHP-FPM and long-running workers (FrankenPHP worker mode,
-     * Swoole, RoadRunner).
-     *
-     * Wired through the `kernel.reset` tag: `ServicesResetter` calls this between
-     * requests, so the next request re-runs `configure*()` and hydrates its own
-     * rows instead of re-serving the previous request's payload -- along with the
-     * action URLs and CSRF tokens resolved for the previous user.
-     *
-     * Deliberately not named `reset()`: that name is common enough on user tables
-     * (`ResetInterface`, filter resets) that adding it as a final method would break
-     * existing subclasses on upgrade. A subclass method must never win here either,
-     * since silently skipping this would reintroduce the cross-request leak, hence
-     * both the distinctive name and `final`.
-     *
-     * `$infrastructure` is deliberately kept: it is injected once by a
-     * construction-time method call that is never replayed. `static::$attributeCache`
-     * is kept too, being keyed by class and holding an immutable value object.
-     */
     final public function resetDataTableState(): void
     {
         unset($this->table, $this->columns, $this->filters);
@@ -194,21 +174,6 @@ abstract class AbstractDataTable
     }
 
     /**
-     * Resolve the Mercure configuration exactly as the render path would
-     * serialize it to the browser, WITHOUT hydrating client-side data and
-     * WITHOUT mutating this container-shared instance.
-     *
-     * Delegates to the same pure RenderingPreparer::resolveMercureConfig() the
-     * render path uses, so published topics always match the ones the client
-     * subscribed to, but deliberately skips hydrateClientSideData() so resolving
-     * topics for a mutation never triggers a data-provider / DB query as a side
-     * effect. When the render path would embed static client-side data — which
-     * disables Mercure live updates — this returns null, mirroring
-     * RenderingPreparer::configureMercure().
-     *
-     * Callers that must not fail (e.g. after a committed mutation) should guard
-     * against the LogicException that Mercure hub-URL resolution can throw.
-     *
      * @throws \LogicException if Mercure is enabled but the hub URL cannot be resolved
      */
     public function resolveMercureConfigWithoutHydration(): ?MercureConfig

--- a/src/Model/AbstractDataTable.php
+++ b/src/Model/AbstractDataTable.php
@@ -64,6 +64,31 @@ abstract class AbstractDataTable
         $this->infrastructure = $infrastructure;
     }
 
+    /**
+     * Clear every piece of per-request state so a container-shared table behaves
+     * identically under PHP-FPM and long-running workers (FrankenPHP worker mode,
+     * Swoole, RoadRunner).
+     *
+     * Wired through the `kernel.reset` tag: `ServicesResetter` calls this between
+     * requests, so the next request re-runs `configure*()` and hydrates its own
+     * rows instead of re-serving the previous request's payload -- along with the
+     * action URLs and CSRF tokens resolved for the previous user.
+     *
+     * `$infrastructure` is deliberately kept: it is injected once by a
+     * construction-time method call that is never replayed. `static::$attributeCache`
+     * is kept too, being keyed by class and holding an immutable value object.
+     */
+    final public function reset(): void
+    {
+        unset($this->table, $this->columns, $this->filters);
+
+        $this->defaultRowMapper  = null;
+        $this->asDataTable       = null;
+        $this->runtime           = null;
+        $this->initialized       = false;
+        $this->renderingPrepared = false;
+    }
+
     private function initialize(): void
     {
         if ($this->initialized) {

--- a/tests/Unit/DataTablesBundleTest.php
+++ b/tests/Unit/DataTablesBundleTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pentiminax\UX\DataTables\Tests\Unit;
 
 use Pentiminax\UX\DataTables\DataTablesBundle;
+use Pentiminax\UX\DataTables\Model\AbstractDataTable;
 use Pentiminax\UX\DataTables\Model\FilterLabels;
 use Pentiminax\UX\DataTables\Query\Intent\DefaultDataTableQueryIntentFactory;
 use Pentiminax\UX\DataTables\Runtime\DataTableInfrastructure;
@@ -30,6 +31,24 @@ final class DataTablesBundleTest extends TestCase
         self::assertArrayHasKey('DataTablesBundle', $this->kernel->getBundles());
         self::assertInstanceOf(DataTableInfrastructure::class, $infrastructure);
         self::assertInstanceOf(DefaultDataTableQueryIntentFactory::class, $infrastructure->queryIntentFactory());
+    }
+
+    /**
+     * Autoconfigured tables are tagged `kernel.reset`, so worker runtimes
+     * (FrankenPHP worker mode, Swoole, RoadRunner) get the per-request isolation
+     * PHP-FPM gets from a fresh process.
+     */
+    #[Test]
+    public function it_resets_shared_data_tables_between_requests(): void
+    {
+        /** @var AbstractDataTable $table */
+        $table = $this->kernel->getContainer()->get('test.datatables.server_side_template');
+
+        $configured = $table->getDataTable();
+
+        $this->container->get('services_resetter')->reset();
+
+        self::assertNotSame($configured, $table->getDataTable());
     }
 
     #[Test]

--- a/tests/Unit/Model/AbstractDataTableResetTest.php
+++ b/tests/Unit/Model/AbstractDataTableResetTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Unit\Model;
+
+use Pentiminax\UX\DataTables\Column\ActionColumn;
+use Pentiminax\UX\DataTables\Column\ColumnResolver;
+use Pentiminax\UX\DataTables\Column\Rendering\ActionRowDataResolver;
+use Pentiminax\UX\DataTables\Column\TextColumn;
+use Pentiminax\UX\DataTables\Model\AbstractDataTable;
+use Pentiminax\UX\DataTables\Model\Action;
+use Pentiminax\UX\DataTables\Model\Actions;
+use Pentiminax\UX\DataTables\Model\DataTable;
+use Pentiminax\UX\DataTables\Runtime\DataTableInfrastructure;
+use Pentiminax\UX\DataTables\Runtime\DataTableRuntimeFactory;
+use Pentiminax\UX\DataTables\Security\PermissionChecker;
+use Pentiminax\UX\DataTables\Tests\Support\ConfigurableDataTable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+/**
+ * A container-shared table serves many requests under a worker runtime
+ * (FrankenPHP worker mode, Swoole, RoadRunner). `reset()` is what gives those
+ * runtimes the same per-request isolation PHP-FPM gets for free.
+ *
+ * @internal
+ */
+#[CoversClass(AbstractDataTable::class)]
+final class AbstractDataTableResetTest extends TestCase
+{
+    #[Test]
+    public function it_re_evaluates_the_configuration_after_a_reset(): void
+    {
+        $rows = [['id' => 1]];
+
+        $table = new ConfigurableDataTable(
+            [TextColumn::new('id')],
+            configureTable: static function (DataTable $table) use (&$rows): DataTable {
+                return $table->data($rows);
+            },
+        );
+        $table->setDataTableInfrastructure(DataTableInfrastructure::createDefault());
+
+        $this->assertSame([['id' => 1]], $table->getDataTable()->getOption('data'));
+
+        $rows = [['id' => 2]];
+
+        $this->assertSame(
+            [['id' => 1]],
+            $table->getDataTable()->getOption('data'),
+            'Without a reset the first request\'s rows stay frozen on the shared instance.',
+        );
+
+        $table->reset();
+
+        $this->assertSame([['id' => 2]], $table->getDataTable()->getOption('data'));
+    }
+
+    #[Test]
+    public function it_rebuilds_the_data_table_after_a_reset(): void
+    {
+        $table = new ConfigurableDataTable([TextColumn::new('id')]);
+        $table->setDataTableInfrastructure(DataTableInfrastructure::createDefault());
+
+        $first = $table->getDataTable();
+
+        $table->reset();
+
+        $this->assertNotSame($first, $table->getDataTable());
+    }
+
+    #[Test]
+    public function it_drops_the_handled_request_after_a_reset(): void
+    {
+        $table = new ConfigurableDataTable([TextColumn::new('id')]);
+        $table->setDataTableInfrastructure(DataTableInfrastructure::createDefault());
+
+        $table->handleRequest(new Request(['draw' => '1']));
+
+        $this->assertNotNull($table->getRequest());
+
+        $table->reset();
+
+        $this->assertNull($table->getRequest());
+        $this->assertFalse($table->isRequestHandled());
+    }
+
+    /**
+     * The leak PR #323 reported: an action resolved for a privileged user keeps
+     * its URL and CSRF token in the rows cached on the shared instance, and the
+     * next render hands them to whoever asks.
+     */
+    #[Test]
+    public function it_drops_action_data_resolved_for_the_previous_user_after_a_reset(): void
+    {
+        $granted = true;
+
+        $table = $this->tableWithAction(
+            Action::detail()
+                ->permission('ROLE_ADMIN')
+                ->linkToUrl(static fn (array $row): string => '/books/'.$row['id']),
+            $granted,
+        );
+
+        $this->assertSame(
+            ['DETAIL' => ['url' => '/books/5']],
+            $this->rowActions($table),
+        );
+
+        $granted = false;
+        $table->reset();
+
+        $this->assertNull($this->rowActions($table));
+    }
+
+    /**
+     * Per-row permissions are re-evaluated too: intersecting the previous
+     * request's action names would keep this one, since the action stays
+     * configured and only its subject is denied.
+     */
+    #[Test]
+    public function it_drops_per_row_denied_action_data_after_a_reset(): void
+    {
+        $granted = true;
+
+        $table = $this->tableWithAction(
+            Action::detail()
+                ->permission('BOOK_VIEW', static fn (array $row): array => $row)
+                ->linkToUrl(static fn (array $row): string => '/books/'.$row['id']),
+            $granted,
+        );
+
+        $this->assertSame(
+            ['DETAIL' => ['url' => '/books/5']],
+            $this->rowActions($table),
+        );
+
+        $granted = false;
+        $table->reset();
+
+        $this->assertNull($this->rowActions($table));
+    }
+
+    #[Test]
+    public function it_accepts_infrastructure_injection_after_a_reset(): void
+    {
+        $table = new ConfigurableDataTable([TextColumn::new('id')]);
+        $table->setDataTableInfrastructure(DataTableInfrastructure::createDefault());
+
+        $table->getDataTable();
+        $table->reset();
+
+        $table->setDataTableInfrastructure(DataTableInfrastructure::createDefault());
+
+        $this->assertNotNull($table->getDataTable());
+    }
+
+    private function tableWithAction(Action $action, bool &$granted): ConfigurableDataTable
+    {
+        $checker = $this->createMock(AuthorizationCheckerInterface::class);
+        $checker
+            ->method('isGranted')
+            ->willReturnCallback(static function () use (&$granted): bool {
+                return $granted;
+            });
+
+        $permissionChecker = new PermissionChecker($checker);
+
+        $table = new ConfigurableDataTable(
+            [
+                TextColumn::new('id'),
+                ActionColumn::fromActions('actions', 'Actions', (new Actions())->add($action)),
+            ],
+            configureTable: static fn (DataTable $table): DataTable => $table->data([['id' => 5]]),
+        );
+
+        $table->setDataTableInfrastructure(DataTableInfrastructure::createDefault(
+            columnResolver: new ColumnResolver(permissionChecker: $permissionChecker),
+            runtimeFactory: new DataTableRuntimeFactory(
+                actionRowDataResolver: new ActionRowDataResolver($permissionChecker),
+                permissionChecker: $permissionChecker,
+            ),
+        ));
+
+        return $table;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function rowActions(ConfigurableDataTable $table): ?array
+    {
+        $data = $table->getDataTable()->getOption('data');
+
+        return $data[0][ActionRowDataResolver::ROW_ACTIONS_KEY] ?? null;
+    }
+}

--- a/tests/Unit/Model/AbstractDataTableResetTest.php
+++ b/tests/Unit/Model/AbstractDataTableResetTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 /**
  * A container-shared table serves many requests under a worker runtime
- * (FrankenPHP worker mode, Swoole, RoadRunner). `reset()` is what gives those
+ * (FrankenPHP worker mode, Swoole, RoadRunner). `resetDataTableState()` is what gives those
  * runtimes the same per-request isolation PHP-FPM gets for free.
  *
  * @internal
@@ -55,7 +55,7 @@ final class AbstractDataTableResetTest extends TestCase
             'Without a reset the first request\'s rows stay frozen on the shared instance.',
         );
 
-        $table->reset();
+        $table->resetDataTableState();
 
         $this->assertSame([['id' => 2]], $table->getDataTable()->getOption('data'));
     }
@@ -68,7 +68,7 @@ final class AbstractDataTableResetTest extends TestCase
 
         $first = $table->getDataTable();
 
-        $table->reset();
+        $table->resetDataTableState();
 
         $this->assertNotSame($first, $table->getDataTable());
     }
@@ -83,7 +83,7 @@ final class AbstractDataTableResetTest extends TestCase
 
         $this->assertNotNull($table->getRequest());
 
-        $table->reset();
+        $table->resetDataTableState();
 
         $this->assertNull($table->getRequest());
         $this->assertFalse($table->isRequestHandled());
@@ -112,7 +112,7 @@ final class AbstractDataTableResetTest extends TestCase
         );
 
         $granted = false;
-        $table->reset();
+        $table->resetDataTableState();
 
         $this->assertNull($this->rowActions($table));
     }
@@ -140,7 +140,7 @@ final class AbstractDataTableResetTest extends TestCase
         );
 
         $granted = false;
-        $table->reset();
+        $table->resetDataTableState();
 
         $this->assertNull($this->rowActions($table));
     }
@@ -152,11 +152,43 @@ final class AbstractDataTableResetTest extends TestCase
         $table->setDataTableInfrastructure(DataTableInfrastructure::createDefault());
 
         $table->getDataTable();
-        $table->reset();
+        $table->resetDataTableState();
 
         $table->setDataTableInfrastructure(DataTableInfrastructure::createDefault());
 
         $this->assertNotNull($table->getDataTable());
+    }
+
+    /**
+     * `reset()` is a common enough method name on user tables (`ResetInterface`,
+     * filter resets) that claiming it as a final method would break existing
+     * subclasses on upgrade. Declaring one here fails at class-load time if the
+     * hook is ever renamed back.
+     */
+    #[Test]
+    public function it_leaves_the_reset_method_name_to_subclasses(): void
+    {
+        $table = new class extends AbstractDataTable {
+            public bool $resetCalled = false;
+
+            public function reset(): void
+            {
+                $this->resetCalled = true;
+            }
+
+            public function configureColumns(): iterable
+            {
+                return [TextColumn::new('id')];
+            }
+        };
+        $table->setDataTableInfrastructure(DataTableInfrastructure::createDefault());
+
+        $first = $table->getDataTable();
+
+        $table->resetDataTableState();
+
+        $this->assertNotSame($first, $table->getDataTable());
+        $this->assertFalse($table->resetCalled);
     }
 
     private function tableWithAction(Action $action, bool &$granted): ConfigurableDataTable


### PR DESCRIPTION
Phase 1 of #313: give worker runtimes the per-request isolation PHP-FPM gets for free.

## Problem

`AbstractDataTable` is a container-shared service that caches its entire per-request state: the configured `DataTable`, the hydrated rows, the resolved `DataTableRuntime`, and the `initialized` / `renderingPrepared` flags.

Under PHP-FPM the process dies after each request, so none of it is observable. Under a worker runtime (FrankenPHP worker mode, Swoole, RoadRunner) the same instance serves many requests for many users, and the second request re-serves the first one's payload — rows, action URLs, and **CSRF tokens minted against the previous user's session**.

## Change

- `AbstractDataTable::resetDataTableState()` clears `$table`, `$columns`, `$filters`, `$defaultRowMapper`, `$asDataTable`, `$runtime`, `$initialized`, and `$renderingPrepared`.
- The autoconfiguration in `DataTablesBundle::loadExtension()` tags tables with `kernel.reset`, so `ServicesResetter` calls it between requests. No-op under FPM.
- The `configure*()` purity contract is documented in the `AbstractDataTable` reference.

### Why not `reset()`

#313 spells the hook `reset()`, but `AbstractDataTable` is the primary extension point and `reset()` is a common enough method name on user tables — `ResetInterface`, a filter reset — that claiming it as a `final` method makes any subclass already declaring one fatal at class-load time after the upgrade.

Dropping `final` is worse: a subclass `reset()` would silently win over the hook, the per-request state would never be cleared, and the leak would come back with no signal at all. A distinctive name keeps `final` and removes the collision, matching the `setDataTableInfrastructure()` convention already used for framework-facing hooks on this class. The `kernel.reset` tag carries the method name explicitly, so #313's intent is unchanged.

### Other decisions

`$infrastructure` is deliberately kept across resets: it is injected by a construction-time method call that is never replayed, so dropping it would silently fall back to `DataTableInfrastructure::createDefault()` and lose the container-configured collaborators. `static $attributeCache` is kept too — keyed by class, immutable value object.

`$table`, `$columns` and `$filters` are `unset()` rather than reassigned: they are typed properties with no default, and `unset()` is the only way back to the exact constructor state that `initialize()` and `configureColumns()` already expect.

The guard in `setDataTableInfrastructure()` needed no change: after a reset, `$initialized` is `false` and `$runtime` is `null`, so re-injection stays legal. A test pins that.

## Relation to #323

#323 reports a real bug — same root cause, narrower symptom. Its fix intersects the cached `__ux_datatables_actions` payload with the actions still allowed for the current user. Two things that cannot fix:

- **Per-row permissions.** `Action::permission($attribute, $subjectResolver)` is not re-evaluated by an intersection on action names, so an action denied *for this row / this user* keeps its URL and token. This is the P1 review comment on that PR, and it is valid.
- **CSRF tokens.** Even for an action that stays allowed, the cached URL and token were minted against the **first** user's session. At best the action is broken for the next user; at worst the token is reused across sessions. Only re-resolution fixes this, and re-resolving at the Twig boundary is not possible cleanly — `DataTablesExtension` passes the *mapped* row as `$sourceRow`, while the subject resolvers and `resolveRouteParameters()` need the source entity.

Resetting the instance re-resolves everything from scratch, which covers both, plus the stale rows, the stale `DataTableRequest`, and the frozen configuration.

## Tests

`tests/Unit/Model/AbstractDataTableResetTest.php`:

- configuration is re-evaluated after a reset (and demonstrably frozen without one)
- a fresh `DataTable` instance is built
- the handled `DataTableRequest` is dropped
- action data resolved for a privileged user disappears once the permission is denied — **static** and **per-row** variants
- infrastructure injection stays legal after a reset
- a subclass can still declare its own `reset()` — the test fails at class-load time if the hook is ever renamed back

`tests/Unit/DataTablesBundleTest.php`: the `kernel.reset` tag actually resets a shared table through `ServicesResetter`. Verified meaningful — the test fails when the tag is removed.

## Out of scope

- #313 phase 2: per-request `DataTable` clone inside `DataTableRuntime`, after which the reset shrinks to dropping the runtime and the configuration is built once per worker instead of once per request.

## Verification

- `composer fix` — clean
- `composer audit` — no advisories
- `vendor/bin/phpunit` — 979 tests, 3172 assertions, green
- `npm run lint` and `npm run build` in `docs/` — green
- Not tested: a real FrankenPHP worker / Swoole / RoadRunner run.

Refs #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request isolation for shared services and authorization-sensitive row actions/CSRF; behavior is well-tested but worker-runtime integration was not manually verified.
> 
> **Overview**
> **Fixes cross-request leakage** when `AbstractDataTable` services stay alive across requests (FrankenPHP worker, Swoole, RoadRunner). Shared instances previously kept hydrated rows, handled Ajax state, resolved action URLs, and CSRF tokens from the first user.
> 
> Adds **`AbstractDataTable::resetDataTableState()`**, which clears the configured `DataTable`, columns, filters, runtime, and init/render flags while **keeping** injected infrastructure (and class-level attribute cache). Autoconfigured tables are tagged **`kernel.reset`** with method `resetDataTableState`, so Symfony’s `ServicesResetter` runs between requests (no-op under PHP-FPM).
> 
> Documents that **`configure*()` must stay pure**—no request, session, security token, or locale reads—because configuration is rebuilt after reset but the service remains shared.
> 
> Adds unit tests for re-configuration, fresh `DataTable` instances, dropped requests, **role- and per-row** action data after permission changes, post-reset infrastructure injection, and subclass `reset()` compatibility; plus a bundle test that `services_resetter` yields a new table instance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90bfb219ab062dd50b6e223a72ec294604f780eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->