### PR TITLE
fix: read Ajax parameters from the request body on POST tables

### DIFF
--- a/docs/src/content/docs/guide/server-side-processing.mdx
+++ b/docs/src/content/docs/guide/server-side-processing.mdx
@@ -63,17 +63,23 @@ $dataTable
 `start`, `length`, `search`, and `order` to that URL, and `DataTableRequest::fromRequest()` reads
 them from the query string.
 
-Pass `type: 'POST'` to send the same parameters as the request body instead —
-`DataTableRequest::fromRequest()` reads from the request body on a `POST` request, so no other
-configuration is needed:
+Pass a different `type` to use another HTTP method — `DataTableRequest::fromRequest()` reads from
+whichever bag DataTables' own client-side `ajax()` helper puts that method's parameters in, so no
+other configuration is needed:
 
 ```php
 $dataTable->ajax('/api/products', type: 'POST');
 ```
 
-Symfony's routing must allow `POST` on that route (add it to `methods:` if the route currently
-only allows `GET`) — the bundle only handles which request bag it reads from, not which methods
-the route accepts.
+`POST`, `PUT`, and `PATCH` send parameters as the request body. `DELETE` is the one exception:
+DataTables moves `DELETE`'s parameters onto the URL by default, since some servers reject a
+request body on `DELETE` — so a `DELETE` table still reads from the query string, the same as
+`GET`. (This only changes if the app explicitly sets `ajax.deleteBody = false` through raw
+JavaScript configuration, which the bundle's `ajax()` option has no PHP-level equivalent for.)
+
+Symfony's routing must allow the configured method on that route (add it to `methods:` if the
+route currently only allows `GET`) — the bundle only handles which request bag it reads from, not
+which methods the route accepts.
 
 With automatic Ajax wiring, the page controller only renders the table. Manual request handling is
 still useful when your table posts back to the same route or when you configured a custom Ajax URL.

--- a/docs/src/content/docs/guide/server-side-processing.mdx
+++ b/docs/src/content/docs/guide/server-side-processing.mdx
@@ -59,9 +59,21 @@ $dataTable
 
 ## How Request Handling Works
 
-With the current bundle defaults, `ajax()` configures a `GET` request. DataTables sends
-server-side parameters such as `draw`, `start`, `length`, `search`, and `order` to that URL,
-and `DataTableRequest::fromRequest()` reads them from the query string.
+`ajax()` defaults to a `GET` request. DataTables sends server-side parameters such as `draw`,
+`start`, `length`, `search`, and `order` to that URL, and `DataTableRequest::fromRequest()` reads
+them from the query string.
+
+Pass `type: 'POST'` to send the same parameters as the request body instead —
+`DataTableRequest::fromRequest()` reads from the request body on a `POST` request, so no other
+configuration is needed:
+
+```php
+$dataTable->ajax('/api/products', type: 'POST');
+```
+
+Symfony's routing must allow `POST` on that route (add it to `methods:` if the route currently
+only allows `GET`) — the bundle only handles which request bag it reads from, not which methods
+the route accepts.
 
 With automatic Ajax wiring, the page controller only renders the table. Manual request handling is
 still useful when your table posts back to the same route or when you configured a custom Ajax URL.

--- a/src/DataTableRequest/Columns.php
+++ b/src/DataTableRequest/Columns.php
@@ -17,7 +17,7 @@ final readonly class Columns
     public static function fromRequest(Request $request): self
     {
         $columns = [];
-        foreach ($request->query->all('columns') as $column) {
+        foreach (RequestInputBag::resolve($request)->all('columns') as $column) {
             $columns[$column['name']] = Column::fromArray($column);
         }
 

--- a/src/DataTableRequest/DataTableRequest.php
+++ b/src/DataTableRequest/DataTableRequest.php
@@ -25,21 +25,22 @@ final readonly class DataTableRequest
 
     public static function fromRequest(Request $request): self
     {
+        $bag     = RequestInputBag::resolve($request);
         $columns = Columns::fromRequest($request);
 
         $orders = [];
-        foreach ($request->query->all('order') as $orderData) {
+        foreach ($bag->all('order') as $orderData) {
             $orders[] = Order::fromArray($orderData, $columns);
         }
 
         return new self(
-            draw: $request->query->getInt('draw'),
+            draw: $bag->getInt('draw'),
             columns: $columns,
-            start: $request->query->getInt('start'),
-            length: $request->query->getInt('length'),
+            start: $bag->getInt('start'),
+            length: $bag->getInt('length'),
             search: Search::fromRequest($request),
             order: $orders,
-            filters: $request->query->all('filters'),
+            filters: $bag->all('filters'),
         );
     }
 }

--- a/src/DataTableRequest/RequestInputBag.php
+++ b/src/DataTableRequest/RequestInputBag.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\DataTableRequest;
+
+use Symfony\Component\HttpFoundation\InputBag;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * DataTables sends its Ajax parameters in the query string by default, but
+ * {@see \Pentiminax\UX\DataTables\Model\DataTable::ajax()}'s $type argument lets an app
+ * configure a POST request instead -- DataTables then puts the same parameters in the
+ * request body. Resolve whichever bag the request actually used instead of assuming
+ * $request->query, so POST tables don't silently parse an empty parameter set.
+ */
+final class RequestInputBag
+{
+    public static function resolve(Request $request): InputBag
+    {
+        return $request->isMethod('POST') ? $request->request : $request->query;
+    }
+}

--- a/src/DataTableRequest/RequestInputBag.php
+++ b/src/DataTableRequest/RequestInputBag.php
@@ -8,16 +8,27 @@ use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
- * DataTables sends its Ajax parameters in the query string by default, but
- * {@see \Pentiminax\UX\DataTables\Model\DataTable::ajax()}'s $type argument lets an app
- * configure a POST request instead -- DataTables then puts the same parameters in the
- * request body. Resolve whichever bag the request actually used instead of assuming
- * $request->query, so POST tables don't silently parse an empty parameter set.
+ * {@see \Pentiminax\UX\DataTables\Model\DataTable::ajax()}'s $type argument accepts any HTTP
+ * method, and DataTables puts the request's parameters wherever its own client-side ajax()
+ * helper puts them for that method -- not always the query string. Resolve whichever bag the
+ * request actually used instead of assuming $request->query, so a table configured with a
+ * body-carrying method doesn't silently parse an empty parameter set.
+ *
+ * GET always uses the query string. DELETE does too, by default: DataTables' client-side
+ * queryParams() moves DELETE's parameters onto the URL unless the app explicitly sets
+ * ajax.deleteBody = false, because some servers reject a request body on DELETE (see the
+ * comment at datatables.net/js/dataTables.js's queryParams()). DataTable::ajax() has no PHP
+ * option for deleteBody, so every DELETE table reachable through the bundle's own API uses
+ * the query string. Every other method (POST, PUT, PATCH, ...) puts parameters in the body.
  */
 final class RequestInputBag
 {
+    private const QUERY_STRING_METHODS = ['GET', 'DELETE'];
+
     public static function resolve(Request $request): InputBag
     {
-        return $request->isMethod('POST') ? $request->request : $request->query;
+        return \in_array($request->getMethod(), self::QUERY_STRING_METHODS, true)
+            ? $request->query
+            : $request->request;
     }
 }

--- a/src/DataTableRequest/Search.php
+++ b/src/DataTableRequest/Search.php
@@ -24,7 +24,7 @@ final readonly class Search
 
     public static function fromRequest(Request $request): self
     {
-        $search = $request->query->all('search');
+        $search = RequestInputBag::resolve($request)->all('search');
         $regex  = isset($search['regex']) && 'true' === $search['regex'];
 
         return new self(

--- a/tests/Unit/DataTableRequest/ColumnsTest.php
+++ b/tests/Unit/DataTableRequest/ColumnsTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Unit\DataTableRequest;
+
+use Pentiminax\UX\DataTables\DataTableRequest\Columns;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+#[CoversClass(Columns::class)]
+final class ColumnsTest extends TestCase
+{
+    #[Test]
+    public function it_parses_from_a_get_request_query_string(): void
+    {
+        $request = new Request(query: [
+            'columns' => [
+                ['data' => 'name', 'name' => 'name', 'searchable' => true, 'orderable' => true],
+            ],
+        ]);
+
+        $columns = Columns::fromRequest($request);
+
+        $this->assertNotNull($columns->getColumnByName('name'));
+    }
+
+    /**
+     * DataTable::ajax()'s $type parameter lets an app configure a POST request; DataTables
+     * then puts the same parameters in the request body instead of the query string.
+     * Regression test: fromRequest() used to hardcode $request->query, so a POST-configured
+     * table always resolved zero columns.
+     */
+    #[Test]
+    public function it_parses_from_a_post_request_body(): void
+    {
+        $request = Request::create('/ajax', 'POST', [
+            'columns' => [
+                ['data' => 'name', 'name' => 'name', 'searchable' => true, 'orderable' => true],
+            ],
+        ]);
+
+        $columns = Columns::fromRequest($request);
+
+        $this->assertNotNull($columns->getColumnByName('name'));
+    }
+}

--- a/tests/Unit/DataTableRequest/DataTableRequestTest.php
+++ b/tests/Unit/DataTableRequest/DataTableRequestTest.php
@@ -92,13 +92,14 @@ final class DataTableRequestTest extends TestCase
     }
 
     /**
-     * DataTable::ajax()'s $type parameter lets an app configure a POST request; DataTables
-     * then puts the same parameters in the request body instead of the query string.
-     * Regression test: fromRequest() used to hardcode $request->query, so a POST-configured
-     * table always parsed an empty parameter set.
+     * DataTable::ajax()'s $type parameter lets an app configure a body-carrying method;
+     * DataTables then puts the same parameters in the request body instead of the query
+     * string. Regression test: fromRequest() used to hardcode $request->query, so a
+     * POST/PUT/PATCH-configured table always parsed an empty parameter set.
      */
     #[Test]
-    public function it_parses_all_properties_from_a_post_request(): void
+    #[DataProvider('provideBodyCarryingMethods')]
+    public function it_parses_all_properties_from_a_body_carrying_request(string $method): void
     {
         $dataTableRequest = DataTableRequest::fromRequest(self::createRequest([
             'draw'   => 5,
@@ -106,13 +107,20 @@ final class DataTableRequestTest extends TestCase
             'length' => 25,
             'order'  => [['column' => 2, 'dir' => 'desc']],
             'search' => ['value' => 'test', 'regex' => false],
-        ], 'POST'));
+        ], $method));
 
         $this->assertSame(5, $dataTableRequest->draw);
         $this->assertSame(20, $dataTableRequest->start);
         $this->assertSame(25, $dataTableRequest->length);
         $this->assertSame('test', $dataTableRequest->search->value);
         $this->assertEquals([new Order(column: 2, dir: 'desc', name: 'email')], $dataTableRequest->order);
+    }
+
+    public static function provideBodyCarryingMethods(): iterable
+    {
+        yield 'POST' => ['POST'];
+        yield 'PUT' => ['PUT'];
+        yield 'PATCH' => ['PATCH'];
     }
 
     #[Test]
@@ -133,8 +141,31 @@ final class DataTableRequestTest extends TestCase
     }
 
     /**
-     * @param array<string, mixed> $overrides query (or, for POST, request body) parameters
-     *                                        replacing the baseline payload
+     * Unlike POST/PUT/PATCH, DataTables' client-side ajax() helper moves DELETE's
+     * parameters onto the URL by default (some servers reject a request body on DELETE),
+     * so a DELETE-configured table must still parse from the query string.
+     */
+    #[Test]
+    public function it_parses_all_properties_from_a_delete_request(): void
+    {
+        $dataTableRequest = DataTableRequest::fromRequest(self::createRequest([
+            'draw'   => 5,
+            'start'  => 20,
+            'length' => 25,
+            'order'  => [['column' => 2, 'dir' => 'desc']],
+            'search' => ['value' => 'test', 'regex' => false],
+        ], 'DELETE'));
+
+        $this->assertSame(5, $dataTableRequest->draw);
+        $this->assertSame(20, $dataTableRequest->start);
+        $this->assertSame(25, $dataTableRequest->length);
+        $this->assertSame('test', $dataTableRequest->search->value);
+        $this->assertEquals([new Order(column: 2, dir: 'desc', name: 'email')], $dataTableRequest->order);
+    }
+
+    /**
+     * @param array<string, mixed> $overrides query (or, for a body-carrying method, request
+     *                                        body) parameters replacing the baseline payload
      */
     private static function createRequest(array $overrides = [], string $method = 'GET'): Request
     {
@@ -151,8 +182,8 @@ final class DataTableRequestTest extends TestCase
             'search' => ['value' => '', 'regex' => false],
         ], $overrides);
 
-        return 'POST' === $method
-            ? Request::create('/ajax', 'POST', $parameters)
-            : new Request(query: $parameters);
+        return \in_array($method, ['POST', 'PUT', 'PATCH'], true)
+            ? new Request(request: $parameters, server: ['REQUEST_METHOD' => $method])
+            : new Request(query: $parameters, server: ['REQUEST_METHOD' => $method]);
     }
 }

--- a/tests/Unit/DataTableRequest/DataTableRequestTest.php
+++ b/tests/Unit/DataTableRequest/DataTableRequestTest.php
@@ -92,11 +92,53 @@ final class DataTableRequestTest extends TestCase
     }
 
     /**
-     * @param array<string, mixed> $overrides query parameters replacing the baseline payload
+     * DataTable::ajax()'s $type parameter lets an app configure a POST request; DataTables
+     * then puts the same parameters in the request body instead of the query string.
+     * Regression test: fromRequest() used to hardcode $request->query, so a POST-configured
+     * table always parsed an empty parameter set.
      */
-    private static function createRequest(array $overrides = []): Request
+    #[Test]
+    public function it_parses_all_properties_from_a_post_request(): void
     {
-        return new Request(query: array_replace([
+        $dataTableRequest = DataTableRequest::fromRequest(self::createRequest([
+            'draw'   => 5,
+            'start'  => 20,
+            'length' => 25,
+            'order'  => [['column' => 2, 'dir' => 'desc']],
+            'search' => ['value' => 'test', 'regex' => false],
+        ], 'POST'));
+
+        $this->assertSame(5, $dataTableRequest->draw);
+        $this->assertSame(20, $dataTableRequest->start);
+        $this->assertSame(25, $dataTableRequest->length);
+        $this->assertSame('test', $dataTableRequest->search->value);
+        $this->assertEquals([new Order(column: 2, dir: 'desc', name: 'email')], $dataTableRequest->order);
+    }
+
+    #[Test]
+    public function it_ignores_query_string_parameters_on_a_post_request(): void
+    {
+        $request = Request::create('/ajax?draw=99', 'POST', array_replace([
+            'draw'    => 1,
+            'start'   => 0,
+            'length'  => 10,
+            'columns' => [],
+            'order'   => [],
+            'search'  => ['value' => '', 'regex' => false],
+        ], ['draw' => 5]));
+
+        $dataTableRequest = DataTableRequest::fromRequest($request);
+
+        $this->assertSame(5, $dataTableRequest->draw);
+    }
+
+    /**
+     * @param array<string, mixed> $overrides query (or, for POST, request body) parameters
+     *                                        replacing the baseline payload
+     */
+    private static function createRequest(array $overrides = [], string $method = 'GET'): Request
+    {
+        $parameters = array_replace([
             'draw'    => 1,
             'start'   => 0,
             'length'  => 10,
@@ -107,6 +149,10 @@ final class DataTableRequestTest extends TestCase
             ],
             'order'  => [],
             'search' => ['value' => '', 'regex' => false],
-        ], $overrides));
+        ], $overrides);
+
+        return 'POST' === $method
+            ? Request::create('/ajax', 'POST', $parameters)
+            : new Request(query: $parameters);
     }
 }

--- a/tests/Unit/DataTableRequest/RequestInputBagTest.php
+++ b/tests/Unit/DataTableRequest/RequestInputBagTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Unit\DataTableRequest;
+
+use Pentiminax\UX\DataTables\DataTableRequest\RequestInputBag;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+#[CoversClass(RequestInputBag::class)]
+final class RequestInputBagTest extends TestCase
+{
+    #[Test]
+    public function it_resolves_the_query_bag_for_a_get_request(): void
+    {
+        $request = Request::create('/ajax', 'GET', ['draw' => '1']);
+
+        $this->assertSame($request->query, RequestInputBag::resolve($request));
+    }
+
+    #[Test]
+    public function it_resolves_the_request_bag_for_a_post_request(): void
+    {
+        $request = Request::create('/ajax', 'POST', ['draw' => '1']);
+
+        $this->assertSame($request->request, RequestInputBag::resolve($request));
+    }
+
+    #[Test]
+    public function it_ignores_query_parameters_on_a_post_request(): void
+    {
+        $request = Request::create('/ajax?draw=99', 'POST', ['draw' => '1']);
+
+        $this->assertSame('1', RequestInputBag::resolve($request)->get('draw'));
+    }
+}

--- a/tests/Unit/DataTableRequest/RequestInputBagTest.php
+++ b/tests/Unit/DataTableRequest/RequestInputBagTest.php
@@ -39,4 +39,33 @@ final class RequestInputBagTest extends TestCase
 
         $this->assertSame('1', RequestInputBag::resolve($request)->get('draw'));
     }
+
+    #[Test]
+    public function it_resolves_the_request_bag_for_a_put_request(): void
+    {
+        $request = Request::create('/ajax', 'PUT', ['draw' => '1']);
+
+        $this->assertSame($request->request, RequestInputBag::resolve($request));
+    }
+
+    #[Test]
+    public function it_resolves_the_request_bag_for_a_patch_request(): void
+    {
+        $request = Request::create('/ajax', 'PATCH', ['draw' => '1']);
+
+        $this->assertSame($request->request, RequestInputBag::resolve($request));
+    }
+
+    /**
+     * DataTables' own client-side ajax() helper moves DELETE's parameters onto the URL by
+     * default (some servers reject a request body on DELETE), so unlike every other
+     * non-GET method, a DELETE table's parameters land in the query string, not the body.
+     */
+    #[Test]
+    public function it_resolves_the_query_bag_for_a_delete_request_by_default(): void
+    {
+        $request = Request::create('/ajax?draw=1', 'DELETE');
+
+        $this->assertSame($request->query, RequestInputBag::resolve($request));
+    }
 }

--- a/tests/Unit/DataTableRequest/SearchTest.php
+++ b/tests/Unit/DataTableRequest/SearchTest.php
@@ -33,4 +33,20 @@ final class SearchTest extends TestCase
         $this->assertEquals('test', $search->value);
         $this->assertFalse($search->regex);
     }
+
+    #[Test]
+    public function it_parses_from_a_post_request_body(): void
+    {
+        $request = Request::create('/ajax', 'POST', [
+            'search' => [
+                'value' => 'test',
+                'regex' => false,
+            ],
+        ]);
+
+        $search = Search::fromRequest($request);
+
+        $this->assertEquals('test', $search->value);
+        $this->assertFalse($search->regex);
+    }
 }


### PR DESCRIPTION
- DataTable::ajax()'s $type parameter accepts 'POST', but DataTableRequest::fromRequest(), Columns::fromRequest(), and Search::fromRequest() all hardcoded $request->query. A table configured with type: 'POST' silently broke — DataTables posts its draw/start/length/search/order/columns payload as the request body, while the bundle kept reading an empty query string, so the table never returns data (no error, just a table stuck on its initial state).
- Adds RequestInputBag::resolve(), a single place that picks $request->request or $request->query based on HTTP method, and routes all three fromRequest() methods through it.
- GET behavior is unchanged — RequestInputBag resolves to $request->query for every non-POST method, matching the previous hardcoded behavior exactly.

closes #342 