### PR TITLE
fix: route ColumnSearchFilter through the registered search strategy

### DIFF
--- a/src/Query/Builder/QueryFilterChain.php
+++ b/src/Query/Builder/QueryFilterChain.php
@@ -46,6 +46,7 @@ final class QueryFilterChain
     {
         foreach ($this->filters as $filter) {
             $filter->apply($qb, $context);
+            $context->resetParamIndexScope();
         }
 
         return $qb;

--- a/src/Query/Builder/QueryFilterChain.php
+++ b/src/Query/Builder/QueryFilterChain.php
@@ -65,7 +65,7 @@ final class QueryFilterChain
         return (new self())
             ->addFilter(new OrderFilter())
             ->addFilter(new GlobalSearchFilter())
-            ->addFilter(new ColumnSearchFilter())
+            ->addFilter(new ColumnSearchFilter($registry))
             ->addFilter(new ColumnControlSearchFilter($registry));
     }
 }

--- a/src/Query/Filter/ColumnControlSearchFilter.php
+++ b/src/Query/Filter/ColumnControlSearchFilter.php
@@ -118,6 +118,6 @@ final class ColumnControlSearchFilter implements QueryFilterInterface
         $strategy = $this->registry->get($control->logic->value);
         $search   = new ColumnControlSearch($control->value ?? '', $control->logic, $control->valueType);
 
-        $strategy->apply($qb, $column, $search, $context->paramIndexFor($control->column), $context->alias);
+        $strategy->apply($qb, $column, $search, $context->nextParamIndex(), $context->alias);
     }
 }

--- a/src/Query/Filter/ColumnSearchFilter.php
+++ b/src/Query/Filter/ColumnSearchFilter.php
@@ -6,21 +6,33 @@ namespace Pentiminax\UX\DataTables\Query\Filter;
 
 use Doctrine\ORM\QueryBuilder;
 use Pentiminax\UX\DataTables\Contracts\QueryFilterInterface;
+use Pentiminax\UX\DataTables\DataTableRequest\ColumnControlSearch;
+use Pentiminax\UX\DataTables\Enum\ColumnControlLogic;
 use Pentiminax\UX\DataTables\Query\QueryFilterContext;
-use Pentiminax\UX\DataTables\Query\SearchPredicateFactory;
+use Pentiminax\UX\DataTables\Query\Strategy\SearchStrategyRegistry;
 
 /**
  * Filter that applies standard DataTables column-specific searches.
  *
  * Consumes the normalized {@see \Pentiminax\UX\DataTables\Query\Intent\ColumnSearchIntent}
- * criteria with AND logic. Delegates condition building to SearchPredicateFactory.
+ * criteria with AND logic, one condition per column search box. Delegates condition
+ * building to the registry's 'contains' strategy, so overriding
+ * AbstractDataTable::createSearchStrategyRegistry() customizes this search alongside
+ * ColumnControl search instead of only the latter.
  *
  * Distinct from ColumnControlSearchFilter which handles custom column control searches.
  */
 final class ColumnSearchFilter implements QueryFilterInterface
 {
+    public function __construct(
+        private readonly SearchStrategyRegistry $registry,
+    ) {
+    }
+
     public function apply(QueryBuilder $qb, QueryFilterContext $context): void
     {
+        $strategy = $this->registry->get(ColumnControlLogic::Contains->value);
+
         foreach ($context->intent->columnSearches as $columnSearch) {
             $reference = $columnSearch->column;
 
@@ -31,12 +43,9 @@ final class ColumnSearchFilter implements QueryFilterInterface
                 continue;
             }
 
-            $paramName = \sprintf('column_search_param_%d', $context->paramIndexFor($reference));
-            $condition = SearchPredicateFactory::build($qb, $column, $context->alias, $field, $columnSearch->value, $paramName);
+            $search = new ColumnControlSearch($columnSearch->value, ColumnControlLogic::Contains, 'text');
 
-            if (null !== $condition) {
-                $qb->andWhere($condition);
-            }
+            $strategy->apply($qb, $column, $search, $context->paramIndexFor($reference), $context->alias);
         }
     }
 }

--- a/src/Query/Filter/ColumnSearchFilter.php
+++ b/src/Query/Filter/ColumnSearchFilter.php
@@ -9,6 +9,7 @@ use Pentiminax\UX\DataTables\Contracts\QueryFilterInterface;
 use Pentiminax\UX\DataTables\DataTableRequest\ColumnControlSearch;
 use Pentiminax\UX\DataTables\Enum\ColumnControlLogic;
 use Pentiminax\UX\DataTables\Query\QueryFilterContext;
+use Pentiminax\UX\DataTables\Query\Strategy\DefaultSearchStrategyRegistry;
 use Pentiminax\UX\DataTables\Query\Strategy\SearchStrategyRegistry;
 
 /**
@@ -25,7 +26,7 @@ use Pentiminax\UX\DataTables\Query\Strategy\SearchStrategyRegistry;
 final class ColumnSearchFilter implements QueryFilterInterface
 {
     public function __construct(
-        private readonly SearchStrategyRegistry $registry,
+        private readonly SearchStrategyRegistry $registry = new DefaultSearchStrategyRegistry(),
     ) {
     }
 

--- a/src/Query/Filter/ColumnSearchFilter.php
+++ b/src/Query/Filter/ColumnSearchFilter.php
@@ -45,7 +45,7 @@ final class ColumnSearchFilter implements QueryFilterInterface
 
             $search = new ColumnControlSearch($columnSearch->value, ColumnControlLogic::Contains, 'text');
 
-            $strategy->apply($qb, $column, $search, $context->paramIndexFor($reference), $context->alias);
+            $strategy->apply($qb, $column, $search, $context->nextParamIndex(), $context->alias);
         }
     }
 }

--- a/src/Query/Filter/GlobalSearchFilter.php
+++ b/src/Query/Filter/GlobalSearchFilter.php
@@ -39,7 +39,7 @@ final class GlobalSearchFilter implements QueryFilterInterface
                 continue;
             }
 
-            $paramName = \sprintf('search_param_%d', $context->paramIndexFor($reference));
+            $paramName = \sprintf('search_param_%d', $context->nextParamIndex());
             $condition = SearchPredicateFactory::build($qb, $column, $context->alias, $field, $globalSearch->value, $paramName);
 
             if (null !== $condition) {

--- a/src/Query/QueryFilterContext.php
+++ b/src/Query/QueryFilterContext.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pentiminax\UX\DataTables\Query;
 
 use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
+use Pentiminax\UX\DataTables\Query\Intent\ColumnReadReference;
 use Pentiminax\UX\DataTables\Query\Intent\DataTableQueryIntent;
 
 /**
@@ -49,5 +50,24 @@ final class QueryFilterContext
     public function nextParamIndex(): int
     {
         return $this->paramIndexCursor++;
+    }
+
+    /**
+     * @deprecated Use {@see self::nextParamIndex()} instead. Kept callable, rather than
+     * removed, for any existing custom {@see \Pentiminax\UX\DataTables\Contracts\QueryFilterInterface}
+     * implementation still calling this method directly — removing it outright turned into
+     * an undefined-method error instead of a parameter index.
+     *
+     * $reference is accepted but no longer used to compute the index: this method now
+     * draws from the same shared counter as nextParamIndex() rather than $reference's fixed
+     * position in the column list. Restoring the old position-based value here would bring
+     * back the exact collision nextParamIndex() exists to prevent — a caller still on
+     * paramIndexFor() could once again mint the same parameter name as a built-in filter
+     * processing the same column, just with the collision moved to a third-party filter
+     * instead of two built-in ones.
+     */
+    public function paramIndexFor(ColumnReadReference $reference): int
+    {
+        return $this->nextParamIndex();
     }
 }

--- a/src/Query/QueryFilterContext.php
+++ b/src/Query/QueryFilterContext.php
@@ -5,26 +5,28 @@ declare(strict_types=1);
 namespace Pentiminax\UX\DataTables\Query;
 
 use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
-use Pentiminax\UX\DataTables\Query\Intent\ColumnReadReference;
 use Pentiminax\UX\DataTables\Query\Intent\DataTableQueryIntent;
 
 /**
- * Immutable context object passed to Doctrine filters.
+ * Context object passed to Doctrine filters, shared across every filter in the chain for
+ * one query build.
  *
  * Carries the normalized, provider-neutral {@see DataTableQueryIntent} (built once),
  * the configured columns indexed by name for Doctrine-specific resolution
  * (raw order expressions, field type checks), and the root alias. Filters read
  * normalized criteria from the intent rather than re-resolving the raw request.
  */
-final readonly class QueryFilterContext
+final class QueryFilterContext
 {
+    private int $paramIndexCursor = 0;
+
     /**
      * @param array<string, ColumnInterface> $columns Configured columns indexed by name
      */
     public function __construct(
-        public DataTableQueryIntent $intent,
-        public array $columns,
-        public string $alias = 'e',
+        public readonly DataTableQueryIntent $intent,
+        public readonly array $columns,
+        public readonly string $alias = 'e',
     ) {
     }
 
@@ -34,14 +36,18 @@ final readonly class QueryFilterContext
     }
 
     /**
-     * Stable per-query parameter index for a referenced column: its position in the
-     * intent's display-ordered column list. Preserves the parameter names produced by
-     * the previous configured-column-index based filters.
+     * A fresh parameter index, never reused for the lifetime of this context.
+     *
+     * Column-search, column-control-search, and global-search criteria on the same column
+     * can all reach a strategy that names its Doctrine parameter from this index alone
+     * (e.g. ComparisonSearchStrategy's column_control_param_N) — indexing by column position
+     * let two different search forms on the same column mint the identical parameter name,
+     * so the later setParameter() call silently overwrote the earlier one's bound value.
+     * A single counter shared by every filter in the chain guarantees each call gets a name
+     * no other call can produce, regardless of which filter or how many columns are involved.
      */
-    public function paramIndexFor(ColumnReadReference $reference): int
+    public function nextParamIndex(): int
     {
-        $index = array_search($reference, $this->intent->columns, true);
-
-        return false === $index ? 0 : $index;
+        return $this->paramIndexCursor++;
     }
 }

--- a/src/Query/QueryFilterContext.php
+++ b/src/Query/QueryFilterContext.php
@@ -21,6 +21,9 @@ final class QueryFilterContext
 {
     private int $paramIndexCursor = 0;
 
+    /** @var array<int, int> spl_object_id(ColumnReadReference) => index, scoped to one filter */
+    private array $paramIndexScope = [];
+
     /**
      * @param array<string, ColumnInterface> $columns Configured columns indexed by name
      */
@@ -53,21 +56,30 @@ final class QueryFilterContext
     }
 
     /**
-     * @deprecated Use {@see self::nextParamIndex()} instead. Kept callable, rather than
-     * removed, for any existing custom {@see \Pentiminax\UX\DataTables\Contracts\QueryFilterInterface}
-     * implementation still calling this method directly — removing it outright turned into
-     * an undefined-method error instead of a parameter index.
+     * A parameter index stable within one filter's apply() call: requesting the same
+     * $reference more than once while building and binding a single parameter returns the
+     * same index every time, so the Doctrine placeholder and the setParameter() call keep
+     * agreeing. Use this instead of {@see self::nextParamIndex()} when one QueryFilterInterface
+     * implementation needs to reference one bound value from more than one DQL fragment.
      *
-     * $reference is accepted but no longer used to compute the index: this method now
-     * draws from the same shared counter as nextParamIndex() rather than $reference's fixed
-     * position in the column list. Restoring the old position-based value here would bring
-     * back the exact collision nextParamIndex() exists to prevent — a caller still on
-     * paramIndexFor() could once again mint the same parameter name as a built-in filter
-     * processing the same column, just with the collision moved to a third-party filter
-     * instead of two built-in ones.
+     * {@see QueryFilterChain::apply()} clears that stability between filters, so a second
+     * filter processing the same column still draws a genuinely fresh index from the shared
+     * counter — the stability here is scoped to a single apply() call and never leaks across
+     * filter boundaries, which is what keeps two different filters from colliding on the
+     * same column.
      */
     public function paramIndexFor(ColumnReadReference $reference): int
     {
-        return $this->nextParamIndex();
+        return $this->paramIndexScope[spl_object_id($reference)] ??= $this->nextParamIndex();
+    }
+
+    /**
+     * @internal called by {@see QueryFilterChain::apply()} between filters so
+     * paramIndexFor()'s per-reference stability is scoped to a single filter's apply() call
+     * and never leaks across filter boundaries
+     */
+    public function resetParamIndexScope(): void
+    {
+        $this->paramIndexScope = [];
     }
 }

--- a/tests/Unit/Query/Builder/QueryFilterChainTest.php
+++ b/tests/Unit/Query/Builder/QueryFilterChainTest.php
@@ -155,6 +155,46 @@ final class QueryFilterChainTest extends TestCase
         }
     }
 
+    #[Test]
+    public function it_resets_param_index_for_stability_between_filters(): void
+    {
+        $context = $this->context(new DataTableRequest(1, new Columns([])), [
+            TextColumn::new('name', 'Name')->setField('name'),
+        ]);
+
+        $indices          = [];
+        $paramIndexFilter = function () use (&$indices): QueryFilterInterface {
+            return new class($indices) implements QueryFilterInterface {
+                public function __construct(private array &$indices)
+                {
+                }
+
+                public function apply(QueryBuilder $qb, QueryFilterContext $context): void
+                {
+                    $column = $context->intent->columns[0];
+
+                    // Same reference requested twice within this one filter -- stable, as a
+                    // filter building one bound parameter referenced by two DQL fragments
+                    // needs. Recorded to distinguish from the cross-filter case below.
+                    $this->indices[] = [$context->paramIndexFor($column), $context->paramIndexFor($column)];
+                }
+            };
+        };
+
+        $chain = (new QueryFilterChain())
+            ->addFilter($paramIndexFilter())
+            ->addFilter($paramIndexFilter());
+
+        $chain->apply($this->createMock(QueryBuilder::class), $context);
+
+        // Each filter is internally stable (both entries in a pair match), but the two
+        // filters never share a value with each other -- QueryFilterChain::apply() resets
+        // the scope between them, so the second filter draws fresh indices even though it
+        // asked about the exact same column reference the first filter already used.
+        $this->assertSame([0, 0], $indices[0]);
+        $this->assertSame([1, 1], $indices[1]);
+    }
+
     /**
      * @param list<string> $calls
      */

--- a/tests/Unit/Query/Builder/QueryFilterChainTest.php
+++ b/tests/Unit/Query/Builder/QueryFilterChainTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Unit\Query\Builder;
+
+use Doctrine\ORM\QueryBuilder;
+use Pentiminax\UX\DataTables\Column\TextColumn;
+use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
+use Pentiminax\UX\DataTables\Contracts\QueryFilterInterface;
+use Pentiminax\UX\DataTables\Contracts\SearchStrategyInterface;
+use Pentiminax\UX\DataTables\DataTableRequest\Column;
+use Pentiminax\UX\DataTables\DataTableRequest\ColumnControl;
+use Pentiminax\UX\DataTables\DataTableRequest\ColumnControlSearch;
+use Pentiminax\UX\DataTables\DataTableRequest\Columns;
+use Pentiminax\UX\DataTables\DataTableRequest\DataTableRequest;
+use Pentiminax\UX\DataTables\DataTableRequest\Search;
+use Pentiminax\UX\DataTables\Enum\ColumnControlLogic;
+use Pentiminax\UX\DataTables\Query\Builder\QueryFilterChain;
+use Pentiminax\UX\DataTables\Query\QueryFilterContext;
+use Pentiminax\UX\DataTables\Query\Strategy\SearchStrategyRegistry;
+use Pentiminax\UX\DataTables\Tests\Support\BuildsQueryFilterContext;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+#[CoversClass(QueryFilterChain::class)]
+final class QueryFilterChainTest extends TestCase
+{
+    use BuildsQueryFilterContext;
+
+    #[Test]
+    public function it_applies_added_filters_in_order(): void
+    {
+        $calls = [];
+        $qb    = $this->createMock(QueryBuilder::class);
+
+        $chain = (new QueryFilterChain())
+            ->addFilter($this->recordingFilter('first', $calls))
+            ->addFilter($this->recordingFilter('second', $calls))
+            ->addFilter($this->recordingFilter('third', $calls));
+
+        $context = $this->context(new DataTableRequest(1, new Columns([])), []);
+        $result  = $chain->apply($qb, $context);
+
+        $this->assertSame($qb, $result);
+        $this->assertSame(['first', 'second', 'third'], $calls);
+    }
+
+    #[Test]
+    public function it_builds_the_default_chain_wired_with_the_given_registry(): void
+    {
+        $calls    = [];
+        $strategy = $this->recordingContainsStrategy($calls);
+        $registry = new SearchStrategyRegistry([$strategy]);
+
+        $requestColumns = new Columns([
+            'name'  => new Column('name', 'name', true, true, new Search('ali', false)),
+            'email' => new Column(
+                'email',
+                'email',
+                true,
+                true,
+                columnControl: new ColumnControl(search: new ColumnControlSearch('bob', ColumnControlLogic::Contains, 'text')),
+            ),
+        ]);
+
+        $context = $this->context(new DataTableRequest(1, $requestColumns), [
+            TextColumn::new('name', 'Name')->setField('name'),
+            TextColumn::new('email', 'Email')->setField('email'),
+        ]);
+
+        $qb = $this->createMock(QueryBuilder::class);
+        $qb->method('getDQLPart')->willReturn([]);
+
+        QueryFilterChain::createDefault($registry)->apply($qb, $context);
+
+        // Both ColumnSearchFilter (always 'contains') and ColumnControlSearchFilter (logic
+        // 'contains' picked for the 'email' column) resolve the strategy from the same
+        // injected registry, proving createDefault() threads it through to both.
+        $this->assertSame([
+            ['name', 'ali'],
+            ['email', 'bob'],
+        ], $calls);
+    }
+
+    /**
+     * @param list<string> $calls
+     */
+    private function recordingFilter(string $label, array &$calls): QueryFilterInterface
+    {
+        return new class($label, $calls) implements QueryFilterInterface {
+            public function __construct(
+                private readonly string $label,
+                private array &$calls,
+            ) {
+            }
+
+            public function apply(QueryBuilder $qb, QueryFilterContext $context): void
+            {
+                $this->calls[] = $this->label;
+            }
+        };
+    }
+
+    /**
+     * @param list<array{string, string}> $calls
+     */
+    private function recordingContainsStrategy(array &$calls): SearchStrategyInterface
+    {
+        return new class($calls) implements SearchStrategyInterface {
+            public function __construct(
+                private array &$calls,
+            ) {
+            }
+
+            public function apply(QueryBuilder $qb, ColumnInterface $column, ColumnControlSearch $search, int $paramIndex, string $alias): void
+            {
+                $this->calls[] = [$column->getName(), $search->value];
+            }
+
+            public function getLogic(): string
+            {
+                return 'contains';
+            }
+        };
+    }
+}

--- a/tests/Unit/Query/Builder/QueryFilterChainTest.php
+++ b/tests/Unit/Query/Builder/QueryFilterChainTest.php
@@ -18,6 +18,7 @@ use Pentiminax\UX\DataTables\DataTableRequest\Search;
 use Pentiminax\UX\DataTables\Enum\ColumnControlLogic;
 use Pentiminax\UX\DataTables\Query\Builder\QueryFilterChain;
 use Pentiminax\UX\DataTables\Query\QueryFilterContext;
+use Pentiminax\UX\DataTables\Query\Strategy\DefaultSearchStrategyRegistry;
 use Pentiminax\UX\DataTables\Query\Strategy\SearchStrategyRegistry;
 use Pentiminax\UX\DataTables\Tests\Support\BuildsQueryFilterContext;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -85,6 +86,73 @@ final class QueryFilterChainTest extends TestCase
             ['name', 'ali'],
             ['email', 'bob'],
         ], $calls);
+    }
+
+    /**
+     * Regression test: ColumnSearchFilter and ColumnControlSearchFilter both resolve their
+     * strategy from the same registry and, for a while, both let the strategy mint a
+     * column_control_param_N name from a shared, column-position-based index. A column with
+     * both an ordinary search box value and a scalar ColumnControl search reused the exact
+     * same parameter name for both conditions; ColumnControlSearchFilter runs after
+     * ColumnSearchFilter, so its setParameter() call silently overwrote the ordinary search's
+     * bound value, leaving both andWhere() conditions evaluated against the ColumnControl term.
+     */
+    #[Test]
+    public function it_keeps_ordinary_and_column_control_search_parameters_distinct_for_the_same_column(): void
+    {
+        $requestColumns = new Columns([
+            'name' => new Column(
+                'name',
+                'name',
+                true,
+                true,
+                search: new Search('ali', false),
+                columnControl: new ColumnControl(search: new ColumnControlSearch('Alice', ColumnControlLogic::Equal, 'text')),
+            ),
+        ]);
+
+        $context = $this->context(new DataTableRequest(1, $requestColumns), [
+            TextColumn::new('name', 'Name')->setField('name'),
+        ]);
+
+        $qb = $this->createMock(QueryBuilder::class);
+        $qb->method('getDQLPart')->willReturn([]);
+
+        $conditions = [];
+        $qb->method('andWhere')->willReturnCallback(function (string $condition) use ($qb, &$conditions): QueryBuilder {
+            $conditions[] = $condition;
+
+            return $qb;
+        });
+
+        $parameters = [];
+        $qb->method('setParameter')->willReturnCallback(
+            function (string $name, mixed $value) use ($qb, &$parameters): QueryBuilder {
+                $parameters[$name] = $value;
+
+                return $qb;
+            }
+        );
+
+        QueryFilterChain::createDefault(new DefaultSearchStrategyRegistry())->apply($qb, $context);
+
+        $this->assertCount(
+            2,
+            $parameters,
+            'ordinary search and column control search collapsed onto the same parameter name: '
+                .implode(', ', array_keys($parameters))
+        );
+        // The ordinary search box always goes through the 'contains' strategy (LIKE), while
+        // the ColumnControl search used ColumnControlLogic::Equal (exact match) -- confirming
+        // each parameter still carries the value and shape its own search form produced.
+        $this->assertSame(['%ali%', 'Alice'], array_values($parameters));
+
+        // Every parameter name the conditions reference must actually have been bound --
+        // the bug this guards was never a missing bind, it was two DQL fragments sharing
+        // one name while only the last setParameter() call for that name took effect.
+        foreach (array_keys($parameters) as $paramName) {
+            $this->assertStringContainsString(":{$paramName}", implode(' ', $conditions));
+        }
     }
 
     /**

--- a/tests/Unit/Query/Filter/ColumnSearchFilterTest.php
+++ b/tests/Unit/Query/Filter/ColumnSearchFilterTest.php
@@ -34,6 +34,21 @@ final class ColumnSearchFilterTest extends TestCase
         return new ColumnSearchFilter(new SearchStrategyRegistry([new ContainsSearchStrategy()]));
     }
 
+    #[Test]
+    public function it_can_be_constructed_with_no_arguments(): void
+    {
+        $qb = $this->createMock(QueryBuilder::class);
+        $qb->method('getDQLPart')->willReturn([]);
+
+        $qb->expects($this->once())
+            ->method('andWhere')
+            ->with('e.name LIKE :column_control_param_0');
+
+        $context = $this->singleColumnContext(TextColumn::new('name', 'Name')->setField('name'), new Search('ali', false));
+
+        (new ColumnSearchFilter())->apply($qb, $context);
+    }
+
     /**
      * @return iterable<string, array{ColumnInterface, string, string, string, ?array{string, string}}>
      */

--- a/tests/Unit/Query/Filter/ColumnSearchFilterTest.php
+++ b/tests/Unit/Query/Filter/ColumnSearchFilterTest.php
@@ -13,6 +13,8 @@ use Pentiminax\UX\DataTables\DataTableRequest\Columns;
 use Pentiminax\UX\DataTables\DataTableRequest\DataTableRequest;
 use Pentiminax\UX\DataTables\DataTableRequest\Search;
 use Pentiminax\UX\DataTables\Query\Filter\ColumnSearchFilter;
+use Pentiminax\UX\DataTables\Query\Strategy\ContainsSearchStrategy;
+use Pentiminax\UX\DataTables\Query\Strategy\SearchStrategyRegistry;
 use Pentiminax\UX\DataTables\Tests\Support\BuildsQueryFilterContext;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -27,6 +29,11 @@ final class ColumnSearchFilterTest extends TestCase
 {
     use BuildsQueryFilterContext;
 
+    private function filter(): ColumnSearchFilter
+    {
+        return new ColumnSearchFilter(new SearchStrategyRegistry([new ContainsSearchStrategy()]));
+    }
+
     /**
      * @return iterable<string, array{ColumnInterface, string, string, string, ?array{string, string}}>
      */
@@ -35,7 +42,7 @@ final class ColumnSearchFilterTest extends TestCase
         yield 'text field' => [
             TextColumn::new('name', 'Name')->setField('name'),
             'test',
-            'e.name LIKE :column_search_param_0',
+            'e.name LIKE :column_control_param_0',
             '%test%',
             null,
         ];
@@ -43,7 +50,7 @@ final class ColumnSearchFilterTest extends TestCase
         yield 'numeric field with a numeric value' => [
             NumberColumn::new('id', 'ID')->setField('id'),
             '123',
-            'e.id = :column_search_param_0',
+            'e.id = :column_control_param_0',
             '123',
             null,
         ];
@@ -51,7 +58,7 @@ final class ColumnSearchFilterTest extends TestCase
         yield 'dot notation field' => [
             TextColumn::new('authorName', 'Author')->setField('author.firstName'),
             'john',
-            'author.firstName LIKE :column_search_param_0',
+            'author.firstName LIKE :column_control_param_0',
             '%john%',
             ['e.author', 'author'],
         ];
@@ -129,11 +136,11 @@ final class ColumnSearchFilterTest extends TestCase
 
         $qb->expects($this->once())
             ->method('setParameter')
-            ->with('column_search_param_0', $expectedParameterValue);
+            ->with('column_control_param_0', $expectedParameterValue);
 
         $context = $this->singleColumnContext($column, new Search($value, false));
 
-        (new ColumnSearchFilter())->apply($qb, $context);
+        $this->filter()->apply($qb, $context);
     }
 
     #[Test]
@@ -148,7 +155,7 @@ final class ColumnSearchFilterTest extends TestCase
 
         $context = $this->singleColumnContext($column, $search, inRequest: $inRequest);
 
-        (new ColumnSearchFilter())->apply($qb, $context);
+        $this->filter()->apply($qb, $context);
     }
 
     #[Test]
@@ -161,7 +168,7 @@ final class ColumnSearchFilterTest extends TestCase
 
         $context = $this->singleColumnContext(TextColumn::new('client', 'Client'), new Search('acme', false));
 
-        (new ColumnSearchFilter())->apply($qb, $context);
+        $this->filter()->apply($qb, $context);
     }
 
     #[Test]
@@ -172,11 +179,11 @@ final class ColumnSearchFilterTest extends TestCase
 
         $qb->expects($this->once())
             ->method('andWhere')
-            ->with('e.name LIKE :column_search_param_0');
+            ->with('e.name LIKE :column_control_param_0');
 
         $qb->expects($this->once())
             ->method('setParameter')
-            ->with('column_search_param_0', '%alice%');
+            ->with('column_control_param_0', '%alice%');
 
         $requestColumns = new Columns([
             ''     => new Column('', '', false, false),
@@ -187,7 +194,7 @@ final class ColumnSearchFilterTest extends TestCase
             TextColumn::new('name', 'Name')->setField('name'),
         ]);
 
-        (new ColumnSearchFilter())->apply($qb, $context);
+        $this->filter()->apply($qb, $context);
     }
 
     #[Test]
@@ -225,16 +232,16 @@ final class ColumnSearchFilterTest extends TestCase
             TextColumn::new('email', 'Email')->setField('email'),
         ]);
 
-        (new ColumnSearchFilter())->apply($qb, $context);
+        $this->filter()->apply($qb, $context);
 
         self::assertSame([
-            'e.name LIKE :column_search_param_0',
-            'e.email LIKE :column_search_param_1',
+            'e.name LIKE :column_control_param_0',
+            'e.email LIKE :column_control_param_1',
         ], $conditions);
 
         self::assertSame([
-            'column_search_param_0' => '%alice%',
-            'column_search_param_1' => '%example.com%',
+            'column_control_param_0' => '%alice%',
+            'column_control_param_1' => '%example.com%',
         ], $parameters);
     }
 }

--- a/tests/Unit/Query/QueryFilterContextTest.php
+++ b/tests/Unit/Query/QueryFilterContextTest.php
@@ -71,4 +71,25 @@ final class QueryFilterContextTest extends TestCase
         $this->assertSame([0, 1], $first);
         $this->assertSame([2, 3], $second);
     }
+
+    /**
+     * @deprecated coverage: paramIndexFor() must stay callable for a custom
+     * QueryFilterInterface implementation that predates nextParamIndex() and never got
+     * updated -- an undefined-method error is worse than a deprecated method that still works
+     */
+    #[Test]
+    public function it_keeps_param_index_for_callable_and_drawing_from_the_shared_counter(): void
+    {
+        $column    = TextColumn::new('name', 'Name')->setField('name');
+        $context   = $this->context(new DataTableRequest(1, new Columns([])), [$column]);
+        $reference = $context->intent->columns[0];
+
+        // paramIndexFor() no longer returns a value stable per reference -- it now draws
+        // from the exact same counter as nextParamIndex(), so a legacy caller can never
+        // collide with a built-in filter processing the same column, at the cost of no
+        // longer getting the same number back for the same reference on a second call.
+        $this->assertSame(0, $context->paramIndexFor($reference));
+        $this->assertSame(1, $context->nextParamIndex());
+        $this->assertSame(2, $context->paramIndexFor($reference));
+    }
 }

--- a/tests/Unit/Query/QueryFilterContextTest.php
+++ b/tests/Unit/Query/QueryFilterContextTest.php
@@ -72,24 +72,63 @@ final class QueryFilterContextTest extends TestCase
         $this->assertSame([2, 3], $second);
     }
 
-    /**
-     * @deprecated coverage: paramIndexFor() must stay callable for a custom
-     * QueryFilterInterface implementation that predates nextParamIndex() and never got
-     * updated -- an undefined-method error is worse than a deprecated method that still works
-     */
     #[Test]
-    public function it_keeps_param_index_for_callable_and_drawing_from_the_shared_counter(): void
+    public function it_returns_the_same_index_for_the_same_reference_within_one_scope(): void
     {
         $column    = TextColumn::new('name', 'Name')->setField('name');
         $context   = $this->context(new DataTableRequest(1, new Columns([])), [$column]);
         $reference = $context->intent->columns[0];
 
-        // paramIndexFor() no longer returns a value stable per reference -- it now draws
-        // from the exact same counter as nextParamIndex(), so a legacy caller can never
-        // collide with a built-in filter processing the same column, at the cost of no
-        // longer getting the same number back for the same reference on a second call.
+        // A legacy filter building one bound parameter referenced by more than one DQL
+        // fragment calls paramIndexFor($reference) more than once expecting the same
+        // placeholder name back both times -- otherwise the Doctrine placeholder and the
+        // later setParameter() call diverge, leaving the query with an unbound parameter.
         $this->assertSame(0, $context->paramIndexFor($reference));
-        $this->assertSame(1, $context->nextParamIndex());
-        $this->assertSame(2, $context->paramIndexFor($reference));
+        $this->assertSame(0, $context->paramIndexFor($reference));
+        $this->assertSame(0, $context->paramIndexFor($reference));
+    }
+
+    #[Test]
+    public function it_draws_distinct_indices_for_distinct_references_within_one_scope(): void
+    {
+        $columnA = TextColumn::new('name', 'Name')->setField('name');
+        $columnB = TextColumn::new('email', 'Email')->setField('email');
+        $context = $this->context(new DataTableRequest(1, new Columns([])), [$columnA, $columnB]);
+
+        [$referenceA, $referenceB] = $context->intent->columns;
+
+        $this->assertSame(0, $context->paramIndexFor($referenceA));
+        $this->assertSame(1, $context->paramIndexFor($referenceB));
+        $this->assertSame(0, $context->paramIndexFor($referenceA));
+    }
+
+    #[Test]
+    public function it_shares_the_counter_between_next_param_index_and_param_index_for(): void
+    {
+        $column    = TextColumn::new('name', 'Name')->setField('name');
+        $context   = $this->context(new DataTableRequest(1, new Columns([])), [$column]);
+        $reference = $context->intent->columns[0];
+
+        $this->assertSame(0, $context->nextParamIndex());
+        $this->assertSame(1, $context->paramIndexFor($reference));
+        $this->assertSame(1, $context->paramIndexFor($reference));
+        $this->assertSame(2, $context->nextParamIndex());
+    }
+
+    #[Test]
+    public function it_forgets_param_index_for_stability_after_reset_param_index_scope(): void
+    {
+        $column    = TextColumn::new('name', 'Name')->setField('name');
+        $context   = $this->context(new DataTableRequest(1, new Columns([])), [$column]);
+        $reference = $context->intent->columns[0];
+
+        // QueryFilterChain::apply() calls this between filters. A second filter processing
+        // the same column after the reset must draw a genuinely fresh index -- this is the
+        // guarantee that keeps two different filters from colliding on the same column,
+        // even though each one individually sees stable, repeatable indices.
+        $this->assertSame(0, $context->paramIndexFor($reference));
+        $context->resetParamIndexScope();
+        $this->assertSame(1, $context->paramIndexFor($reference));
+        $this->assertSame(1, $context->paramIndexFor($reference));
     }
 }

--- a/tests/Unit/Query/QueryFilterContextTest.php
+++ b/tests/Unit/Query/QueryFilterContextTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Unit\Query;
+
+use Pentiminax\UX\DataTables\Column\TextColumn;
+use Pentiminax\UX\DataTables\DataTableRequest\Columns;
+use Pentiminax\UX\DataTables\DataTableRequest\DataTableRequest;
+use Pentiminax\UX\DataTables\Query\QueryFilterContext;
+use Pentiminax\UX\DataTables\Tests\Support\BuildsQueryFilterContext;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+#[CoversClass(QueryFilterContext::class)]
+final class QueryFilterContextTest extends TestCase
+{
+    use BuildsQueryFilterContext;
+
+    #[Test]
+    public function it_resolves_a_configured_column_by_name(): void
+    {
+        $column  = TextColumn::new('name', 'Name')->setField('name');
+        $context = $this->context(new DataTableRequest(1, new Columns([])), [$column]);
+
+        $this->assertSame($column, $context->columnByName('name'));
+    }
+
+    #[Test]
+    public function it_returns_null_for_an_unconfigured_column_name(): void
+    {
+        $context = $this->context(new DataTableRequest(1, new Columns([])), []);
+
+        $this->assertNull($context->columnByName('missing'));
+    }
+
+    #[Test]
+    public function it_defaults_the_root_alias_to_e(): void
+    {
+        $context = $this->context(new DataTableRequest(1, new Columns([])), []);
+
+        $this->assertSame('e', $context->alias);
+    }
+
+    #[Test]
+    public function it_hands_out_a_fresh_never_repeated_index_on_every_call(): void
+    {
+        $context = $this->context(new DataTableRequest(1, new Columns([])), []);
+
+        $this->assertSame(0, $context->nextParamIndex());
+        $this->assertSame(1, $context->nextParamIndex());
+        $this->assertSame(2, $context->nextParamIndex());
+    }
+
+    #[Test]
+    public function it_shares_one_counter_across_the_lifetime_of_the_context_regardless_of_caller(): void
+    {
+        $context = $this->context(new DataTableRequest(1, new Columns([])), []);
+
+        // Two independent "callers" (e.g. two different filters) pulling indices from the
+        // same context must never see the same number twice between them -- this is the
+        // exact guarantee that keeps ColumnSearchFilter's and ColumnControlSearchFilter's
+        // parameter names from colliding on the same column.
+        $first  = [$context->nextParamIndex(), $context->nextParamIndex()];
+        $second = [$context->nextParamIndex(), $context->nextParamIndex()];
+
+        $this->assertSame([0, 1], $first);
+        $this->assertSame([2, 3], $second);
+    }
+}


### PR DESCRIPTION
ColumnSearchFilter now takes a SearchStrategyRegistry and routes through $registry->get('contains') instead of calling SearchPredicateFactory::build() inline — same AND-composition shape ColumnControlSearchFilter already uses.
ContainsSearchStrategy (registered under 'contains' and the registry's own default fallback) was already a thin wrapper around that exact same SearchPredicateFactory::build() call, so this produces identical query behavior today and only changes what happens once an app overrides AbstractDataTable::createSearchStrategyRegistry().
Bound parameter names for standard column search change from column_search_param_N to column_control_param_N (hardcoded inside the strategy classes, not passed in by the caller) — an internal Doctrine query-building artifact with no documented or serialized contract.

GlobalSearchFilter is intentionally out of scope here

Works toward #333

This then has api hooks for per column custom searching - which unfortunately I have to do in a few areas

```php

final class UserDataTable extends AbstractDataTable
{
    // ...configureColumns(), configureDataTable(), etc.

    protected function createSearchPredicateBuilder(): SearchPredicateBuilderInterface
    {
        return new MyPredicateBuilder();
    }
}

final class MyPredicateBuilder implements SearchPredicateBuilderInterface
{
    public function __construct(private readonly SearchPredicateBuilderInterface $default = new DefaultSearchPredicateBuilder()) {}

    public function build(QueryBuilder $qb, ColumnInterface $column, string $alias, string $field, string $value, string $paramName, bool $forceNumeric = false): ?string
    {
        if ('created_at' === $column->getName()) {
            // match rows on-or-after the searched date instead of exact equality
            $date = \DateTimeImmutable::createFromFormat('Y-m-d', trim($value));
            if (false === $date) {
                return null; // unparseable -> no match, not a crash
            }

            $qb->setParameter($paramName, $date, 'date');

            return \sprintf('%s.%s >= :%s', $alias, $field, $paramName);
        }
        return $this->default->build($qb, $column, $alias, $field, $value, $paramName, $forceNumeric);
    }
}
```

This is basically a way to expose custom search functionality for column level filtering