### PR TITLE
fix: escape LIKE wildcard characters in search values

### DIFF
--- a/src/Filter/TextFilter.php
+++ b/src/Filter/TextFilter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pentiminax\UX\DataTables\Filter;
 
 use Doctrine\ORM\QueryBuilder;
+use Pentiminax\UX\DataTables\Query\LikeValueEscaper;
 use Pentiminax\UX\DataTables\Query\RelationFieldResolver;
 
 /**
@@ -37,7 +38,7 @@ final class TextFilter extends AbstractFilter
 
         $param = $this->parameterName();
 
-        $qb->andWhere(\sprintf('LOWER(%s) LIKE :%s', $expr, $param));
-        $qb->setParameter($param, '%'.mb_strtolower(trim($value)).'%');
+        $qb->andWhere(\sprintf("LOWER(%s) LIKE :%s ESCAPE '%s'", $expr, $param, LikeValueEscaper::ESCAPE_CHARACTER));
+        $qb->setParameter($param, '%'.LikeValueEscaper::escape(mb_strtolower(trim($value))).'%');
     }
 }

--- a/src/Query/LikeValueEscaper.php
+++ b/src/Query/LikeValueEscaper.php
@@ -17,10 +17,17 @@ namespace Pentiminax\UX\DataTables\Query;
  * Every generated LIKE condition must add `ESCAPE '{@see self::ESCAPE_CHARACTER}'` for this
  * escaping to take effect — without it, the database still treats the doubled escape
  * character and the escaped wildcards literally rather than as an escape sequence.
+ *
+ * `!` is the escape character, not the more conventional backslash: MySQL's default SQL mode
+ * treats backslash as a string-literal escape character, so embedding a raw backslash inside
+ * the quoted `ESCAPE '\'` literal is parsed as escaping the closing quote instead of closing
+ * the string, breaking the query with a syntax error on every LIKE search. `!` has no special
+ * meaning in any supported platform's string literal syntax, so the same generated SQL is
+ * correct everywhere without needing to detect which database is actually connected.
  */
 final class LikeValueEscaper
 {
-    public const string ESCAPE_CHARACTER = '\\';
+    public const string ESCAPE_CHARACTER = '!';
 
     public static function escape(string $value): string
     {

--- a/src/Query/LikeValueEscaper.php
+++ b/src/Query/LikeValueEscaper.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Query;
+
+/**
+ * Escapes SQL LIKE wildcard characters in a user-supplied search term before it is wrapped
+ * into a LIKE pattern.
+ *
+ * Without this, a term containing a literal `%` or `_` is interpreted as a wildcard instead
+ * of a literal character — e.g. searching for "50% off" matches any string starting with
+ * "50", any characters, then " off", rather than the literal substring "50% off". This is a
+ * correctness bug, not a SQL injection risk: the term is always bound through setParameter(),
+ * never interpolated into the DQL string.
+ *
+ * Every generated LIKE condition must add `ESCAPE '{@see self::ESCAPE_CHARACTER}'` for this
+ * escaping to take effect — without it, the database still treats the doubled escape
+ * character and the escaped wildcards literally rather than as an escape sequence.
+ */
+final class LikeValueEscaper
+{
+    public const string ESCAPE_CHARACTER = '\\';
+
+    public static function escape(string $value): string
+    {
+        return str_replace(
+            [self::ESCAPE_CHARACTER, '%', '_'],
+            [self::ESCAPE_CHARACTER.self::ESCAPE_CHARACTER, self::ESCAPE_CHARACTER.'%', self::ESCAPE_CHARACTER.'_'],
+            $value,
+        );
+    }
+}

--- a/src/Query/SearchConditionBuilder.php
+++ b/src/Query/SearchConditionBuilder.php
@@ -15,13 +15,17 @@ final class SearchConditionBuilder
 {
     /**
      * Build a LIKE %value% condition, set the parameter, return the DQL expression.
+     *
+     * $value is escaped so a literal `%` or `_` in the search term is matched literally
+     * rather than treated as a wildcard; the ESCAPE clause is what makes the database honor
+     * that escaping — see {@see LikeValueEscaper}.
      */
     public static function text(QueryBuilder $qb, string $alias, string $fieldPath, string $value, string $paramName): string
     {
         $field = RelationFieldResolver::resolve($qb, $alias, $fieldPath);
-        $qb->setParameter($paramName, \sprintf('%%%s%%', $value));
+        $qb->setParameter($paramName, \sprintf('%%%s%%', LikeValueEscaper::escape($value)));
 
-        return \sprintf('%s LIKE :%s', $field, $paramName);
+        return \sprintf("%s LIKE :%s ESCAPE '%s'", $field, $paramName, LikeValueEscaper::ESCAPE_CHARACTER);
     }
 
     /**

--- a/src/Query/Strategy/ComparisonSearchStrategy.php
+++ b/src/Query/Strategy/ComparisonSearchStrategy.php
@@ -10,6 +10,7 @@ use Pentiminax\UX\DataTables\Contracts\SearchStrategyInterface;
 use Pentiminax\UX\DataTables\DataTableRequest\ColumnControlSearch;
 use Pentiminax\UX\DataTables\Enum\ColumnControlLogic;
 use Pentiminax\UX\DataTables\Query\DateSearchTerm;
+use Pentiminax\UX\DataTables\Query\LikeValueEscaper;
 use Pentiminax\UX\DataTables\Query\RelationFieldResolver;
 use Pentiminax\UX\DataTables\Query\UuidSearchTerm;
 
@@ -40,7 +41,9 @@ final class ComparisonSearchStrategy implements SearchStrategyInterface
             return;
         }
 
-        if ($this->logic->usesLikeOperator() && !RelationFieldResolver::supportsTextSearch($qb, $fieldPath)) {
+        $usesLike = $this->logic->usesLikeOperator();
+
+        if ($usesLike && !RelationFieldResolver::supportsTextSearch($qb, $fieldPath)) {
             return;
         }
 
@@ -53,10 +56,19 @@ final class ComparisonSearchStrategy implements SearchStrategyInterface
         $field     = RelationFieldResolver::resolve($qb, $alias, $fieldPath);
         $paramName = \sprintf('column_control_param_%d', $paramIndex);
 
-        $qb->andWhere(\sprintf('%s %s :%s', $field, $this->logic->operator(), $paramName));
+        $condition = \sprintf('%s %s :%s', $field, $this->logic->operator(), $paramName);
+        if ($usesLike) {
+            $condition .= \sprintf(" ESCAPE '%s'", LikeValueEscaper::ESCAPE_CHARACTER);
+        }
+
+        $qb->andWhere($condition);
         $qb->setParameter(
             $paramName,
-            $bindValue instanceof \DateTimeImmutable ? $bindValue : \sprintf($this->logic->paramFormat(), $bindValue),
+            match (true) {
+                $bindValue instanceof \DateTimeImmutable => $bindValue,
+                $usesLike                                => \sprintf($this->logic->paramFormat(), LikeValueEscaper::escape($bindValue)),
+                default                                  => \sprintf($this->logic->paramFormat(), $bindValue),
+            },
             $bindType,
         );
     }

--- a/tests/Unit/Filter/TextFilterTest.php
+++ b/tests/Unit/Filter/TextFilterTest.php
@@ -55,7 +55,7 @@ final class TextFilterTest extends TestCase
             'name',
             'John',
             null,
-            ["LOWER(e.name) LIKE :filter_name ESCAPE '\\'"],
+            ["LOWER(e.name) LIKE :filter_name ESCAPE '!'"],
             ['filter_name' => '%john%'],
         ];
 
@@ -63,8 +63,8 @@ final class TextFilterTest extends TestCase
             'name',
             '50%_off',
             null,
-            ["LOWER(e.name) LIKE :filter_name ESCAPE '\\'"],
-            ['filter_name' => '%50\%\_off%'],
+            ["LOWER(e.name) LIKE :filter_name ESCAPE '!'"],
+            ['filter_name' => '%50!%!_off%'],
         ];
 
         yield 'uuid field' => ['id', '018f2c3e', 'uuid', [], []];

--- a/tests/Unit/Filter/TextFilterTest.php
+++ b/tests/Unit/Filter/TextFilterTest.php
@@ -55,8 +55,16 @@ final class TextFilterTest extends TestCase
             'name',
             'John',
             null,
-            ['LOWER(e.name) LIKE :filter_name'],
+            ["LOWER(e.name) LIKE :filter_name ESCAPE '\\'"],
             ['filter_name' => '%john%'],
+        ];
+
+        yield 'value with like wildcards is escaped, not interpreted' => [
+            'name',
+            '50%_off',
+            null,
+            ["LOWER(e.name) LIKE :filter_name ESCAPE '\\'"],
+            ['filter_name' => '%50\%\_off%'],
         ];
 
         yield 'uuid field' => ['id', '018f2c3e', 'uuid', [], []];

--- a/tests/Unit/Query/Filter/ColumnSearchFilterTest.php
+++ b/tests/Unit/Query/Filter/ColumnSearchFilterTest.php
@@ -57,8 +57,16 @@ final class ColumnSearchFilterTest extends TestCase
         yield 'text field' => [
             TextColumn::new('name', 'Name')->setField('name'),
             'test',
-            'e.name LIKE :column_control_param_0',
+            "e.name LIKE :column_control_param_0 ESCAPE '\\'",
             '%test%',
+            null,
+        ];
+
+        yield 'text field with like wildcards is escaped, not interpreted' => [
+            TextColumn::new('name', 'Name')->setField('name'),
+            '50%_off',
+            "e.name LIKE :column_control_param_0 ESCAPE '\\'",
+            '%50\%\_off%',
             null,
         ];
 
@@ -73,7 +81,7 @@ final class ColumnSearchFilterTest extends TestCase
         yield 'dot notation field' => [
             TextColumn::new('authorName', 'Author')->setField('author.firstName'),
             'john',
-            'author.firstName LIKE :column_control_param_0',
+            "author.firstName LIKE :column_control_param_0 ESCAPE '\\'",
             '%john%',
             ['e.author', 'author'],
         ];
@@ -194,7 +202,7 @@ final class ColumnSearchFilterTest extends TestCase
 
         $qb->expects($this->once())
             ->method('andWhere')
-            ->with('e.name LIKE :column_control_param_0');
+            ->with("e.name LIKE :column_control_param_0 ESCAPE '\\'");
 
         $qb->expects($this->once())
             ->method('setParameter')
@@ -250,8 +258,8 @@ final class ColumnSearchFilterTest extends TestCase
         $this->filter()->apply($qb, $context);
 
         self::assertSame([
-            'e.name LIKE :column_control_param_0',
-            'e.email LIKE :column_control_param_1',
+            "e.name LIKE :column_control_param_0 ESCAPE '\\'",
+            "e.email LIKE :column_control_param_1 ESCAPE '\\'",
         ], $conditions);
 
         self::assertSame([

--- a/tests/Unit/Query/Filter/ColumnSearchFilterTest.php
+++ b/tests/Unit/Query/Filter/ColumnSearchFilterTest.php
@@ -42,7 +42,7 @@ final class ColumnSearchFilterTest extends TestCase
 
         $qb->expects($this->once())
             ->method('andWhere')
-            ->with('e.name LIKE :column_control_param_0');
+            ->with("e.name LIKE :column_control_param_0 ESCAPE '!'");
 
         $context = $this->singleColumnContext(TextColumn::new('name', 'Name')->setField('name'), new Search('ali', false));
 
@@ -57,7 +57,7 @@ final class ColumnSearchFilterTest extends TestCase
         yield 'text field' => [
             TextColumn::new('name', 'Name')->setField('name'),
             'test',
-            "e.name LIKE :column_control_param_0 ESCAPE '\\'",
+            "e.name LIKE :column_control_param_0 ESCAPE '!'",
             '%test%',
             null,
         ];
@@ -65,8 +65,8 @@ final class ColumnSearchFilterTest extends TestCase
         yield 'text field with like wildcards is escaped, not interpreted' => [
             TextColumn::new('name', 'Name')->setField('name'),
             '50%_off',
-            "e.name LIKE :column_control_param_0 ESCAPE '\\'",
-            '%50\%\_off%',
+            "e.name LIKE :column_control_param_0 ESCAPE '!'",
+            '%50!%!_off%',
             null,
         ];
 
@@ -81,7 +81,7 @@ final class ColumnSearchFilterTest extends TestCase
         yield 'dot notation field' => [
             TextColumn::new('authorName', 'Author')->setField('author.firstName'),
             'john',
-            "author.firstName LIKE :column_control_param_0 ESCAPE '\\'",
+            "author.firstName LIKE :column_control_param_0 ESCAPE '!'",
             '%john%',
             ['e.author', 'author'],
         ];
@@ -202,7 +202,7 @@ final class ColumnSearchFilterTest extends TestCase
 
         $qb->expects($this->once())
             ->method('andWhere')
-            ->with("e.name LIKE :column_control_param_0 ESCAPE '\\'");
+            ->with("e.name LIKE :column_control_param_0 ESCAPE '!'");
 
         $qb->expects($this->once())
             ->method('setParameter')
@@ -258,8 +258,8 @@ final class ColumnSearchFilterTest extends TestCase
         $this->filter()->apply($qb, $context);
 
         self::assertSame([
-            "e.name LIKE :column_control_param_0 ESCAPE '\\'",
-            "e.email LIKE :column_control_param_1 ESCAPE '\\'",
+            "e.name LIKE :column_control_param_0 ESCAPE '!'",
+            "e.email LIKE :column_control_param_1 ESCAPE '!'",
         ], $conditions);
 
         self::assertSame([

--- a/tests/Unit/Query/Filter/GlobalSearchFilterTest.php
+++ b/tests/Unit/Query/Filter/GlobalSearchFilterTest.php
@@ -35,15 +35,23 @@ final class GlobalSearchFilterTest extends TestCase
         yield 'simple field' => [
             TextColumn::new('name', 'Name')->setField('name'),
             'test',
-            'e.name LIKE :search_param_0',
+            "e.name LIKE :search_param_0 ESCAPE '\\'",
             '%test%',
+            null,
+        ];
+
+        yield 'field with like wildcards is escaped, not interpreted' => [
+            TextColumn::new('name', 'Name')->setField('name'),
+            '50%_off',
+            "e.name LIKE :search_param_0 ESCAPE '\\'",
+            '%50\%\_off%',
             null,
         ];
 
         yield 'dot notation field' => [
             TextColumn::new('authorName', 'Author')->setField('author.firstName'),
             'john',
-            'author.firstName LIKE :search_param_0',
+            "author.firstName LIKE :search_param_0 ESCAPE '\\'",
             '%john%',
             ['e.author', 'author'],
         ];

--- a/tests/Unit/Query/Filter/GlobalSearchFilterTest.php
+++ b/tests/Unit/Query/Filter/GlobalSearchFilterTest.php
@@ -35,7 +35,7 @@ final class GlobalSearchFilterTest extends TestCase
         yield 'simple field' => [
             TextColumn::new('name', 'Name')->setField('name'),
             'test',
-            "e.name LIKE :search_param_0 ESCAPE '\\'",
+            "e.name LIKE :search_param_0 ESCAPE '!'",
             '%test%',
             null,
         ];
@@ -43,15 +43,15 @@ final class GlobalSearchFilterTest extends TestCase
         yield 'field with like wildcards is escaped, not interpreted' => [
             TextColumn::new('name', 'Name')->setField('name'),
             '50%_off',
-            "e.name LIKE :search_param_0 ESCAPE '\\'",
-            '%50\%\_off%',
+            "e.name LIKE :search_param_0 ESCAPE '!'",
+            '%50!%!_off%',
             null,
         ];
 
         yield 'dot notation field' => [
             TextColumn::new('authorName', 'Author')->setField('author.firstName'),
             'john',
-            "author.firstName LIKE :search_param_0 ESCAPE '\\'",
+            "author.firstName LIKE :search_param_0 ESCAPE '!'",
             '%john%',
             ['e.author', 'author'],
         ];

--- a/tests/Unit/Query/LikeValueEscaperTest.php
+++ b/tests/Unit/Query/LikeValueEscaperTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Unit\Query;
+
+use Pentiminax\UX\DataTables\Query\LikeValueEscaper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+#[CoversClass(LikeValueEscaper::class)]
+final class LikeValueEscaperTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function values(): iterable
+    {
+        yield 'no special characters' => ['hello', 'hello'];
+        yield 'percent sign' => ['50%', '50\%'];
+        yield 'underscore' => ['a_b', 'a\_b'];
+        yield 'backslash' => ['a\b', 'a\\\\b'];
+        yield 'percent, underscore, and backslash together' => [
+            '50%_off\sale',
+            '50\%\_off\\\\sale',
+        ];
+        yield 'only wildcards' => ['%_', '\%\_'];
+        yield 'backslash immediately before a wildcard' => [
+            '\%',
+            '\\\\\%',
+        ];
+        yield 'empty string' => ['', ''];
+    }
+
+    #[Test]
+    #[DataProvider('values')]
+    public function it_escapes_like_wildcard_characters(string $value, string $expected): void
+    {
+        $this->assertSame($expected, LikeValueEscaper::escape($value));
+    }
+
+    /**
+     * Demonstrates the actual bug this class fixes: without escaping, a literal wildcard in
+     * the search term changes what the pattern matches instead of being matched literally.
+     */
+    #[Test]
+    public function it_produces_a_pattern_that_matches_the_literal_term_instead_of_a_wildcard(): void
+    {
+        $escaped = LikeValueEscaper::escape('50% off');
+        $pattern = \sprintf('%%%s%%', $escaped);
+
+        // The escaped pattern reads back as a literal match for "50% off" bracketed by
+        // wildcards this call added itself -- not "50", then anything, then " off", which
+        // is what wrapping the raw, unescaped value in %...% would produce instead.
+        $this->assertSame('%50\% off%', $pattern);
+        $this->assertStringNotContainsString('%50%', $pattern);
+    }
+
+    #[Test]
+    public function it_is_reversible_by_removing_the_escape_character(): void
+    {
+        // Sanity check on the escaping scheme itself for a value with no literal backslash of
+        // its own: removing every escape character this call introduced recovers the original
+        // value exactly, confirming no wildcard or character was dropped or duplicated.
+        $value   = 'a_b%c';
+        $escaped = LikeValueEscaper::escape($value);
+
+        $this->assertSame($value, str_replace(LikeValueEscaper::ESCAPE_CHARACTER, '', $escaped));
+    }
+}

--- a/tests/Unit/Query/LikeValueEscaperTest.php
+++ b/tests/Unit/Query/LikeValueEscaperTest.php
@@ -22,17 +22,18 @@ final class LikeValueEscaperTest extends TestCase
     public static function values(): iterable
     {
         yield 'no special characters' => ['hello', 'hello'];
-        yield 'percent sign' => ['50%', '50\%'];
-        yield 'underscore' => ['a_b', 'a\_b'];
-        yield 'backslash' => ['a\b', 'a\\\\b'];
-        yield 'percent, underscore, and backslash together' => [
-            '50%_off\sale',
-            '50\%\_off\\\\sale',
+        yield 'percent sign' => ['50%', '50!%'];
+        yield 'underscore' => ['a_b', 'a!_b'];
+        yield 'backslash is not special' => ['a\b', 'a\b'];
+        yield 'exclamation mark, the escape character itself' => ['great!', 'great!!'];
+        yield 'percent, underscore, and exclamation mark together' => [
+            '50%_off!sale',
+            '50!%!_off!!sale',
         ];
-        yield 'only wildcards' => ['%_', '\%\_'];
-        yield 'backslash immediately before a wildcard' => [
-            '\%',
-            '\\\\\%',
+        yield 'only wildcards' => ['%_', '!%!_'];
+        yield 'exclamation mark immediately before a wildcard' => [
+            '!%',
+            '!!!%',
         ];
         yield 'empty string' => ['', ''];
     }
@@ -57,16 +58,31 @@ final class LikeValueEscaperTest extends TestCase
         // The escaped pattern reads back as a literal match for "50% off" bracketed by
         // wildcards this call added itself -- not "50", then anything, then " off", which
         // is what wrapping the raw, unescaped value in %...% would produce instead.
-        $this->assertSame('%50\% off%', $pattern);
+        $this->assertSame('%50!% off%', $pattern);
         $this->assertStringNotContainsString('%50%', $pattern);
+    }
+
+    /**
+     * ! rather than the more conventional backslash is deliberate: MySQL's default SQL mode
+     * treats a raw backslash inside a quoted string literal as escaping the closing quote,
+     * so ESCAPE '\' breaks with a syntax error on every LIKE search on that platform. ! has
+     * no special meaning in any supported platform's string literal syntax, so the same
+     * generated ESCAPE clause is correct everywhere without detecting which database is
+     * connected.
+     */
+    #[Test]
+    public function it_uses_an_escape_character_with_no_special_meaning_in_sql_string_literals(): void
+    {
+        $this->assertSame('!', LikeValueEscaper::ESCAPE_CHARACTER);
     }
 
     #[Test]
     public function it_is_reversible_by_removing_the_escape_character(): void
     {
-        // Sanity check on the escaping scheme itself for a value with no literal backslash of
-        // its own: removing every escape character this call introduced recovers the original
-        // value exactly, confirming no wildcard or character was dropped or duplicated.
+        // Sanity check on the escaping scheme itself for a value with no literal exclamation
+        // mark of its own: removing every escape character this call introduced recovers the
+        // original value exactly, confirming no wildcard or character was dropped or
+        // duplicated.
         $value   = 'a_b%c';
         $escaped = LikeValueEscaper::escape($value);
 

--- a/tests/Unit/Query/SearchConditionBuilderTest.php
+++ b/tests/Unit/Query/SearchConditionBuilderTest.php
@@ -29,7 +29,7 @@ final class SearchConditionBuilderTest extends TestCase
             'text',
             'name',
             'hello',
-            'e.name LIKE :param_0',
+            "e.name LIKE :param_0 ESCAPE '\\'",
             ['param_0', '%hello%'],
             null,
         ];
@@ -38,9 +38,18 @@ final class SearchConditionBuilderTest extends TestCase
             'text',
             'author.firstName',
             'john',
-            'author.firstName LIKE :param_0',
+            "author.firstName LIKE :param_0 ESCAPE '\\'",
             ['param_0', '%john%'],
             ['e.author', 'author'],
+        ];
+
+        yield 'text with like wildcards is escaped, not interpreted' => [
+            'text',
+            'name',
+            '50%_off',
+            "e.name LIKE :param_0 ESCAPE '\\'",
+            ['param_0', '%50\%\_off%'],
+            null,
         ];
 
         yield 'numeric on a simple field' => [

--- a/tests/Unit/Query/SearchConditionBuilderTest.php
+++ b/tests/Unit/Query/SearchConditionBuilderTest.php
@@ -29,7 +29,7 @@ final class SearchConditionBuilderTest extends TestCase
             'text',
             'name',
             'hello',
-            "e.name LIKE :param_0 ESCAPE '\\'",
+            "e.name LIKE :param_0 ESCAPE '!'",
             ['param_0', '%hello%'],
             null,
         ];
@@ -38,7 +38,7 @@ final class SearchConditionBuilderTest extends TestCase
             'text',
             'author.firstName',
             'john',
-            "author.firstName LIKE :param_0 ESCAPE '\\'",
+            "author.firstName LIKE :param_0 ESCAPE '!'",
             ['param_0', '%john%'],
             ['e.author', 'author'],
         ];
@@ -47,8 +47,8 @@ final class SearchConditionBuilderTest extends TestCase
             'text',
             'name',
             '50%_off',
-            "e.name LIKE :param_0 ESCAPE '\\'",
-            ['param_0', '%50\%\_off%'],
+            "e.name LIKE :param_0 ESCAPE '!'",
+            ['param_0', '%50!%!_off%'],
             null,
         ];
 

--- a/tests/Unit/Query/SearchPredicateFactoryTest.php
+++ b/tests/Unit/Query/SearchPredicateFactoryTest.php
@@ -40,8 +40,17 @@ final class SearchPredicateFactoryTest extends TestCase
             null,
             'hello',
             false,
-            'e.name LIKE :p_0',
+            "e.name LIKE :p_0 ESCAPE '\\'",
             ['p_0', '%hello%'],
+        ];
+
+        yield 'text column with like wildcards is escaped, not interpreted' => [
+            TextColumn::new('name', 'Name')->setField('name'),
+            null,
+            '50%_off',
+            false,
+            "e.name LIKE :p_0 ESCAPE '\\'",
+            ['p_0', '%50\%\_off%'],
         ];
 
         yield 'numeric column with numeric value' => [

--- a/tests/Unit/Query/SearchPredicateFactoryTest.php
+++ b/tests/Unit/Query/SearchPredicateFactoryTest.php
@@ -40,7 +40,7 @@ final class SearchPredicateFactoryTest extends TestCase
             null,
             'hello',
             false,
-            "e.name LIKE :p_0 ESCAPE '\\'",
+            "e.name LIKE :p_0 ESCAPE '!'",
             ['p_0', '%hello%'],
         ];
 
@@ -49,8 +49,8 @@ final class SearchPredicateFactoryTest extends TestCase
             null,
             '50%_off',
             false,
-            "e.name LIKE :p_0 ESCAPE '\\'",
-            ['p_0', '%50\%\_off%'],
+            "e.name LIKE :p_0 ESCAPE '!'",
+            ['p_0', '%50!%!_off%'],
         ];
 
         yield 'numeric column with numeric value' => [

--- a/tests/Unit/Query/Strategy/ComparisonSearchStrategyTest.php
+++ b/tests/Unit/Query/Strategy/ComparisonSearchStrategyTest.php
@@ -205,8 +205,29 @@ final class ComparisonSearchStrategyTest extends TestCase
         yield 'starts' => [
             ColumnControlLogic::Starts,
             'Ali',
-            'e.name LIKE :column_control_param_3',
+            "e.name LIKE :column_control_param_3 ESCAPE '\\'",
             'Ali%',
+        ];
+
+        yield 'ends' => [
+            ColumnControlLogic::Ends,
+            'ice',
+            "e.name LIKE :column_control_param_3 ESCAPE '\\'",
+            '%ice',
+        ];
+
+        yield 'notContains' => [
+            ColumnControlLogic::NotContains,
+            'ali',
+            "e.name NOT LIKE :column_control_param_3 ESCAPE '\\'",
+            '%ali%',
+        ];
+
+        yield 'starts with like wildcards is escaped, not interpreted' => [
+            ColumnControlLogic::Starts,
+            '50%_off',
+            "e.name LIKE :column_control_param_3 ESCAPE '\\'",
+            '50\%\_off%',
         ];
     }
 

--- a/tests/Unit/Query/Strategy/ComparisonSearchStrategyTest.php
+++ b/tests/Unit/Query/Strategy/ComparisonSearchStrategyTest.php
@@ -205,29 +205,29 @@ final class ComparisonSearchStrategyTest extends TestCase
         yield 'starts' => [
             ColumnControlLogic::Starts,
             'Ali',
-            "e.name LIKE :column_control_param_3 ESCAPE '\\'",
+            "e.name LIKE :column_control_param_3 ESCAPE '!'",
             'Ali%',
         ];
 
         yield 'ends' => [
             ColumnControlLogic::Ends,
             'ice',
-            "e.name LIKE :column_control_param_3 ESCAPE '\\'",
+            "e.name LIKE :column_control_param_3 ESCAPE '!'",
             '%ice',
         ];
 
         yield 'notContains' => [
             ColumnControlLogic::NotContains,
             'ali',
-            "e.name NOT LIKE :column_control_param_3 ESCAPE '\\'",
+            "e.name NOT LIKE :column_control_param_3 ESCAPE '!'",
             '%ali%',
         ];
 
         yield 'starts with like wildcards is escaped, not interpreted' => [
             ColumnControlLogic::Starts,
             '50%_off',
-            "e.name LIKE :column_control_param_3 ESCAPE '\\'",
-            '50\%\_off%',
+            "e.name LIKE :column_control_param_3 ESCAPE '!'",
+            '50!%!_off%',
         ];
     }
 

--- a/tests/Unit/Query/Strategy/ContainsSearchStrategyTest.php
+++ b/tests/Unit/Query/Strategy/ContainsSearchStrategyTest.php
@@ -77,7 +77,7 @@ final class ContainsSearchStrategyTest extends TestCase
             'text',
             3,
             'foo',
-            "e.name LIKE :column_control_param_3 ESCAPE '\\'",
+            "e.name LIKE :column_control_param_3 ESCAPE '!'",
             ['column_control_param_3', '%foo%'],
         ];
 
@@ -86,8 +86,8 @@ final class ContainsSearchStrategyTest extends TestCase
             'text',
             3,
             '50%_off',
-            "e.name LIKE :column_control_param_3 ESCAPE '\\'",
-            ['column_control_param_3', '%50\%\_off%'],
+            "e.name LIKE :column_control_param_3 ESCAPE '!'",
+            ['column_control_param_3', '%50!%!_off%'],
         ];
 
         yield 'numeric column uses exact match' => [

--- a/tests/Unit/Query/Strategy/ContainsSearchStrategyTest.php
+++ b/tests/Unit/Query/Strategy/ContainsSearchStrategyTest.php
@@ -77,8 +77,17 @@ final class ContainsSearchStrategyTest extends TestCase
             'text',
             3,
             'foo',
-            'e.name LIKE :column_control_param_3',
+            "e.name LIKE :column_control_param_3 ESCAPE '\\'",
             ['column_control_param_3', '%foo%'],
+        ];
+
+        yield 'text column with like wildcards is escaped, not interpreted' => [
+            TextColumn::new('name')->setField('name'),
+            'text',
+            3,
+            '50%_off',
+            "e.name LIKE :column_control_param_3 ESCAPE '\\'",
+            ['column_control_param_3', '%50\%\_off%'],
         ];
 
         yield 'numeric column uses exact match' => [


### PR DESCRIPTION
- Adds LikeValueEscaper (src/Query/): escapes the escape character itself, %, and _ (in that order, so introduced backslashes are never re-escaped) before a value is wrapped in a LIKE pattern.
Every generated LIKE condition now also appends ESCAPE '\' — the escaping only takes effect once the database is told which character marks an escape sequence.
- Applied at all three LIKE-building call sites: SearchConditionBuilder::text() (global search and standard column search), ComparisonSearchStrategy (ColumnControl's Starts/Ends/NotContains logics), and TextFilter. Non-LIKE paths (numeric, UUID, date comparisons, Equal/NotEqual/etc.) are untouched.
Closes #336