### PR TITLE
feat: add a generic collection Button type for grouping dropdowns

### DIFF
--- a/docs/src/content/docs/extensions/buttons.mdx
+++ b/docs/src/content/docs/extensions/buttons.mdx
@@ -45,6 +45,7 @@ generated.
     ['`ButtonType::PRINT`', 'Open print view'],
     ['`ButtonType::COLUMN_VISIBILITY`', 'Toggle column visibility'],
     ['`ButtonType::COLUMN_CONTROL_SEARCH_CLEAR`', 'Clear every active search — see below'],
+    ['`ButtonType::COLLECTION`', 'Group other buttons in a dropdown — see below'],
   ]}
 />
 
@@ -133,6 +134,35 @@ clears ColumnControl's own search state. It enables and disables itself automati
 whether any search (global or per-column) is currently active, and defaults to the text "Clear
 search" (localized). `ButtonsExtension::withCcSearchClearButton()` is the fluent-collection
 shortcut.
+
+## Grouping Buttons In A Dropdown
+
+`Button::collection(array $buttons)` builds a dropdown that groups other buttons together, using
+DataTables' generic collection button type — the same mechanism `Button::colVis()` builds on
+internally, made directly available for a plain grouping menu:
+
+```php
+use Pentiminax\UX\DataTables\Enum\Feature;
+use Pentiminax\UX\DataTables\Model\Extensions\Button;
+use Pentiminax\UX\DataTables\Model\Extensions\ButtonsExtension;
+
+$dataTable
+    ->addExtension(new ButtonsExtension([
+        Button::collection([
+            Button::custom('lockColumns')->text('Lock Columns'),
+            Button::custom('restoreOrder')->text('Restore order'),
+        ])->text('Reorder'),
+    ]))
+    ->layout([
+        'topStart' => Feature::BUTTONS,
+    ]);
+```
+
+`buttons` accepts `Button` objects, raw arrays, or bare extend-name strings, mixed freely — they
+serialize the same way whether nested here or at the top level, including custom actions (the
+frontend resolver walks into a collection's `buttons` array recursively, exactly like it does for
+`postfixButtons`/`prefixButtons`). `text` defaults to DataTables' own "Collection" label if omitted.
+`ButtonsExtension::withCollectionButton(array $buttons)` is the fluent-collection shortcut.
 
 ## Frequent Pitfalls
 

--- a/docs/src/content/docs/extensions/buttons.mdx
+++ b/docs/src/content/docs/extensions/buttons.mdx
@@ -149,9 +149,10 @@ use Pentiminax\UX\DataTables\Model\Extensions\ButtonsExtension;
 $dataTable
     ->addExtension(new ButtonsExtension([
         Button::collection([
-            Button::custom('lockColumns')->text('Lock Columns'),
-            Button::custom('restoreOrder')->text('Restore order'),
-        ])->text('Reorder'),
+            Button::csv(),
+            Button::excel(),
+            'colvis',
+        ])->text('Export'),
     ]))
     ->layout([
         'topStart' => Feature::BUTTONS,
@@ -159,9 +160,9 @@ $dataTable
 ```
 
 `buttons` accepts `Button` objects, raw arrays, or bare extend-name strings, mixed freely — they
-serialize the same way whether nested here or at the top level, including custom actions (the
-frontend resolver walks into a collection's `buttons` array recursively, exactly like it does for
-`postfixButtons`/`prefixButtons`). `text` defaults to DataTables' own "Collection" label if omitted.
+serialize the same way whether nested here or at the top level, since `Button` implements
+`JsonSerializable` and PHP's `json_encode()` resolves nested `JsonSerializable` values
+automatically. `text` defaults to DataTables' own "Collection" label if omitted.
 `ButtonsExtension::withCollectionButton(array $buttons)` is the fluent-collection shortcut.
 
 ## Frequent Pitfalls

--- a/docs/src/content/docs/reference/enums.mdx
+++ b/docs/src/content/docs/reference/enums.mdx
@@ -7,7 +7,7 @@ order: 80
 <Table
   headers={['Enum', 'Values']}
   rows={[
-    ['`ButtonType`', '`COLUMN_CONTROL_SEARCH_CLEAR`, `COLUMN_VISIBILITY`, `COPY`, `CSV`, `EXCEL`, `PDF`, `PRINT`'],
+    ['`ButtonType`', '`COLLECTION`, `COLUMN_CONTROL_SEARCH_CLEAR`, `COLUMN_VISIBILITY`, `COPY`, `CSV`, `EXCEL`, `PDF`, `PRINT`'],
     ['`SelectStyle`', '`SINGLE`, `MULTI`'],
     ['`SelectItemType`', '`ROW`, `COLUMN`, `CELL`'],
     [

--- a/skills/ux-datatables/references/extensions.md
+++ b/skills/ux-datatables/references/extensions.md
@@ -31,7 +31,7 @@ new ButtonsExtension([
 ]);
 ```
 
-`ButtonType` cases: `COPY`, `CSV`, `EXCEL`, `PDF`, `PRINT`, `COLUMN_VISIBILITY` (value `'colvis'`), `COLUMN_CONTROL_SEARCH_CLEAR` (value `'ccSearchClear'`). The constructor also accepts strings or `Button` objects. Fluent helpers: `withCopyButton()`, `withCsvButton()`, `withExcelButton()`, `withPdfButton()`, `withPrintButton()`, `withColVisButton()`, `withCcSearchClearButton()`.
+`ButtonType` cases: `COPY`, `CSV`, `EXCEL`, `PDF`, `PRINT`, `COLUMN_VISIBILITY` (value `'colvis'`), `COLUMN_CONTROL_SEARCH_CLEAR` (value `'ccSearchClear'`), `COLLECTION` (value `'collection'`). The constructor also accepts strings or `Button` objects. Fluent helpers: `withCopyButton()`, `withCsvButton()`, `withExcelButton()`, `withPdfButton()`, `withPrintButton()`, `withColVisButton()`, `withCcSearchClearButton()`, `withCollectionButton(array $buttons)`.
 
 Fine-grained config via `Button`:
 ```php
@@ -46,6 +46,17 @@ To position buttons, place `Feature::BUTTONS` in `layout()` (see options).
 `Button::ccSearchClear()` clears the global search plus every ColumnControl per-column search in
 one click, using ColumnControl's own native Buttons entry (no JS needed). Requires
 `ColumnControlExtension` on the table.
+
+`Button::collection(array $buttons)` groups other buttons in a dropdown (the same mechanism
+`colVis()` builds on). `buttons` accepts `Button` objects, raw arrays, or extend-name strings, mixed
+freely — nested buttons serialize correctly at any depth since `Button` is `JsonSerializable`.
+
+```php
+Button::collection([
+    Button::custom('lockColumns')->text('Lock Columns'),
+    Button::custom('restoreOrder')->text('Restore order'),
+])->text('Reorder');
+```
 
 ## Select — row/cell selection
 

--- a/skills/ux-datatables/references/extensions.md
+++ b/skills/ux-datatables/references/extensions.md
@@ -52,10 +52,7 @@ one click, using ColumnControl's own native Buttons entry (no JS needed). Requir
 freely — nested buttons serialize correctly at any depth since `Button` is `JsonSerializable`.
 
 ```php
-Button::collection([
-    Button::custom('lockColumns')->text('Lock Columns'),
-    Button::custom('restoreOrder')->text('Restore order'),
-])->text('Reorder');
+Button::collection([Button::csv(), Button::excel(), 'colvis'])->text('Export');
 ```
 
 ## Select — row/cell selection

--- a/src/Enum/ButtonType.php
+++ b/src/Enum/ButtonType.php
@@ -6,6 +6,7 @@ namespace Pentiminax\UX\DataTables\Enum;
 
 enum ButtonType: string
 {
+    case COLLECTION                  = 'collection';
     case COLUMN_CONTROL_SEARCH_CLEAR = 'ccSearchClear';
     case COLUMN_VISIBILITY           = 'colvis';
     case COPY                        = 'copy';

--- a/src/Model/Extensions/Button.php
+++ b/src/Model/Extensions/Button.php
@@ -11,12 +11,24 @@ final class Button implements \JsonSerializable
     private const DEFAULT_EXPORT_COLUMNS = ':visible:not(.not-exportable)';
 
     /**
-     * Utility button types that never export data: no default `exportOptions`, and serialized as
-     * a bare extend string when no other option is set.
+     * Button types that never export data: no default `exportOptions` is injected for these.
      *
      * @var list<ButtonType>
      */
     private const NON_EXPORT_TYPES = [
+        ButtonType::COLLECTION,
+        ButtonType::COLUMN_CONTROL_SEARCH_CLEAR,
+        ButtonType::COLUMN_VISIBILITY,
+    ];
+
+    /**
+     * Utility button types serialized as a bare extend string when no other option is set. A
+     * collection is never bare — its `buttons` array is the point of the button — so it is a
+     * NON_EXPORT_TYPES member but not one of these.
+     *
+     * @var list<ButtonType>
+     */
+    private const BARE_STRING_TYPES = [
         ButtonType::COLUMN_CONTROL_SEARCH_CLEAR,
         ButtonType::COLUMN_VISIBILITY,
     ];
@@ -74,6 +86,21 @@ final class Button implements \JsonSerializable
         return self::fromType(ButtonType::COLUMN_CONTROL_SEARCH_CLEAR);
     }
 
+    /**
+     * A dropdown grouping other buttons together, using DataTables' generic collection button
+     * type — the same mechanism `Button::colVis()` builds on internally, made directly available
+     * for a plain grouping dropdown (e.g. a "Reorder" menu holding custom column-reorder actions).
+     *
+     * @param list<Button|array<string, mixed>|string> $buttons
+     */
+    public static function collection(array $buttons): self
+    {
+        $button                     = self::fromType(ButtonType::COLLECTION);
+        $button->options['buttons'] = $buttons;
+
+        return $button;
+    }
+
     public function text(string $text): self
     {
         $this->options['text'] = $text;
@@ -107,9 +134,7 @@ final class Button implements \JsonSerializable
 
     public function jsonSerialize(): array|string
     {
-        $isNonExport = \in_array($this->type, self::NON_EXPORT_TYPES, true);
-
-        if ($isNonExport && [] === $this->options) {
+        if (\in_array($this->type, self::BARE_STRING_TYPES, true) && [] === $this->options) {
             return $this->type->value;
         }
 
@@ -117,7 +142,7 @@ final class Button implements \JsonSerializable
             'extend' => $this->type->value,
         ];
 
-        if (!$isNonExport && !\array_key_exists('exportOptions', $this->options)) {
+        if (!\in_array($this->type, self::NON_EXPORT_TYPES, true) && !\array_key_exists('exportOptions', $this->options)) {
             $config['exportOptions'] = [
                 'columns' => self::DEFAULT_EXPORT_COLUMNS,
             ];

--- a/src/Model/Extensions/Button.php
+++ b/src/Model/Extensions/Button.php
@@ -89,7 +89,7 @@ final class Button implements \JsonSerializable
     /**
      * A dropdown grouping other buttons together, using DataTables' generic collection button
      * type — the same mechanism `Button::colVis()` builds on internally, made directly available
-     * for a plain grouping dropdown (e.g. a "Reorder" menu holding custom column-reorder actions).
+     * for a plain grouping dropdown (e.g. an "Export" menu holding several export buttons).
      *
      * @param list<Button|array<string, mixed>|string> $buttons
      */

--- a/src/Model/Extensions/ButtonsExtension.php
+++ b/src/Model/Extensions/ButtonsExtension.php
@@ -48,6 +48,18 @@ final class ButtonsExtension extends AbstractExtension implements LayoutAwareExt
     }
 
     /**
+     * @param list<Button|array<string, mixed>|string> $buttons
+     *
+     * @see Button::collection()
+     */
+    public function withCollectionButton(array $buttons): self
+    {
+        $this->buttons[] = Button::collection($buttons);
+
+        return $this;
+    }
+
+    /**
      * @see Button::ccSearchClear()
      */
     public function withCcSearchClearButton(): self

--- a/tests/Unit/Model/Extensions/ButtonTest.php
+++ b/tests/Unit/Model/Extensions/ButtonTest.php
@@ -88,5 +88,31 @@ final class ButtonTest extends TestCase
                 'text'   => 'Clear filters',
             ],
         ];
+
+        yield 'collection with no options is still an object, not a bare string' => [
+            Button::collection([]),
+            [
+                'extend'  => 'collection',
+                'buttons' => [],
+            ],
+        ];
+    }
+
+    #[Test]
+    public function it_serializes_a_collection_with_nested_button_objects_and_raw_strings(): void
+    {
+        $button = Button::collection([Button::csv(), 'colvis'])->text('Export');
+
+        $this->assertSame([
+            'extend'  => 'collection',
+            'buttons' => [
+                [
+                    'extend'        => 'csv',
+                    'exportOptions' => ['columns' => ':visible:not(.not-exportable)'],
+                ],
+                'colvis',
+            ],
+            'text' => 'Export',
+        ], json_decode(json_encode($button), true));
     }
 }

--- a/tests/Unit/Model/Extensions/ButtonsExtensionTest.php
+++ b/tests/Unit/Model/Extensions/ButtonsExtensionTest.php
@@ -81,4 +81,17 @@ final class ButtonsExtensionTest extends DataTableTestCase
 
         $this->assertExtensionPayload(['ccSearchClear'], $extension);
     }
+
+    #[Test]
+    public function it_adds_a_collection_button_via_the_fluent_helper(): void
+    {
+        $extension = (new ButtonsExtension([]))->withCollectionButton(['colvis', 'csv']);
+
+        $this->assertExtensionPayload([
+            [
+                'extend'  => 'collection',
+                'buttons' => ['colvis', 'csv'],
+            ],
+        ], $extension);
+    }
 }


### PR DESCRIPTION
- Adds ButtonType::COLLECTION and Button::collection(array $buttons), requiring only the button list.
- Splits Button::jsonSerialize()'s previous single NON_EXPORT_TYPES check into two: NON_EXPORT_TYPES (no default exportOptions — colvis, ccSearchClear, and now collection) and BARE_STRING_TYPES (bare-string shorthand — colvis/ccSearchClear only; a collection can never be bare since its buttons array is the entire point of the button).
buttons accepts Button objects, raw arrays, or bare extend-name strings, mixed freely, at any nesting depth — no new serialization code needed, since Button already implements JsonSerializable.
- ButtonsExtension::withCollectionButton(array $buttons) fluent-collection shortcut.
- Docs: new "Grouping Buttons In A Dropdown" section in extensions/buttons.mdx, ButtonType::COLLECTION added to the enums reference and the bundled skill file.
Closes #329