### PR TITLE
fix: give ComparisonSearchStrategy date-type awareness

### DIFF
--- a/src/Query/DateSearchTerm.php
+++ b/src/Query/DateSearchTerm.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Query;
+
+/**
+ * Normalizes a search term before it is bound to a native date/time column.
+ *
+ * Doctrine's date/time types convert a DateTimeInterface value to the column's stored
+ * representation; a raw string makes that conversion throw instead of simply not matching.
+ * Callers skip the condition when normalization returns null, so an unparseable value
+ * yields a graceful no-match rather than a 500.
+ */
+final class DateSearchTerm
+{
+    public static function normalize(string $value): ?\DateTimeImmutable
+    {
+        $value = trim($value);
+
+        if ('' === $value) {
+            return null;
+        }
+
+        try {
+            return new \DateTimeImmutable($value);
+        } catch (\Exception) {
+            return null;
+        }
+    }
+}

--- a/src/Query/RelationFieldResolver.php
+++ b/src/Query/RelationFieldResolver.php
@@ -30,6 +30,21 @@ final class RelationFieldResolver
     ];
 
     /**
+     * Doctrine date/time types. Comparison values must be converted to a DateTimeInterface
+     * before binding: setParameter() throws when a date-typed parameter is given a raw string.
+     *
+     * @var list<string>
+     */
+    private const array DATE_FIELD_TYPES = [
+        'date',
+        'date_immutable',
+        'datetime',
+        'datetime_immutable',
+        'datetimetz',
+        'datetimetz_immutable',
+    ];
+
+    /**
      * Doctrine field types that cannot be used with SQL LIKE without an explicit cast.
      *
      * @var list<string>
@@ -39,12 +54,6 @@ final class RelationFieldResolver
         'binary',
         'blob',
         'boolean',
-        'date',
-        'date_immutable',
-        'datetime',
-        'datetime_immutable',
-        'datetimetz',
-        'datetimetz_immutable',
         'decimal',
         'float',
         'integer',
@@ -52,6 +61,7 @@ final class RelationFieldResolver
         'smallint',
         'time',
         'time_immutable',
+        ...self::DATE_FIELD_TYPES,
         ...self::UUID_FIELD_TYPES,
     ];
 
@@ -143,6 +153,27 @@ final class RelationFieldResolver
         $fieldType = self::resolveFieldType($qb, $fieldPath);
 
         if (null === $fieldType || !\in_array($fieldType, self::UUID_FIELD_TYPES, true)) {
+            return null;
+        }
+
+        return $fieldType;
+    }
+
+    /**
+     * Returns the Doctrine type of a date/time field path, or null when the field is not one.
+     *
+     * Callers need the type name itself, not only the answer, because setParameter() must
+     * bind with it: a DateTimeInterface value converts to the wrong column type otherwise.
+     */
+    public static function resolveDateFieldType(QueryBuilder $qb, string $fieldPath): ?string
+    {
+        if (!self::supportsSearchFiltering($qb, $fieldPath)) {
+            return null;
+        }
+
+        $fieldType = self::resolveFieldType($qb, $fieldPath);
+
+        if (null === $fieldType || !\in_array($fieldType, self::DATE_FIELD_TYPES, true)) {
             return null;
         }
 

--- a/src/Query/Strategy/ComparisonSearchStrategy.php
+++ b/src/Query/Strategy/ComparisonSearchStrategy.php
@@ -9,6 +9,7 @@ use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
 use Pentiminax\UX\DataTables\Contracts\SearchStrategyInterface;
 use Pentiminax\UX\DataTables\DataTableRequest\ColumnControlSearch;
 use Pentiminax\UX\DataTables\Enum\ColumnControlLogic;
+use Pentiminax\UX\DataTables\Query\DateSearchTerm;
 use Pentiminax\UX\DataTables\Query\RelationFieldResolver;
 use Pentiminax\UX\DataTables\Query\UuidSearchTerm;
 
@@ -43,26 +44,48 @@ final class ComparisonSearchStrategy implements SearchStrategyInterface
             return;
         }
 
-        $uuidType = RelationFieldResolver::resolveUuidFieldType($qb, $fieldPath);
-        $value    = $search->value;
+        [$bindValue, $bindType] = $this->resolveBindValue($qb, $fieldPath, $search->value);
 
-        if (null !== $uuidType) {
-            $value = UuidSearchTerm::normalize($value, $uuidType);
-
-            if (null === $value) {
-                return;
-            }
+        if (null === $bindValue) {
+            return;
         }
 
         $field     = RelationFieldResolver::resolve($qb, $alias, $fieldPath);
         $paramName = \sprintf('column_control_param_%d', $paramIndex);
 
         $qb->andWhere(\sprintf('%s %s :%s', $field, $this->logic->operator(), $paramName));
-        $qb->setParameter($paramName, \sprintf($this->logic->paramFormat(), $value), $uuidType);
+        $qb->setParameter(
+            $paramName,
+            $bindValue instanceof \DateTimeImmutable ? $bindValue : \sprintf($this->logic->paramFormat(), $bindValue),
+            $bindType,
+        );
     }
 
     public function getLogic(): string
     {
         return $this->logic->value;
+    }
+
+    /**
+     * Resolves the value to bind and its Doctrine type hint, or [null, null] when the raw
+     * search term cannot be bound to the field's actual column type. LIKE-incompatible types
+     * (uuid, date, etc.) are already filtered above; this only normalizes the value for the
+     * types that still need a specific Doctrine type on setParameter().
+     *
+     * @return array{0: string|\DateTimeImmutable|null, 1: ?string}
+     */
+    private function resolveBindValue(QueryBuilder $qb, string $fieldPath, string $rawValue): array
+    {
+        $uuidType = RelationFieldResolver::resolveUuidFieldType($qb, $fieldPath);
+        if (null !== $uuidType) {
+            return [UuidSearchTerm::normalize($rawValue, $uuidType), $uuidType];
+        }
+
+        $dateType = RelationFieldResolver::resolveDateFieldType($qb, $fieldPath);
+        if (null !== $dateType) {
+            return [DateSearchTerm::normalize($rawValue), $dateType];
+        }
+
+        return [$rawValue, null];
     }
 }

--- a/tests/Unit/Query/DateSearchTermTest.php
+++ b/tests/Unit/Query/DateSearchTermTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Unit\Query;
+
+use Pentiminax\UX\DataTables\Query\DateSearchTerm;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+#[CoversClass(DateSearchTerm::class)]
+final class DateSearchTermTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('parsable_terms')]
+    public function it_parses_a_well_formed_date_string(string $value, string $expectedFormat): void
+    {
+        $result = DateSearchTerm::normalize($value);
+
+        $this->assertInstanceOf(\DateTimeImmutable::class, $result);
+        $this->assertSame($expectedFormat, $result->format('Y-m-d'));
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function parsable_terms(): iterable
+    {
+        yield 'iso date' => ['2026-08-19', '2026-08-19'];
+        yield 'iso datetime' => ['2026-08-19 14:30:00', '2026-08-19'];
+        yield 'padded date' => ['  2026-08-19  ', '2026-08-19'];
+        yield 'slash date' => ['2026/08/19', '2026-08-19'];
+    }
+
+    #[Test]
+    #[DataProvider('unparsable_terms')]
+    public function it_rejects_a_value_that_does_not_parse_as_a_date(string $value): void
+    {
+        $this->assertNull(DateSearchTerm::normalize($value));
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function unparsable_terms(): iterable
+    {
+        yield 'empty string' => [''];
+        yield 'blank string' => ['   '];
+        yield 'garbage text' => ['not-a-date'];
+        yield 'malformed punctuation' => ['2026--08~~19'];
+    }
+}

--- a/tests/Unit/Query/RelationFieldResolverTest.php
+++ b/tests/Unit/Query/RelationFieldResolverTest.php
@@ -57,26 +57,31 @@ final class RelationFieldResolverTest extends TestCase
     }
 
     /**
-     * Each case gives the Doctrine type of the field, whether it supports SQL LIKE and the
-     * UUID type it must be bound with. A null type stands for unavailable root metadata.
+     * Each case gives the Doctrine type of the field, whether it supports SQL LIKE, the
+     * UUID type it must be bound with, and the date type it must be bound with. A null type
+     * stands for unavailable root metadata.
      *
-     * @return iterable<string, array{?string, bool, ?string}>
+     * @return iterable<string, array{?string, bool, ?string, ?string}>
      */
     public static function fieldTypes(): iterable
     {
-        yield 'unavailable root entity metadata' => [null, true, null];
+        yield 'unavailable root entity metadata' => [null, true, null, null];
 
-        yield 'string' => ['string', true, null];
+        yield 'string' => ['string', true, null, null];
 
-        yield 'boolean' => ['boolean', false, null];
+        yield 'boolean' => ['boolean', false, null, null];
 
-        yield 'guid' => ['guid', false, 'guid'];
+        yield 'guid' => ['guid', false, 'guid', null];
 
-        yield 'uuid' => ['uuid', false, 'uuid'];
+        yield 'uuid' => ['uuid', false, 'uuid', null];
 
-        yield 'ulid' => ['ulid', false, 'ulid'];
+        yield 'ulid' => ['ulid', false, 'ulid', null];
 
-        yield 'binary uuid' => ['uuid_binary_ordered_time', false, 'uuid_binary_ordered_time'];
+        yield 'binary uuid' => ['uuid_binary_ordered_time', false, 'uuid_binary_ordered_time', null];
+
+        yield 'date' => ['date', false, null, 'date'];
+
+        yield 'datetime_immutable' => ['datetime_immutable', false, null, 'datetime_immutable'];
     }
 
     /**
@@ -119,12 +124,14 @@ final class RelationFieldResolverTest extends TestCase
         ?string $fieldType,
         bool $supportsTextSearch,
         ?string $expectedUuidType,
+        ?string $expectedDateType,
     ): void {
         $qb = $this->queryBuilderWithFieldType('id', $fieldType);
 
         $this->assertTrue(RelationFieldResolver::supportsSearchFiltering($qb, 'id'));
         $this->assertSame($supportsTextSearch, RelationFieldResolver::supportsTextSearch($qb, 'id'));
         $this->assertSame($expectedUuidType, RelationFieldResolver::resolveUuidFieldType($qb, 'id'));
+        $this->assertSame($expectedDateType, RelationFieldResolver::resolveDateFieldType($qb, 'id'));
     }
 
     #[Test]
@@ -135,6 +142,7 @@ final class RelationFieldResolverTest extends TestCase
         $this->assertFalse(RelationFieldResolver::supportsSearchFiltering($qb, 'client'));
         $this->assertFalse(RelationFieldResolver::supportsTextSearch($qb, 'client'));
         $this->assertNull(RelationFieldResolver::resolveUuidFieldType($qb, 'client'));
+        $this->assertNull(RelationFieldResolver::resolveDateFieldType($qb, 'client'));
     }
 
     #[Test]

--- a/tests/Unit/Query/Strategy/ComparisonSearchStrategyTest.php
+++ b/tests/Unit/Query/Strategy/ComparisonSearchStrategyTest.php
@@ -123,6 +123,57 @@ final class ComparisonSearchStrategyTest extends TestCase
     }
 
     #[Test]
+    #[DataProvider('date_skip_cases')]
+    public function it_skips_an_unbindable_predicate_on_a_date_column(ColumnControlLogic $logic, string $value): void
+    {
+        $qb = $this->queryBuilderWithFieldType('birthDate', 'date');
+        $qb->expects($this->never())->method('andWhere');
+        $qb->expects($this->never())->method('setParameter');
+
+        $strategy = new ComparisonSearchStrategy($logic);
+        $column   = TextColumn::new('birthDate')->setField('birthDate');
+        $search   = new ColumnControlSearch($value, $logic, 'text');
+
+        $strategy->apply($qb, $column, $search, 3, 'e');
+    }
+
+    #[Test]
+    public function it_applies_equality_on_a_date_column_with_the_doctrine_type_and_a_parsed_value(): void
+    {
+        $qb = $this->queryBuilderWithFieldType('birthDate', 'date');
+
+        $qb->expects($this->once())
+            ->method('andWhere')
+            ->with('e.birthDate = :column_control_param_3');
+
+        $qb->expects($this->once())
+            ->method('setParameter')
+            ->with(
+                'column_control_param_3',
+                $this->callback(static fn (\DateTimeImmutable $value): bool => '2026-08-19' === $value->format('Y-m-d')),
+                'date',
+            );
+
+        $strategy = new ComparisonSearchStrategy(ColumnControlLogic::Equal);
+        $column   = TextColumn::new('birthDate')->setField('birthDate');
+        $search   = new ColumnControlSearch('2026-08-19', ColumnControlLogic::Equal, 'text');
+
+        $strategy->apply($qb, $column, $search, 3, 'e');
+    }
+
+    /**
+     * @return iterable<string, array{ColumnControlLogic, string}>
+     */
+    public static function date_skip_cases(): iterable
+    {
+        yield 'starts (LIKE on a date column)' => [ColumnControlLogic::Starts, '2026'];
+        yield 'ends (LIKE on a date column)' => [ColumnControlLogic::Ends, '2026'];
+        yield 'notContains (LIKE on a date column)' => [ColumnControlLogic::NotContains, '2026'];
+        yield 'equal (unparsable value)' => [ColumnControlLogic::Equal, 'not-a-date'];
+        yield 'greater (unparsable value)' => [ColumnControlLogic::Greater, 'not-a-date'];
+    }
+
+    #[Test]
     public function it_returns_logic_value(): void
     {
         $strategy = new ComparisonSearchStrategy(ColumnControlLogic::Ends);


### PR DESCRIPTION
- Adds RelationFieldResolver::resolveDateFieldType(), mirroring the existing resolveUuidFieldType(), covering date/date_immutable/datetime/datetime_immutable/ datetimetz/datetimetz_immutable.
- Adds DateSearchTerm::normalize(), mirroring UuidSearchTerm: parses the raw search string into a \DateTimeImmutable, returns null on anything unparseable so the strategy skips the condition instead of reaching setParameter() with a raw untyped string.
- ComparisonSearchStrategy::apply() now resolves an explicit [value, type] pair via a new resolveBindValue() helper instead of overloading a single $uuidType variable as both "is-UUID flag" and "the setParameter() type hint for everything" — the shape that let the date gap go unnoticed after #298. A well-formed date now binds as a real DateTimeImmutable with the column's Doctrine type, so Equal/Greater/Less etc. keep working on date columns instead of merely not crashing.
- UuidSearchTerm, resolveUuidFieldType(), and SearchPredicateFactory are untouched — this is scoped to the reported bug. ColumnControlSearchFilter's scalar path picks up the fix for free since it delegates to ComparisonSearchStrategy.
Closes #331

Not tested: a live PostgreSQL crash reproduction — this repo's suite runs against SQLite, which has no real column typing and can't reproduce SQLSTATE 22P02. Coverage instead asserts the strategy's decision logic directly (typed bind for a parsed date, no query touch at all for an unparseable one or a LIKE logic on a date column).

It might be good at some point to set up test scaffolding for optional strongly typed db (like postgres) to test this (and possibly the uuid bug as well) but that's outside the scope of this fix