### PR TITLE
feat: make GlobalSearchFilter's predicate building pluggable

### DIFF
--- a/skills/ux-datatables/references/defining-a-datatable.md
+++ b/skills/ux-datatables/references/defining-a-datatable.md
@@ -72,7 +72,7 @@ protected function customizeQueryBuilder(QueryBuilder $qb, DataTableRequest $req
 }
 ```
 
-The root alias is `e`. The bundle's search/order filters run *after* this hook via `QueryFilterChain`. To register custom search strategies, override `createSearchStrategyRegistry()`.
+The root alias is `e`. The bundle's search/order filters run *after* this hook via `QueryFilterChain`. To register custom search strategies for ColumnControl and standard column search, override `createSearchStrategyRegistry()`; to customize how global search builds a condition per column, override `createSearchPredicateBuilder()`.
 
 ## Page projection (server-side)
 

--- a/src/Contracts/SearchPredicateBuilderInterface.php
+++ b/src/Contracts/SearchPredicateBuilderInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Contracts;
+
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * Builds a DQL search condition for a column based on its type, returning it for the caller
+ * to compose rather than applying it to the QueryBuilder directly.
+ *
+ * Unlike {@see SearchStrategyInterface}, which mutates the QueryBuilder in place and so only
+ * fits AND-composed criteria, implementations here must not call QueryBuilder::andWhere():
+ * GlobalSearchFilter collects one condition per globally searchable column and combines them
+ * with OR, so the composition decision belongs to the caller.
+ */
+interface SearchPredicateBuilderInterface
+{
+    /**
+     * Returns the DQL condition for $field, or null when $value cannot be searched against it
+     * (an unparseable value for the column's Doctrine type, or a type LIKE cannot be used on).
+     * Binds $paramName on $qb as a side effect when a condition is returned.
+     */
+    public function build(
+        QueryBuilder $qb,
+        ColumnInterface $column,
+        string $alias,
+        string $field,
+        string $value,
+        string $paramName,
+        bool $forceNumeric = false,
+    ): ?string;
+}

--- a/src/Model/AbstractDataTable.php
+++ b/src/Model/AbstractDataTable.php
@@ -10,11 +10,13 @@ use Pentiminax\UX\DataTables\Column\ActionColumn;
 use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
 use Pentiminax\UX\DataTables\Contracts\DataProviderInterface;
 use Pentiminax\UX\DataTables\Contracts\RowMapperInterface;
+use Pentiminax\UX\DataTables\Contracts\SearchPredicateBuilderInterface;
 use Pentiminax\UX\DataTables\DataTableRequest\Column as RequestColumn;
 use Pentiminax\UX\DataTables\DataTableRequest\Columns as RequestColumns;
 use Pentiminax\UX\DataTables\DataTableRequest\DataTableRequest;
 use Pentiminax\UX\DataTables\Enum\ActionsPosition;
 use Pentiminax\UX\DataTables\Mercure\MercureConfig;
+use Pentiminax\UX\DataTables\Query\DefaultSearchPredicateBuilder;
 use Pentiminax\UX\DataTables\Query\Strategy\DefaultSearchStrategyRegistry;
 use Pentiminax\UX\DataTables\Query\Strategy\SearchStrategyRegistry;
 use Pentiminax\UX\DataTables\RowMapper\DefaultRowMapper;
@@ -316,6 +318,7 @@ abstract class AbstractDataTable
             columns: $this->infrastructure()->columnResolver()->filterStaticPermissions($this->columns),
             filters: $this->filters ?? null,
             registry: $this->createSearchStrategyRegistry(),
+            predicateBuilder: $this->createSearchPredicateBuilder(),
         );
     }
 
@@ -332,6 +335,17 @@ abstract class AbstractDataTable
     protected function createSearchStrategyRegistry(): SearchStrategyRegistry
     {
         return new DefaultSearchStrategyRegistry();
+    }
+
+    /**
+     * Create the search predicate builder used by global search.
+     *
+     * Override this method to customize how global search builds a condition for a column,
+     * e.g. to add type handling SearchPredicateFactory does not cover.
+     */
+    protected function createSearchPredicateBuilder(): SearchPredicateBuilderInterface
+    {
+        return new DefaultSearchPredicateBuilder();
     }
 
     public function getColumnByName(string $name): ?ColumnInterface

--- a/src/Query/Builder/QueryFilterChain.php
+++ b/src/Query/Builder/QueryFilterChain.php
@@ -6,6 +6,7 @@ namespace Pentiminax\UX\DataTables\Query\Builder;
 
 use Doctrine\ORM\QueryBuilder;
 use Pentiminax\UX\DataTables\Contracts\QueryFilterInterface;
+use Pentiminax\UX\DataTables\Contracts\SearchPredicateBuilderInterface;
 use Pentiminax\UX\DataTables\Query\Filter\ColumnControlSearchFilter;
 use Pentiminax\UX\DataTables\Query\Filter\ColumnSearchFilter;
 use Pentiminax\UX\DataTables\Query\Filter\GlobalSearchFilter;
@@ -61,11 +62,11 @@ final class QueryFilterChain
      * 3. ColumnSearchFilter - Applies standard DataTables column-specific searches
      * 4. ColumnControlSearchFilter - Applies column-specific filters using strategies
      */
-    public static function createDefault(SearchStrategyRegistry $registry): self
+    public static function createDefault(SearchStrategyRegistry $registry, SearchPredicateBuilderInterface $predicateBuilder): self
     {
         return (new self())
             ->addFilter(new OrderFilter())
-            ->addFilter(new GlobalSearchFilter())
+            ->addFilter(new GlobalSearchFilter($predicateBuilder))
             ->addFilter(new ColumnSearchFilter($registry))
             ->addFilter(new ColumnControlSearchFilter($registry));
     }

--- a/src/Query/Builder/QueryFilterChain.php
+++ b/src/Query/Builder/QueryFilterChain.php
@@ -7,6 +7,7 @@ namespace Pentiminax\UX\DataTables\Query\Builder;
 use Doctrine\ORM\QueryBuilder;
 use Pentiminax\UX\DataTables\Contracts\QueryFilterInterface;
 use Pentiminax\UX\DataTables\Contracts\SearchPredicateBuilderInterface;
+use Pentiminax\UX\DataTables\Query\DefaultSearchPredicateBuilder;
 use Pentiminax\UX\DataTables\Query\Filter\ColumnControlSearchFilter;
 use Pentiminax\UX\DataTables\Query\Filter\ColumnSearchFilter;
 use Pentiminax\UX\DataTables\Query\Filter\GlobalSearchFilter;
@@ -62,8 +63,10 @@ final class QueryFilterChain
      * 3. ColumnSearchFilter - Applies standard DataTables column-specific searches
      * 4. ColumnControlSearchFilter - Applies column-specific filters using strategies
      */
-    public static function createDefault(SearchStrategyRegistry $registry, SearchPredicateBuilderInterface $predicateBuilder): self
-    {
+    public static function createDefault(
+        SearchStrategyRegistry $registry,
+        SearchPredicateBuilderInterface $predicateBuilder = new DefaultSearchPredicateBuilder(),
+    ): self {
         return (new self())
             ->addFilter(new OrderFilter())
             ->addFilter(new GlobalSearchFilter($predicateBuilder))

--- a/src/Query/Builder/QueryFilterPipeline.php
+++ b/src/Query/Builder/QueryFilterPipeline.php
@@ -6,6 +6,7 @@ namespace Pentiminax\UX\DataTables\Query\Builder;
 
 use Doctrine\ORM\QueryBuilder;
 use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
+use Pentiminax\UX\DataTables\Contracts\SearchPredicateBuilderInterface;
 use Pentiminax\UX\DataTables\DataTableRequest\DataTableRequest;
 use Pentiminax\UX\DataTables\Model\Filters;
 use Pentiminax\UX\DataTables\Query\Intent\DataTableQueryIntentFactoryInterface;
@@ -34,6 +35,7 @@ final class QueryFilterPipeline
         array $columns,
         ?Filters $filters,
         SearchStrategyRegistry $registry,
+        SearchPredicateBuilderInterface $predicateBuilder,
     ): QueryBuilder {
         $intent = $this->intentFactory->create($request, array_values($columns));
 
@@ -48,7 +50,7 @@ final class QueryFilterPipeline
             alias: self::ROOT_ALIAS,
         );
 
-        $qb = QueryFilterChain::createDefault($registry)->apply($qb, $context);
+        $qb = QueryFilterChain::createDefault($registry, $predicateBuilder)->apply($qb, $context);
 
         $this->applyConfiguredFilters($qb, $request, $filters);
 

--- a/src/Query/Builder/QueryFilterPipeline.php
+++ b/src/Query/Builder/QueryFilterPipeline.php
@@ -9,6 +9,7 @@ use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
 use Pentiminax\UX\DataTables\Contracts\SearchPredicateBuilderInterface;
 use Pentiminax\UX\DataTables\DataTableRequest\DataTableRequest;
 use Pentiminax\UX\DataTables\Model\Filters;
+use Pentiminax\UX\DataTables\Query\DefaultSearchPredicateBuilder;
 use Pentiminax\UX\DataTables\Query\Intent\DataTableQueryIntentFactoryInterface;
 use Pentiminax\UX\DataTables\Query\QueryFilterContext;
 use Pentiminax\UX\DataTables\Query\Strategy\SearchStrategyRegistry;
@@ -35,7 +36,7 @@ final class QueryFilterPipeline
         array $columns,
         ?Filters $filters,
         SearchStrategyRegistry $registry,
-        SearchPredicateBuilderInterface $predicateBuilder,
+        SearchPredicateBuilderInterface $predicateBuilder = new DefaultSearchPredicateBuilder(),
     ): QueryBuilder {
         $intent = $this->intentFactory->create($request, array_values($columns));
 

--- a/src/Query/DefaultSearchPredicateBuilder.php
+++ b/src/Query/DefaultSearchPredicateBuilder.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Query;
+
+use Doctrine\ORM\QueryBuilder;
+use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
+use Pentiminax\UX\DataTables\Contracts\SearchPredicateBuilderInterface;
+
+/**
+ * Default {@see SearchPredicateBuilderInterface}, delegating to {@see SearchPredicateFactory}.
+ */
+final class DefaultSearchPredicateBuilder implements SearchPredicateBuilderInterface
+{
+    public function build(
+        QueryBuilder $qb,
+        ColumnInterface $column,
+        string $alias,
+        string $field,
+        string $value,
+        string $paramName,
+        bool $forceNumeric = false,
+    ): ?string {
+        return SearchPredicateFactory::build($qb, $column, $alias, $field, $value, $paramName, $forceNumeric);
+    }
+}

--- a/src/Query/Filter/GlobalSearchFilter.php
+++ b/src/Query/Filter/GlobalSearchFilter.php
@@ -7,6 +7,7 @@ namespace Pentiminax\UX\DataTables\Query\Filter;
 use Doctrine\ORM\QueryBuilder;
 use Pentiminax\UX\DataTables\Contracts\QueryFilterInterface;
 use Pentiminax\UX\DataTables\Contracts\SearchPredicateBuilderInterface;
+use Pentiminax\UX\DataTables\Query\DefaultSearchPredicateBuilder;
 use Pentiminax\UX\DataTables\Query\QueryFilterContext;
 
 /**
@@ -23,7 +24,7 @@ use Pentiminax\UX\DataTables\Query\QueryFilterContext;
 final class GlobalSearchFilter implements QueryFilterInterface
 {
     public function __construct(
-        private readonly SearchPredicateBuilderInterface $predicateBuilder,
+        private readonly SearchPredicateBuilderInterface $predicateBuilder = new DefaultSearchPredicateBuilder(),
     ) {
     }
 

--- a/src/Query/Filter/GlobalSearchFilter.php
+++ b/src/Query/Filter/GlobalSearchFilter.php
@@ -6,18 +6,27 @@ namespace Pentiminax\UX\DataTables\Query\Filter;
 
 use Doctrine\ORM\QueryBuilder;
 use Pentiminax\UX\DataTables\Contracts\QueryFilterInterface;
+use Pentiminax\UX\DataTables\Contracts\SearchPredicateBuilderInterface;
 use Pentiminax\UX\DataTables\Query\QueryFilterContext;
-use Pentiminax\UX\DataTables\Query\SearchPredicateFactory;
 
 /**
  * Filter that applies global search across all globally searchable columns.
  *
  * Reads the normalized {@see \Pentiminax\UX\DataTables\Query\Intent\GlobalSearchIntent}
  * and the globally searchable column references from the intent. Delegates condition
- * building to SearchPredicateFactory. All conditions are combined with OR logic.
+ * building to the injected SearchPredicateBuilderInterface, so overriding
+ * AbstractDataTable::createSearchPredicateBuilder() customizes this search. All conditions
+ * are combined with OR logic: each column's condition must stay a returned DQL fragment
+ * rather than a QueryBuilder::andWhere() call, since only this filter knows the columns
+ * need to be OR'd together rather than required individually.
  */
 final class GlobalSearchFilter implements QueryFilterInterface
 {
+    public function __construct(
+        private readonly SearchPredicateBuilderInterface $predicateBuilder,
+    ) {
+    }
+
     public function apply(QueryBuilder $qb, QueryFilterContext $context): void
     {
         $globalSearch = $context->intent->globalSearch;
@@ -40,7 +49,7 @@ final class GlobalSearchFilter implements QueryFilterInterface
             }
 
             $paramName = \sprintf('search_param_%d', $context->nextParamIndex());
-            $condition = SearchPredicateFactory::build($qb, $column, $context->alias, $field, $globalSearch->value, $paramName);
+            $condition = $this->predicateBuilder->build($qb, $column, $context->alias, $field, $globalSearch->value, $paramName);
 
             if (null !== $condition) {
                 $conditions[] = $condition;

--- a/tests/Unit/Query/Builder/QueryFilterChainTest.php
+++ b/tests/Unit/Query/Builder/QueryFilterChainTest.php
@@ -17,6 +17,7 @@ use Pentiminax\UX\DataTables\DataTableRequest\DataTableRequest;
 use Pentiminax\UX\DataTables\DataTableRequest\Search;
 use Pentiminax\UX\DataTables\Enum\ColumnControlLogic;
 use Pentiminax\UX\DataTables\Query\Builder\QueryFilterChain;
+use Pentiminax\UX\DataTables\Query\DefaultSearchPredicateBuilder;
 use Pentiminax\UX\DataTables\Query\QueryFilterContext;
 use Pentiminax\UX\DataTables\Query\Strategy\DefaultSearchStrategyRegistry;
 use Pentiminax\UX\DataTables\Query\Strategy\SearchStrategyRegistry;
@@ -77,7 +78,7 @@ final class QueryFilterChainTest extends TestCase
         $qb = $this->createMock(QueryBuilder::class);
         $qb->method('getDQLPart')->willReturn([]);
 
-        QueryFilterChain::createDefault($registry)->apply($qb, $context);
+        QueryFilterChain::createDefault($registry, new DefaultSearchPredicateBuilder())->apply($qb, $context);
 
         // Both ColumnSearchFilter (always 'contains') and ColumnControlSearchFilter (logic
         // 'contains' picked for the 'email' column) resolve the strategy from the same

--- a/tests/Unit/Query/Builder/QueryFilterChainTest.php
+++ b/tests/Unit/Query/Builder/QueryFilterChainTest.php
@@ -105,7 +105,7 @@ final class QueryFilterChainTest extends TestCase
 
         $qb->expects($this->atLeastOnce())
             ->method('andWhere')
-            ->with('e.name LIKE :column_control_param_0');
+            ->with("e.name LIKE :column_control_param_0 ESCAPE '!'");
 
         // predicateBuilder defaults to DefaultSearchPredicateBuilder() -- callers who only
         // ever passed a registry before GlobalSearchFilter took a second constructor

--- a/tests/Unit/Query/Builder/QueryFilterChainTest.php
+++ b/tests/Unit/Query/Builder/QueryFilterChainTest.php
@@ -89,6 +89,30 @@ final class QueryFilterChainTest extends TestCase
         ], $calls);
     }
 
+    #[Test]
+    public function it_builds_the_default_chain_with_only_a_registry_argument(): void
+    {
+        $requestColumns = new Columns([
+            'name' => new Column('name', 'name', true, true, new Search('ali', false)),
+        ]);
+
+        $context = $this->context(new DataTableRequest(1, $requestColumns), [
+            TextColumn::new('name', 'Name')->setField('name'),
+        ]);
+
+        $qb = $this->createMock(QueryBuilder::class);
+        $qb->method('getDQLPart')->willReturn([]);
+
+        $qb->expects($this->atLeastOnce())
+            ->method('andWhere')
+            ->with('e.name LIKE :column_control_param_0');
+
+        // predicateBuilder defaults to DefaultSearchPredicateBuilder() -- callers who only
+        // ever passed a registry before GlobalSearchFilter took a second constructor
+        // argument must keep working unchanged.
+        QueryFilterChain::createDefault(new DefaultSearchStrategyRegistry())->apply($qb, $context);
+    }
+
     /**
      * Regression test: ColumnSearchFilter and ColumnControlSearchFilter both resolve their
      * strategy from the same registry and, for a while, both let the strategy mint a

--- a/tests/Unit/Query/Builder/QueryFilterPipelineTest.php
+++ b/tests/Unit/Query/Builder/QueryFilterPipelineTest.php
@@ -87,6 +87,24 @@ final class QueryFilterPipelineTest extends TestCase
         $this->assertSame($qb, $result);
     }
 
+    #[Test]
+    public function it_applies_without_a_predicate_builder_argument(): void
+    {
+        $qb = $this->createMock(QueryBuilder::class);
+
+        // predicateBuilder defaults to DefaultSearchPredicateBuilder() -- callers who only
+        // ever passed a registry before this parameter was added must keep working unchanged.
+        $result = $this->pipeline()->apply(
+            qb: $qb,
+            request: $this->request(),
+            columns: [TextColumn::new('name', 'Name')->setField('name')],
+            filters: null,
+            registry: new DefaultSearchStrategyRegistry(),
+        );
+
+        $this->assertSame($qb, $result);
+    }
+
     private function pipeline(): QueryFilterPipeline
     {
         return new QueryFilterPipeline(new DefaultDataTableQueryIntentFactory());

--- a/tests/Unit/Query/Builder/QueryFilterPipelineTest.php
+++ b/tests/Unit/Query/Builder/QueryFilterPipelineTest.php
@@ -13,6 +13,7 @@ use Pentiminax\UX\DataTables\DataTableRequest\Columns;
 use Pentiminax\UX\DataTables\DataTableRequest\DataTableRequest;
 use Pentiminax\UX\DataTables\Model\Filters;
 use Pentiminax\UX\DataTables\Query\Builder\QueryFilterPipeline;
+use Pentiminax\UX\DataTables\Query\DefaultSearchPredicateBuilder;
 use Pentiminax\UX\DataTables\Query\Intent\DefaultDataTableQueryIntentFactory;
 use Pentiminax\UX\DataTables\Query\Strategy\DefaultSearchStrategyRegistry;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -56,6 +57,7 @@ final class QueryFilterPipelineTest extends TestCase
             columns: [TextColumn::new('name', 'Name')->setField('name')],
             filters: (new Filters())->add($filter),
             registry: new DefaultSearchStrategyRegistry(),
+            predicateBuilder: new DefaultSearchPredicateBuilder(),
         );
 
         $expected = array_map(static fn (string $applied): array => [$qb, $applied, 'e'], $expectedValues);
@@ -79,6 +81,7 @@ final class QueryFilterPipelineTest extends TestCase
             columns: $columns,
             filters: null,
             registry: new DefaultSearchStrategyRegistry(),
+            predicateBuilder: new DefaultSearchPredicateBuilder(),
         );
 
         $this->assertSame($qb, $result);

--- a/tests/Unit/Query/DefaultSearchPredicateBuilderTest.php
+++ b/tests/Unit/Query/DefaultSearchPredicateBuilderTest.php
@@ -39,7 +39,7 @@ final class DefaultSearchPredicateBuilderTest extends TestCase
             'p_0',
         );
 
-        $this->assertSame('e.name LIKE :p_0', $result);
+        $this->assertSame("e.name LIKE :p_0 ESCAPE '!'", $result);
     }
 
     #[Test]

--- a/tests/Unit/Query/DefaultSearchPredicateBuilderTest.php
+++ b/tests/Unit/Query/DefaultSearchPredicateBuilderTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Unit\Query;
+
+use Pentiminax\UX\DataTables\Column\NumberColumn;
+use Pentiminax\UX\DataTables\Column\TextColumn;
+use Pentiminax\UX\DataTables\Query\DefaultSearchPredicateBuilder;
+use Pentiminax\UX\DataTables\Tests\Support\BuildsTypedFieldQueryBuilder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * DefaultSearchPredicateBuilder is a thin SearchPredicateBuilderInterface wrapper around
+ * SearchPredicateFactory::build(); the type-dispatch behavior itself is covered by
+ * SearchPredicateFactoryTest, so this only asserts the delegation.
+ *
+ * @internal
+ */
+#[CoversClass(DefaultSearchPredicateBuilder::class)]
+final class DefaultSearchPredicateBuilderTest extends TestCase
+{
+    use BuildsTypedFieldQueryBuilder;
+
+    #[Test]
+    public function it_delegates_to_search_predicate_factory(): void
+    {
+        $qb = $this->queryBuilderWithFieldType('name', null);
+        $qb->expects($this->once())->method('setParameter')->with('p_0', '%hello%');
+
+        $result = (new DefaultSearchPredicateBuilder())->build(
+            $qb,
+            TextColumn::new('name', 'Name')->setField('name'),
+            'e',
+            'name',
+            'hello',
+            'p_0',
+        );
+
+        $this->assertSame('e.name LIKE :p_0', $result);
+    }
+
+    #[Test]
+    public function it_forwards_force_numeric(): void
+    {
+        $qb = $this->queryBuilderWithFieldType('score', null);
+        $qb->expects($this->once())->method('setParameter')->with('p_0', '42', null);
+
+        $result = (new DefaultSearchPredicateBuilder())->build(
+            $qb,
+            TextColumn::new('score', 'Score')->setField('score'),
+            'e',
+            'score',
+            '42',
+            'p_0',
+            forceNumeric: true,
+        );
+
+        $this->assertSame('e.score = :p_0', $result);
+    }
+
+    #[Test]
+    public function it_returns_null_when_the_factory_rejects_the_value(): void
+    {
+        $qb = $this->queryBuilderWithFieldType('id', null);
+        $qb->expects($this->never())->method('setParameter');
+
+        $result = (new DefaultSearchPredicateBuilder())->build(
+            $qb,
+            NumberColumn::new('id', 'ID')->setField('id'),
+            'e',
+            'id',
+            'not-a-number',
+            'p_0',
+        );
+
+        $this->assertNull($result);
+    }
+}

--- a/tests/Unit/Query/Filter/GlobalSearchFilterTest.php
+++ b/tests/Unit/Query/Filter/GlobalSearchFilterTest.php
@@ -8,9 +8,11 @@ use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\QueryBuilder;
 use Pentiminax\UX\DataTables\Column\TextColumn;
 use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
+use Pentiminax\UX\DataTables\Contracts\SearchPredicateBuilderInterface;
 use Pentiminax\UX\DataTables\DataTableRequest\Columns;
 use Pentiminax\UX\DataTables\DataTableRequest\DataTableRequest;
 use Pentiminax\UX\DataTables\DataTableRequest\Search;
+use Pentiminax\UX\DataTables\Query\DefaultSearchPredicateBuilder;
 use Pentiminax\UX\DataTables\Query\Filter\GlobalSearchFilter;
 use Pentiminax\UX\DataTables\Query\QueryFilterContext;
 use Pentiminax\UX\DataTables\Tests\Support\BuildsQueryFilterContext;
@@ -26,6 +28,11 @@ use PHPUnit\Framework\TestCase;
 final class GlobalSearchFilterTest extends TestCase
 {
     use BuildsQueryFilterContext;
+
+    private function filter(): GlobalSearchFilter
+    {
+        return new GlobalSearchFilter(new DefaultSearchPredicateBuilder());
+    }
 
     /**
      * @return iterable<string, array{ColumnInterface, string, string, string, ?array{string, string}}>
@@ -94,7 +101,41 @@ final class GlobalSearchFilterTest extends TestCase
             ->method('setParameter')
             ->with('search_param_0', $expectedParameterValue);
 
-        (new GlobalSearchFilter())->apply($qb, $this->globalSearchContext($column, $value));
+        $this->filter()->apply($qb, $this->globalSearchContext($column, $value));
+    }
+
+    #[Test]
+    public function it_builds_conditions_through_the_injected_predicate_builder(): void
+    {
+        $qb = $this->createMock(QueryBuilder::class);
+        $qb->method('getDQLPart')->willReturn([]);
+
+        $expr = $this->createMock(Expr::class);
+        $expr->expects($this->once())
+            ->method('orX')
+            ->with('e.name = :search_param_0')
+            ->willReturn(new Expr\Orx(['e.name = :search_param_0']));
+
+        $qb->method('expr')->willReturn($expr);
+        $qb->expects($this->once())->method('andWhere')->willReturn($qb);
+
+        $qb->expects($this->once())
+            ->method('setParameter')
+            ->with('search_param_0', 'exact');
+
+        $predicateBuilder = new class implements SearchPredicateBuilderInterface {
+            public function build(QueryBuilder $qb, ColumnInterface $column, string $alias, string $field, string $value, string $paramName, bool $forceNumeric = false): ?string
+            {
+                $qb->setParameter($paramName, $value);
+
+                return \sprintf('%s.%s = :%s', $alias, $field, $paramName);
+            }
+        };
+
+        $filter = new GlobalSearchFilter($predicateBuilder);
+        $column = TextColumn::new('name', 'Name')->setField('name');
+
+        $filter->apply($qb, $this->globalSearchContext($column, 'exact'));
     }
 
     #[Test]
@@ -107,7 +148,7 @@ final class GlobalSearchFilterTest extends TestCase
 
         $context = $this->globalSearchContext(TextColumn::new('client', 'Client'), 'acme');
 
-        (new GlobalSearchFilter())->apply($qb, $context);
+        $this->filter()->apply($qb, $context);
     }
 
     private function globalSearchContext(ColumnInterface $column, string $value): QueryFilterContext

--- a/tests/Unit/Query/Filter/GlobalSearchFilterTest.php
+++ b/tests/Unit/Query/Filter/GlobalSearchFilterTest.php
@@ -34,6 +34,25 @@ final class GlobalSearchFilterTest extends TestCase
         return new GlobalSearchFilter(new DefaultSearchPredicateBuilder());
     }
 
+    #[Test]
+    public function it_can_be_constructed_with_no_arguments(): void
+    {
+        $qb = $this->createMock(QueryBuilder::class);
+        $qb->method('getDQLPart')->willReturn([]);
+
+        $qb->method('expr')->willReturn(new Expr());
+        $qb->expects($this->once())->method('andWhere')->willReturn($qb);
+
+        $qb->expects($this->once())
+            ->method('setParameter')
+            ->with('search_param_0', '%ali%');
+
+        $column  = TextColumn::new('name', 'Name')->setField('name');
+        $context = $this->globalSearchContext($column, 'ali');
+
+        (new GlobalSearchFilter())->apply($qb, $context);
+    }
+
     /**
      * @return iterable<string, array{ColumnInterface, string, string, string, ?array{string, string}}>
      */


### PR DESCRIPTION
- Adds SearchPredicateBuilderInterface (src/Contracts/): returns the DQL condition (or null) instead of mutating the query builder, so GlobalSearchFilter can OR the results together itself.
- Adds DefaultSearchPredicateBuilder, a thin wrapper around the existing SearchPredicateFactory::build() — behavior is unchanged by default.
- GlobalSearchFilter now takes a SearchPredicateBuilderInterface instead of calling SearchPredicateFactory::build() directly.
- Adds AbstractDataTable::createSearchPredicateBuilder(), threaded through QueryFilterPipeline::apply() and - QueryFilterChain::createDefault() the same way createSearchStrategyRegistry() already threads through — the override point PR 1 gave ColumnSearchFilter now exists for GlobalSearchFilter too.
- SearchStrategyInterface and every strategy implementation are untouched.

Depends on #334
Closes #333

```php
final class UserDataTable extends AbstractDataTable
{
    public function configureColumns(): iterable
    {
        yield TextColumn::new('name', 'Name')->setField('name');       // globally searchable by default
        yield TextColumn::new('createdAt', 'Created')->setField('createdAt'); // ->disableGlobalSearch() to opt one out
    }

    protected function createSearchPredicateBuilder(): SearchPredicateBuilderInterface
    {
        return new MyPredicateBuilder();
    }
}

final class MyPredicateBuilder implements SearchPredicateBuilderInterface
{
    public function __construct(private readonly SearchPredicateBuilderInterface $default = new DefaultSearchPredicateBuilder()) {}

    public function build(QueryBuilder $qb, ColumnInterface $column, string $alias, string $field, string $value, string $paramName, bool $forceNumeric = false): ?string
    {
        if ('created_at' === $column->getName()) {
            // match rows on-or-after the searched date instead of exact equality
            $date = \DateTimeImmutable::createFromFormat('Y-m-d', trim($value));
            if (false === $date) {
                return null; // unparseable -> no match, not a crash
            }

            $qb->setParameter($paramName, $date, 'date');

            return \sprintf('%s.%s >= :%s', $alias, $field, $paramName);
        }
        return $this->default->build($qb, $column, $alias, $field, $value, $paramName, $forceNumeric);
    }
}
```

here's a quick look at api use for different hooks for global vs. column level search
```php

final class CreatedAtSearchHooks implements SearchPredicateBuilderInterface, SearchStrategyInterface
{
    public function __construct(
        private readonly SearchPredicateBuilderInterface $defaultBuilder = new DefaultSearchPredicateBuilder(),
    ) {
    }

    // Called only from GlobalSearchFilter -- one predicate per column, OR'd together.
    public function build(QueryBuilder $qb, ColumnInterface $column, string $alias, string $field, string $value, string $paramName, bool $forceNumeric = false): ?string
    {
        if ('createdAt' !== $column->getName()) {
            return $this->defaultBuilder->build($qb, $column, $alias, $field, $value, $paramName, $forceNumeric);
        }

        // loose: match rows created in the searched year
        if (!preg_match('/^\d{4}$/', trim($value))) {
            return null;
        }

        $qb->setParameter($paramName, (int) $value);

        return \sprintf('YEAR(%s.%s) = :%s', $alias, $field, $paramName);
    }

    // Called only from ColumnSearchFilter (registered under 'contains') and
    // ColumnControlSearchFilter (whenever a user picks the 'contains' logic).
    public function apply(QueryBuilder $qb, ColumnInterface $column, ColumnControlSearch $search, int $paramIndex, string $alias): void
    {
        if ('createdAt' !== $column->getName()) {
            (new ContainsSearchStrategy())->apply($qb, $column, $search, $paramIndex, $alias);
            return;
        }

        // strict: exact date match on this column's own search box
        $date = \DateTimeImmutable::createFromFormat('Y-m-d', trim($search->value));
        if (false === $date) {
            return;
        }

        $paramName = \sprintf('column_control_param_%d', $paramIndex);
        $qb->setParameter($paramName, $date, 'date');
        $qb->andWhere(\sprintf('%s.%s = :%s', $alias, $column->getField(), $paramName));
    }

    public function getLogic(): string
    {
        return 'contains';
    }
}

final class UserDataTable extends AbstractDataTable
{
    protected function createSearchPredicateBuilder(): SearchPredicateBuilderInterface
    {
        return new CreatedAtSearchHooks();
    }

    protected function createSearchStrategyRegistry(): SearchStrategyRegistry
    {
        $registry = new DefaultSearchStrategyRegistry();
        $registry->register(new CreatedAtSearchHooks()); // overwrites the 'contains' entry

        return $registry;
    }
}
```
 typing 2026 in the global search box year-matches every row regardless of month/day, while typing 2026-08-19 in that column's own search box requires an exact date. Two different behaviors, same column, differentiated purely by which filter called which method