### PR TITLE
fix: match ColumnControl searchList's empty value against IS NULL, not IN ('')

### DIFF
--- a/src/Query/Filter/ColumnControlSearchFilter.php
+++ b/src/Query/Filter/ColumnControlSearchFilter.php
@@ -22,6 +22,13 @@ use Pentiminax\UX\DataTables\Query\UuidSearchTerm;
  * expand to typed equalities so invalid terms never reach setParameter() and
  * binary identifier types still match. Scalar criteria delegate to the registered
  * search strategy for their logic.
+ *
+ * A list value of '' (the empty string) is matched with IS NULL rather than being
+ * bound into the IN clause: an optional relation's dot-path field (e.g. a
+ * ColumnControl searchList option representing "no value assigned") resolves to
+ * NULL through its LEFT JOIN, never to an empty string, so IN ('') would silently
+ * match nothing. This mirrors ColumnControl's own client-side convention, where an
+ * option with an empty label/value already renders as a distinct "Empty" entry.
  */
 final class ColumnControlSearchFilter implements QueryFilterInterface
 {
@@ -68,11 +75,31 @@ final class ColumnControlSearchFilter implements QueryFilterInterface
             return;
         }
 
-        $expr      = RelationFieldResolver::resolve($qb, $alias, $field);
+        $expr           = RelationFieldResolver::resolve($qb, $alias, $field);
+        $nonEmptyValues = array_values(array_filter($values, static fn (mixed $value): bool => '' !== $value));
+
+        if (\count($nonEmptyValues) === \count($values)) {
+            $paramName = \sprintf(':%s_in', str_replace('.', '_', $field));
+
+            $qb->andWhere(\sprintf('%s IN (%s)', $expr, $paramName));
+            $qb->setParameter($paramName, $values);
+
+            return;
+        }
+
+        if ([] === $nonEmptyValues) {
+            $qb->andWhere($qb->expr()->isNull($expr));
+
+            return;
+        }
+
         $paramName = \sprintf(':%s_in', str_replace('.', '_', $field));
 
-        $qb->andWhere(\sprintf('%s IN (%s)', $expr, $paramName));
-        $qb->setParameter($paramName, $values);
+        $qb->andWhere($qb->expr()->orX(
+            \sprintf('%s IN (%s)', $expr, $paramName),
+            $qb->expr()->isNull($expr),
+        ));
+        $qb->setParameter($paramName, $nonEmptyValues);
     }
 
     /**

--- a/tests/Unit/Query/Filter/ColumnControlSearchFilterTest.php
+++ b/tests/Unit/Query/Filter/ColumnControlSearchFilterTest.php
@@ -95,6 +95,34 @@ final class ColumnControlSearchFilterTest extends TestCase
         $this->applyList($qb, TextColumn::new('name')->setField('name'), ['acme', 'beta']);
     }
 
+    #[Test]
+    public function it_matches_is_null_for_a_text_column_list_of_only_the_empty_value(): void
+    {
+        $qb = $this->queryBuilderWithFieldType('name', 'string');
+        $qb->method('expr')->willReturn(new Expr());
+        $qb->expects($this->once())
+            ->method('andWhere')
+            ->with(new Expr\Comparison('e.name', 'IS', 'NULL'));
+        $qb->expects($this->never())->method('setParameter');
+
+        $this->applyList($qb, TextColumn::new('name')->setField('name'), ['']);
+    }
+
+    #[Test]
+    public function it_combines_an_in_clause_with_is_null_when_the_empty_value_is_selected_alongside_others(): void
+    {
+        $qb = $this->queryBuilderWithFieldType('name', 'string');
+        $qb->method('expr')->willReturn(new Expr());
+        $qb->expects($this->once())
+            ->method('andWhere')
+            ->with(new Expr\Orx(['e.name IN (:name_in)', new Expr\Comparison('e.name', 'IS', 'NULL')]));
+        $qb->expects($this->once())
+            ->method('setParameter')
+            ->with(':name_in', ['acme']);
+
+        $this->applyList($qb, TextColumn::new('name')->setField('name'), ['acme', '']);
+    }
+
     /**
      * Column Control searchList on a native UUID/ULID column used to bind the raw list
      * with IN. An empty option or a partial identifier then 500s (SQLSTATE 22P02 /


### PR DESCRIPTION
- Splits the selected values in applyList(): a lone '' now compiles to an IS NULL predicate; '' mixed with real values compiles to (field IN (:values) OR field IS NULL); no '' present keeps the exact original IN (:values) SQL/param name, so the existing IN-only behavior is untouched.
- Only the plain list branch (applyList()) changes — the native UUID/ULID branch (applyUuidList()) already drops an unparsable empty string before it reaches setParameter(), so identifier-column list search is unaffected.
- Additive: only list payloads that actually contain '' take the new branches; every other list search keeps generating the identical SQL it always has.

Closes #349 