### PR TITLE
fix: accept a list<int> for ColReorderExtension's $columns, not just a string

### DIFF
--- a/docs/src/content/docs/extensions/col-reorder.mdx
+++ b/docs/src/content/docs/extensions/col-reorder.mdx
@@ -27,8 +27,9 @@ $dataTable->addExtension(
 
 `enable: false` loads ColReorder but leaves it initially disabled — pair with the DataTables API
 (`dt.colReorder.enable()` / `.disable()`, e.g. from a `Button::custom()` toggle) to lock and unlock
-reordering at runtime. `columns` is a DataTables column-selector string restricting which columns
-can be dragged; the default `''` allows every column.
+reordering at runtime. `columns` restricts which columns can be dragged, either as a DataTables
+column-selector string (`':not(:first-child)'`) or a plain list of column indexes (`[1, 2, 3]`);
+the default `''` allows every column.
 
 ```php
 $dataTable->addExtension(

--- a/skills/ux-datatables/references/extensions.md
+++ b/skills/ux-datatables/references/extensions.md
@@ -88,8 +88,9 @@ new ColReorderExtension(enable: true, columns: '', headerRows: null, order: null
 ```
 
 `enable: false` loads ColReorder locked; toggle at runtime with the JS API
-(`dt.colReorder.enable()`/`.disable()`, e.g. via `Button::custom()`). `columns` is a DataTables
-column-selector string restricting which columns can be dragged. `headerRows` restricts reordering
+(`dt.colReorder.enable()`/`.disable()`, e.g. via `Button::custom()`). `columns` restricts which
+columns can be dragged: a DataTables column-selector string or a plain `list<int>` of column
+indexes. `headerRows` restricts reordering
 to specific header row indexes (multi-row headers); `order` sets the initial column order (original
 indexes in their new positions). Both default to `null` (every row / document order) and are
 omitted from the payload unless set.

--- a/src/Model/Extensions/ColReorderExtension.php
+++ b/src/Model/Extensions/ColReorderExtension.php
@@ -7,14 +7,17 @@ namespace Pentiminax\UX\DataTables\Model\Extensions;
 class ColReorderExtension extends AbstractExtension
 {
     /**
-     * @param list<int>|null $headerRows restricts reordering to these header row indexes, or null
-     *                                   for every row
-     * @param list<int>|null $order      initial column order (original column indexes in their new
-     *                                   positions), or null to keep document order
+     * @param string|list<int> $columns    column selector restricting which columns end users can
+     *                                     reorder — a DataTables column-selector string (e.g.
+     *                                     ':not(:first-child)') or a list of column indexes
+     * @param list<int>|null   $headerRows restricts reordering to these header row indexes, or null
+     *                                     for every row
+     * @param list<int>|null   $order      initial column order (original column indexes in their
+     *                                     new positions), or null to keep document order
      */
     public function __construct(
         private readonly bool $enable = true,
-        private readonly string $columns = '',
+        private readonly string|array $columns = '',
         private readonly ?array $headerRows = null,
         private readonly ?array $order = null,
     ) {

--- a/tests/Unit/Model/Extensions/ColReorderExtensionTest.php
+++ b/tests/Unit/Model/Extensions/ColReorderExtensionTest.php
@@ -37,6 +37,23 @@ final class ColReorderExtensionTest extends TestCase
         ], $extension->jsonSerialize());
     }
 
+    /**
+     * DataTables' colReorder.columns option is a column-selector, which natively accepts a
+     * list of column indexes as well as a selector string -- the constructor only accepted a
+     * string, forcing callers to build a selector expression for what is otherwise a plain
+     * list<int>, the same shape Button::colVis()->option('columns', ...) already accepts.
+     */
+    #[Test]
+    public function it_serializes_a_list_of_column_indexes(): void
+    {
+        $extension = new ColReorderExtension(columns: [0, 2, 3]);
+
+        $this->assertSame([
+            'enable'  => true,
+            'columns' => [0, 2, 3],
+        ], $extension->jsonSerialize());
+    }
+
     #[Test]
     public function it_omits_header_rows_and_order_when_not_set(): void
     {


### PR DESCRIPTION
colReorder.columns is a DataTables ColumnSelector, which genuinely accepts a plain array of column indexes alongside a selector string — the constructor only typed it as string, forcing callers who just want "these three columns" to build a selector expression instead of passing the list<int> they already have.
Checked the other three constructor parameters - they already match their real JS types exactly — columns was the only one under-typed.
Widened to string|list<int> rather than the full ColumnSelector union (which also permits a DOM node, jQuery object, selector function, etc.) — those remaining variants aren't meaningfully different from a selector string in this bundle's usage, or aren't JSON-serializable from PHP at all.

Other extensions with similar settings were already correct, this one just got missed :(