### PR TITLE
fix: move AbstractColumn's @internal off the class onto createWithType() only

### DIFF
--- a/src/Column/AbstractColumn.php
+++ b/src/Column/AbstractColumn.php
@@ -9,7 +9,15 @@ use Pentiminax\UX\DataTables\Contracts\PermissionAwareColumnInterface;
 use Pentiminax\UX\DataTables\Enum\ColumnType;
 
 /**
- * @internal
+ * Base implementation shared by every bundled column type (TextColumn, DateColumn, ...).
+ *
+ * Not meant to be extended directly to build a custom column type — extend a concrete column
+ * class instead, or implement {@see ColumnInterface} directly for something that shares nothing
+ * with the bundled types. Every public method here (setField(), setColumnControl(),
+ * setClassName(), setCustomOption(), setVisible(), disableGlobalSearch(), ...) is part of the
+ * bundle's documented column-configuration API and is inherited unchanged by every concrete
+ * column — see the "Columns" documentation for usage. Only createWithType() below is genuinely
+ * internal, restricted to how the bundled column types build themselves.
  */
 abstract class AbstractColumn implements ColumnInterface, PermissionAwareColumnInterface
 {

--- a/tests/Unit/Column/AbstractColumnTest.php
+++ b/tests/Unit/Column/AbstractColumnTest.php
@@ -147,4 +147,23 @@ final class AbstractColumnTest extends TestCase
         $this->assertSame('ROLE_HR', $column->getPermission());
         $this->assertArrayNotHasKey('permission', $column->jsonSerialize());
     }
+
+    /**
+     * setField(), setColumnControl(), setClassName(), setCustomOption(), setVisible(), and
+     * disableGlobalSearch() are documented public API (see columns/overview.mdx) inherited
+     * unchanged by every concrete column type. A class-level @internal here previously made
+     * static analysis tools such as Psalm flag every one of those calls from application code
+     * as touching an internal class, even though only createWithType() is actually meant to
+     * stay restricted to the bundle's own column types.
+     */
+    #[Test]
+    public function the_class_itself_is_not_marked_internal_but_create_with_type_still_is(): void
+    {
+        $class = new \ReflectionClass(AbstractColumn::class);
+
+        $this->assertStringNotContainsString('@internal', (string) $class->getDocComment());
+
+        $factory = $class->getMethod('createWithType');
+        $this->assertStringContainsString('@internal', (string) $factory->getDocComment());
+    }
 }


### PR DESCRIPTION
- AbstractColumn carried a class-level @internal, but its public methods (setField(), setColumnControl(), setClassName(), setCustomOption(), setVisible(), disableGlobalSearch(), ...) are the bundle's own documented column-configuration API — columns/overview.mdx teaches users to call these exact methods via concrete subclasses (TextColumn, DateColumn, ...), which inherit them unchanged. Psalm respects @internal at the class level regardless of which method is called, so every documented call gets flagged in any consumer running strict internal-class checks.
- The class-level @internal was really trying to say "don't extend this class directly to build your own column type," not "don't call these methods" — two different constraints, one annotation.
- Moved @internal off the class and onto createWithType() specifically (which already had its own method-level @internal), matching how this repo already annotates internal-but-narrower surface elsewhere (DataTable::getExtensionsCollection(), QueryFilterContext::resetParamIndexScope()).
- No @api-style marker was added instead — Psalm has no annotation that un-internals a method while its class stays internal, so only removing the class-level tag actually changes what gets flagged.
- 
closes #347 