### PR TITLE
feat: collect AJAX queries in the profiler regardless of which controller serves them and verify no-op when no debug/profiling

### DIFF
--- a/config/profiler.php
+++ b/config/profiler.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Pentiminax\UX\DataTables\DataCollector\DataTableCollector;
+use Pentiminax\UX\DataTables\Profiler\DataTableProfiler;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+/**
+ * Only imported when kernel.debug is true (see DataTablesBundle::loadExtension()) -- these
+ * services eagerly record rendered tables and AJAX queries on every request via direct calls
+ * from application code, not just when Symfony's own profiler pulls a collect(), so they
+ * cannot be left registered unconditionally without a real (if small) per-request cost in
+ * production. Every consumer of datatables.profiler (DataTablesExtension, AbstractDataTable,
+ * DataTableInfrastructure) already treats it as optional and no-ops when it is absent, so
+ * this import guard is the only thing standing between debug-only and always-on.
+ */
+return static function (ContainerConfigurator $container): void {
+    $services = $container->services();
+
+    $services->set('datatables.profiler', DataTableProfiler::class)
+        ->tag('kernel.reset', ['method' => 'reset'])
+        ->private();
+
+    $services->set('datatables.data_collector', DataTableCollector::class)
+        ->arg(0, service('datatables.profiler'))
+        ->tag('data_collector', [
+            'id'       => 'datatables',
+            'template' => '@DataTables/Collector/data_collector.html.twig',
+        ])
+        ->private();
+};

--- a/config/services.php
+++ b/config/services.php
@@ -193,7 +193,6 @@ return static function (ContainerConfigurator $container): void {
 
     $services->set('datatables.controller.ajax_data', AjaxDataController::class)
         ->arg(0, service('datatables.ajax.registry'))
-        ->arg(1, service('datatables.profiler'))
         ->tag('controller.service_arguments')
         ->public();
 
@@ -297,6 +296,7 @@ return static function (ContainerConfigurator $container): void {
         ->arg(3, service('datatables.query.intent_factory'))
         ->arg(4, service('datatables.query.filter_pipeline'))
         ->arg(5, service('datatables.builder'))
+        ->arg(6, service('datatables.profiler'))
         ->private();
 
     $services->alias(DataTableInfrastructure::class, 'datatables.infrastructure')

--- a/config/services.php
+++ b/config/services.php
@@ -18,7 +18,6 @@ use Pentiminax\UX\DataTables\Controller\AjaxDeleteController;
 use Pentiminax\UX\DataTables\Controller\AjaxDetailController;
 use Pentiminax\UX\DataTables\Controller\AjaxEditController;
 use Pentiminax\UX\DataTables\Controller\AjaxTemplateRenderController;
-use Pentiminax\UX\DataTables\DataCollector\DataTableCollector;
 use Pentiminax\UX\DataTables\DataProvider\AutoDataProviderFactory;
 use Pentiminax\UX\DataTables\DataProvider\DataProviderResolver;
 use Pentiminax\UX\DataTables\Detail\DetailRowService;
@@ -30,7 +29,6 @@ use Pentiminax\UX\DataTables\Mercure\NullMercurePublisher;
 use Pentiminax\UX\DataTables\Mutation\BooleanMutationContextResolver;
 use Pentiminax\UX\DataTables\Mutation\EntityLocator;
 use Pentiminax\UX\DataTables\Mutation\EntityMutator;
-use Pentiminax\UX\DataTables\Profiler\DataTableProfiler;
 use Pentiminax\UX\DataTables\Query\Builder\QueryFilterPipeline;
 use Pentiminax\UX\DataTables\Query\Intent\DataTableQueryIntentFactoryInterface;
 use Pentiminax\UX\DataTables\Query\Intent\DefaultDataTableQueryIntentFactory;
@@ -58,18 +56,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 return static function (ContainerConfigurator $container): void {
     $services = $container->services();
-
-    $services->set('datatables.profiler', DataTableProfiler::class)
-        ->tag('kernel.reset', ['method' => 'reset'])
-        ->private();
-
-    $services->set('datatables.data_collector', DataTableCollector::class)
-        ->arg(0, service('datatables.profiler'))
-        ->tag('data_collector', [
-            'id'       => 'datatables',
-            'template' => '@DataTables/Collector/data_collector.html.twig',
-        ])
-        ->private();
 
     $services->set('datatables.builder', DataTableBuilder::class)
         ->arg(0, param('datatables.options'))
@@ -296,7 +282,7 @@ return static function (ContainerConfigurator $container): void {
         ->arg(3, service('datatables.query.intent_factory'))
         ->arg(4, service('datatables.query.filter_pipeline'))
         ->arg(5, service('datatables.builder'))
-        ->arg(6, service('datatables.profiler'))
+        ->arg(6, service('datatables.profiler')->nullOnInvalid())
         ->private();
 
     $services->alias(DataTableInfrastructure::class, 'datatables.infrastructure')

--- a/src/Controller/AjaxDataController.php
+++ b/src/Controller/AjaxDataController.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Pentiminax\UX\DataTables\Controller;
 
 use Pentiminax\UX\DataTables\Ajax\AjaxDataTableRegistry;
-use Pentiminax\UX\DataTables\Model\AbstractDataTable;
-use Pentiminax\UX\DataTables\Profiler\DataTableProfiler;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -16,10 +14,15 @@ final class AjaxDataController
 {
     public function __construct(
         private readonly AjaxDataTableRegistry $registry,
-        private readonly DataTableProfiler $profiler,
     ) {
     }
 
+    /**
+     * Profiler collection happens inside {@see AbstractDataTable::getResponse()} itself, not
+     * here -- that way a custom ajax() endpoint calling handleRequest()/getResponse() directly
+     * (bypassing this controller entirely) still gets profiled, which this controller alone
+     * could never guarantee.
+     */
     public function __invoke(Request $request): JsonResponse
     {
         $token = $request->query->getString('table');
@@ -34,42 +37,12 @@ final class AjaxDataController
             throw new NotFoundHttpException('DataTable not found.');
         }
 
-        $start = hrtime(true);
-
         $table->handleRequest($request);
 
         if (!$table->isRequestHandled()) {
             throw new BadRequestHttpException('Invalid DataTables request.');
         }
 
-        $response = $table->getResponse();
-
-        $this->collect($table, $token, $response, $start);
-
-        return $response;
-    }
-
-    private function collect(AbstractDataTable $table, string $token, JsonResponse $response, float $start): void
-    {
-        $durationMs = (hrtime(true) - $start) / 1_000_000;
-
-        $payload = json_decode((string) $response->getContent(), true);
-        $payload = \is_array($payload) ? $payload : [];
-
-        $provider = $table->getDataProvider();
-
-        $this->profiler->collectAjaxQuery(
-            class: $table::class,
-            token: $token,
-            request: $table->getRequest(),
-            recordsTotal: (int) ($payload['recordsTotal'] ?? 0),
-            recordsFiltered: (int) ($payload['recordsFiltered'] ?? 0),
-            durationMs: $durationMs,
-            providerClass: null !== $provider ? $provider::class : null,
-            entityClass: $table->getEntityClass(),
-            rowCount: \is_array($payload['data'] ?? null) ? \count($payload['data']) : 0,
-            payloadBytes: \strlen((string) $response->getContent()),
-            httpStatus: $response->getStatusCode(),
-        );
+        return $table->getResponse();
     }
 }

--- a/src/DataTablesBundle.php
+++ b/src/DataTablesBundle.php
@@ -109,6 +109,13 @@ class DataTablesBundle extends AbstractBundle
 
         $container->import('../config/services.php');
 
+        // Profiler/data-collector recording is a direct, eager call from application code
+        // (not just a pull triggered by Symfony's own profiler), so it is only worth the
+        // per-request cost when kernel.debug is on -- see config/profiler.php.
+        if ($builder->getParameter('kernel.debug')) {
+            $container->import('../config/profiler.php');
+        }
+
         if ($this->isApiPlatformAvailable($builder)) {
             $container->import('../config/api_platform.php');
         }

--- a/src/Model/AbstractDataTable.php
+++ b/src/Model/AbstractDataTable.php
@@ -481,12 +481,19 @@ abstract class AbstractDataTable
         $payload = json_decode((string) $response->getContent(), true);
         $payload = \is_array($payload) ? $payload : [];
 
-        $provider = $this->getDataProvider();
+        // Mirrors DataTableRuntime::getResponse()'s own guard: it only resolves a data
+        // provider once a request has actually been handled, short-circuiting to the empty
+        // response otherwise. Resolving unconditionally here would call getDataProvider()
+        // even on that empty-response path -- for an attributed table with no manual
+        // provider and no EntityManager, resolution throws, so getResponse() would behave
+        // differently depending on whether a profiler happens to be wired.
+        $request  = $this->getRequest();
+        $provider = null !== $request ? $this->getDataProvider() : null;
 
         $profiler->collectAjaxQuery(
             class: static::class,
             token: $this->getHttpRequest()?->query->getString('table') ?: null,
-            request: $this->getRequest(),
+            request: $request,
             recordsTotal: (int) ($payload['recordsTotal'] ?? 0),
             recordsFiltered: (int) ($payload['recordsFiltered'] ?? 0),
             durationMs: (hrtime(true) - $start) / 1_000_000,

--- a/src/Model/AbstractDataTable.php
+++ b/src/Model/AbstractDataTable.php
@@ -140,7 +140,12 @@ abstract class AbstractDataTable
 
     public function getResponse(): JsonResponse
     {
-        return $this->runtime()->getResponse();
+        $start    = hrtime(true);
+        $response = $this->runtime()->getResponse();
+
+        $this->collectAjaxQueryForProfiler($response, $start);
+
+        return $response;
     }
 
     public function prepareForRendering(): void
@@ -457,6 +462,40 @@ abstract class AbstractDataTable
     private function infrastructure(): DataTableInfrastructure
     {
         return $this->infrastructure ??= DataTableInfrastructure::createDefault();
+    }
+
+    /**
+     * Records this Ajax response with the Web Profiler, regardless of which route or
+     * controller called getResponse() -- the bundle's own AjaxDataController, or a custom
+     * ajax() endpoint that calls handleRequest()/getResponse() directly. A no-op when no
+     * profiler is wired (e.g. a table built outside the bundle's DI container).
+     */
+    private function collectAjaxQueryForProfiler(JsonResponse $response, float $start): void
+    {
+        $profiler = $this->infrastructure()->profiler();
+
+        if (null === $profiler) {
+            return;
+        }
+
+        $payload = json_decode((string) $response->getContent(), true);
+        $payload = \is_array($payload) ? $payload : [];
+
+        $provider = $this->getDataProvider();
+
+        $profiler->collectAjaxQuery(
+            class: static::class,
+            token: $this->getHttpRequest()?->query->getString('table') ?: null,
+            request: $this->getRequest(),
+            recordsTotal: (int) ($payload['recordsTotal'] ?? 0),
+            recordsFiltered: (int) ($payload['recordsFiltered'] ?? 0),
+            durationMs: (hrtime(true) - $start) / 1_000_000,
+            providerClass: null !== $provider ? $provider::class : null,
+            entityClass: $this->getEntityClass(),
+            rowCount: \is_array($payload['data'] ?? null) ? \count($payload['data']) : 0,
+            payloadBytes: \strlen((string) $response->getContent()),
+            httpStatus: $response->getStatusCode(),
+        );
     }
 
     private function configureActionColumn(Actions $actions): void

--- a/src/Runtime/DataTableInfrastructure.php
+++ b/src/Runtime/DataTableInfrastructure.php
@@ -7,6 +7,7 @@ namespace Pentiminax\UX\DataTables\Runtime;
 use Pentiminax\UX\DataTables\Builder\DataTableBuilder;
 use Pentiminax\UX\DataTables\Column\ColumnResolver;
 use Pentiminax\UX\DataTables\Contracts\DataTableBuilderInterface;
+use Pentiminax\UX\DataTables\Profiler\DataTableProfiler;
 use Pentiminax\UX\DataTables\Query\Builder\QueryFilterPipeline;
 use Pentiminax\UX\DataTables\Query\Intent\DataTableQueryIntentFactoryInterface;
 use Pentiminax\UX\DataTables\Query\Intent\DefaultDataTableQueryIntentFactory;
@@ -21,6 +22,7 @@ final class DataTableInfrastructure
         private readonly DataTableQueryIntentFactoryInterface $queryIntentFactory,
         private readonly QueryFilterPipeline $queryFilterPipeline,
         private ?DataTableBuilderInterface $builder = null,
+        private readonly ?DataTableProfiler $profiler = null,
     ) {
     }
 
@@ -31,6 +33,7 @@ final class DataTableInfrastructure
         ?DataTableQueryIntentFactoryInterface $queryIntentFactory = null,
         ?QueryFilterPipeline $queryFilterPipeline = null,
         ?DataTableBuilderInterface $builder = null,
+        ?DataTableProfiler $profiler = null,
     ): self {
         $queryIntentFactory ??= new DefaultDataTableQueryIntentFactory();
 
@@ -41,6 +44,7 @@ final class DataTableInfrastructure
             queryIntentFactory: $queryIntentFactory,
             queryFilterPipeline: $queryFilterPipeline ?? new QueryFilterPipeline($queryIntentFactory),
             builder: $builder,
+            profiler: $profiler,
         );
     }
 
@@ -67,6 +71,16 @@ final class DataTableInfrastructure
     public function queryFilterPipeline(): QueryFilterPipeline
     {
         return $this->queryFilterPipeline;
+    }
+
+    /**
+     * Null outside a real DI container (e.g. {@see self::createDefault()} without one), so
+     * profiling is a no-op rather than a hard dependency for tables built without the bundle's
+     * service wiring.
+     */
+    public function profiler(): ?DataTableProfiler
+    {
+        return $this->profiler;
     }
 
     /**

--- a/templates/Collector/data_collector.html.twig
+++ b/templates/Collector/data_collector.html.twig
@@ -122,8 +122,9 @@
 
                 {% if table.serverSide %}
                     <p class="help">
-                        This table fetches its rows over AJAX. Its query details are collected in the
-                        profile of the AJAX request itself, reachable from the toolbar's AJAX tab, not in
+                        This table fetches its rows over AJAX — through the bundle's own endpoint or a
+                        custom ajax() URL, both are covered. Its query details are collected in the
+                        profile of that AJAX request itself, reachable from the toolbar's AJAX tab, not in
                         this page profile.
                     </p>
                 {% endif %}

--- a/tests/Kernel/ProfilerDisabledAppKernel.php
+++ b/tests/Kernel/ProfilerDisabledAppKernel.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Kernel;
+
+use Pentiminax\UX\DataTables\DataTablesBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\MercureBundle\MercureBundle;
+use Symfony\Bundle\TwigBundle\TwigBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\UX\StimulusBundle\StimulusBundle;
+
+/**
+ * Boots the bundle with kernel.debug false -- the profiler/data-collector services must not
+ * be registered at all in this configuration, proving the eager per-request recording in
+ * AbstractDataTable::getResponse() and DataTablesExtension::renderDataTable() is a true no-op
+ * in a production-like environment rather than merely unread.
+ */
+class ProfilerDisabledAppKernel extends Kernel
+{
+    public function registerBundles(): iterable
+    {
+        return [new FrameworkBundle(), new TwigBundle(), new StimulusBundle(), new DataTablesBundle(), new MercureBundle()];
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader): void
+    {
+        $loader->load(function (ContainerBuilder $container): void {
+            $container->loadFromExtension('framework', [
+                'secret'               => '$ecret',
+                'test'                 => true,
+                'http_method_override' => false,
+            ]);
+
+            $container->loadFromExtension('twig', [
+                'default_path'     => __DIR__.'/templates',
+                'strict_variables' => true,
+            ]);
+
+            $container->loadFromExtension('mercure', [
+                'hubs' => ['default' => [
+                    'url' => 'http://localhost:3000/.well-known/mercure',
+                    'jwt' => [
+                        'secret'  => 'jwt_secret',
+                        'publish' => '*',
+                    ],
+                ]],
+            ]);
+
+            $container->setAlias('test.datatables.infrastructure', 'datatables.infrastructure')->setPublic(true);
+        });
+    }
+
+    public function getCacheDir(): string
+    {
+        return sys_get_temp_dir().'/ux_datatables/profiler_disabled_cache/'.$this->environment;
+    }
+
+    public function getLogDir(): string
+    {
+        return sys_get_temp_dir().'/ux_datatables/profiler_disabled_log';
+    }
+}

--- a/tests/Unit/Controller/AjaxDataControllerTest.php
+++ b/tests/Unit/Controller/AjaxDataControllerTest.php
@@ -8,7 +8,6 @@ use Pentiminax\UX\DataTables\Ajax\AjaxDataTableRegistry;
 use Pentiminax\UX\DataTables\Ajax\AjaxDataTableTokenManager;
 use Pentiminax\UX\DataTables\Controller\AjaxDataController;
 use Pentiminax\UX\DataTables\Model\AbstractDataTable;
-use Pentiminax\UX\DataTables\Profiler\DataTableProfiler;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -27,7 +26,7 @@ final class AjaxDataControllerTest extends TestCase
     #[Test]
     public function it_throws_404_when_table_field_is_missing(): void
     {
-        $controller = new AjaxDataController($this->createRegistry(), new DataTableProfiler());
+        $controller = new AjaxDataController($this->createRegistry());
         $request    = new Request();
 
         $this->expectException(NotFoundHttpException::class);
@@ -38,7 +37,7 @@ final class AjaxDataControllerTest extends TestCase
     #[Test]
     public function it_throws_404_when_table_token_is_unknown(): void
     {
-        $controller = new AjaxDataController($this->createRegistry(), new DataTableProfiler());
+        $controller = new AjaxDataController($this->createRegistry());
         $request    = new Request(query: ['table' => 'unknown-token']);
 
         $this->expectException(NotFoundHttpException::class);
@@ -56,15 +55,10 @@ final class AjaxDataControllerTest extends TestCase
         $dataTable->expects($this->once())->method('isRequestHandled')->willReturn(true);
         $dataTable->expects($this->once())->method('getResponse')->willReturn($expectedResponse);
 
-        // The profiler reads the resolved provider, which boots the runtime.
-        $dataTable->method('configureActions')->willReturnArgument(0);
-        $dataTable->method('configureFilters')->willReturnArgument(0);
-        $dataTable->method('configureDataTable')->willReturnArgument(0);
-
         $registry = $this->createRegistry($dataTable);
         $token    = $registry->getToken('App\\UserDataTable');
 
-        $controller = new AjaxDataController($registry, new DataTableProfiler());
+        $controller = new AjaxDataController($registry);
         $response   = $controller(new Request(query: ['table' => $token, 'draw' => 1]));
 
         $this->assertSame($expectedResponse, $response);
@@ -81,7 +75,7 @@ final class AjaxDataControllerTest extends TestCase
         $registry = $this->createRegistry($dataTable);
         $token    = $registry->getToken('App\\UserDataTable');
 
-        $controller = new AjaxDataController($registry, new DataTableProfiler());
+        $controller = new AjaxDataController($registry);
 
         $this->expectException(BadRequestHttpException::class);
 

--- a/tests/Unit/DataCollector/ProfilerDisabledIntegrationTest.php
+++ b/tests/Unit/DataCollector/ProfilerDisabledIntegrationTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Unit\DataCollector;
+
+use Pentiminax\UX\DataTables\Runtime\DataTableInfrastructure;
+use Pentiminax\UX\DataTables\Tests\Kernel\ProfilerDisabledAppKernel;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+final class ProfilerDisabledIntegrationTest extends TestCase
+{
+    /**
+     * datatables.profiler and datatables.data_collector eagerly record on every request from
+     * plain application code (AbstractDataTable::getResponse(), DataTablesExtension::
+     * renderDataTable()), not just when Symfony's own profiler pulls a collect() -- so they
+     * must not exist in the container at all when kernel.debug is off, not merely go unread.
+     */
+    #[Test]
+    public function profiler_services_are_not_registered_when_debug_is_off(): void
+    {
+        $kernel = new ProfilerDisabledAppKernel('test', false);
+        $kernel->boot();
+        $container = $kernel->getContainer()->get('test.service_container');
+
+        $this->assertFalse(
+            $container->has('datatables.profiler'),
+            'datatables.profiler must not be registered when kernel.debug is false.',
+        );
+        $this->assertFalse(
+            $container->has('datatables.data_collector'),
+            'datatables.data_collector must not be registered when kernel.debug is false.',
+        );
+    }
+
+    /**
+     * datatables.infrastructure's profiler argument must resolve to null rather than fail
+     * container compilation when datatables.profiler does not exist -- proving the
+     * nullOnInvalid() wiring, not just the absence of the service on its own.
+     */
+    #[Test]
+    public function infrastructure_resolves_a_null_profiler_when_debug_is_off(): void
+    {
+        $kernel = new ProfilerDisabledAppKernel('test', false);
+        $kernel->boot();
+        $container = $kernel->getContainer()->get('test.service_container');
+
+        /** @var DataTableInfrastructure $infrastructure */
+        $infrastructure = $container->get('test.datatables.infrastructure');
+
+        $this->assertNull($infrastructure->profiler());
+    }
+}

--- a/tests/Unit/Model/AbstractDataTableResponseTest.php
+++ b/tests/Unit/Model/AbstractDataTableResponseTest.php
@@ -129,6 +129,30 @@ final class AbstractDataTableResponseTest extends TestCase
         $this->assertSame(200, $response->getStatusCode());
     }
 
+    /**
+     * Regression test: DataTableRuntime::getResponse() only resolves a data provider once a
+     * request has actually been handled -- calling getResponse() without handleRequest()
+     * first short-circuits straight to the empty response, never touching the provider.
+     * Profiler collection used to call getDataProvider() unconditionally, so for an
+     * attributed table with no manual provider and no EntityManager, wiring a profiler alone
+     * turned this safe, documented no-op call into a thrown LogicException -- application
+     * behavior silently depending on whether profiling happened to be enabled.
+     */
+    #[Test]
+    public function it_returns_the_empty_response_without_a_handled_request_even_with_a_profiler_wired(): void
+    {
+        $profiler = new DataTableProfiler();
+        $table    = new MissingEntityManagerHydrationTestTable();
+        $table->setDataTableInfrastructure(DataTableInfrastructure::createDefault(profiler: $profiler));
+
+        $response = $table->getResponse();
+
+        $this->assertSame(
+            ['draw' => 1, 'recordsTotal' => 0, 'recordsFiltered' => 0, 'data' => []],
+            json_decode((string) $response->getContent(), true),
+        );
+    }
+
     #[Test]
     public function it_throws_when_client_side_auto_provider_cannot_be_created(): void
     {

--- a/tests/Unit/Model/AbstractDataTableResponseTest.php
+++ b/tests/Unit/Model/AbstractDataTableResponseTest.php
@@ -11,6 +11,8 @@ use Pentiminax\UX\DataTables\DataProvider\ArrayDataProvider;
 use Pentiminax\UX\DataTables\DataTableRequest\DataTableRequest;
 use Pentiminax\UX\DataTables\Model\AbstractDataTable;
 use Pentiminax\UX\DataTables\Model\DataTableResult;
+use Pentiminax\UX\DataTables\Profiler\DataTableProfiler;
+use Pentiminax\UX\DataTables\Runtime\DataTableInfrastructure;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -88,6 +90,43 @@ final class AbstractDataTableResponseTest extends TestCase
         $table->getDataTable();
 
         $this->assertSame(2, $table->providerCalls);
+    }
+
+    /**
+     * Regression test: profiler collection used to live only in AjaxDataController, so a
+     * table using a custom ajax() URL -- calling handleRequest()/getResponse() directly, the
+     * documented "Manual Same-Route Handling" pattern, without ever going through that
+     * controller -- never reached the profiler at all. Collection now lives inside
+     * getResponse() itself, so this path is captured the same as the built-in route.
+     */
+    #[Test]
+    public function it_records_the_ajax_query_with_the_profiler_regardless_of_which_controller_calls_it(): void
+    {
+        $profiler = new DataTableProfiler();
+        $table    = new ResponseTestTable(new FixedResultDataProvider());
+        $table->setDataTableInfrastructure(DataTableInfrastructure::createDefault(profiler: $profiler));
+
+        $table->handleRequest(new Request(query: ['draw' => 3]));
+        $table->getResponse();
+
+        $queries = $profiler->getAjaxQueries();
+
+        $this->assertCount(1, $queries);
+        $this->assertSame(ResponseTestTable::class, $queries[0]['class']);
+        $this->assertSame(10, $queries[0]['recordsTotal']);
+        $this->assertSame(4, $queries[0]['recordsFiltered']);
+        $this->assertSame(2, $queries[0]['rowCount']);
+    }
+
+    #[Test]
+    public function it_builds_the_response_without_a_profiler_wired(): void
+    {
+        $table = new ResponseTestTable(new FixedResultDataProvider());
+        $table->handleRequest(new Request(query: ['draw' => 3]));
+
+        $response = $table->getResponse();
+
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     #[Test]

--- a/tests/Unit/Runtime/DataTableInfrastructureTest.php
+++ b/tests/Unit/Runtime/DataTableInfrastructureTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pentiminax\UX\DataTables\Tests\Unit\Runtime;
 
 use Pentiminax\UX\DataTables\Column\ColumnResolver;
+use Pentiminax\UX\DataTables\Profiler\DataTableProfiler;
 use Pentiminax\UX\DataTables\Query\Builder\QueryFilterPipeline;
 use Pentiminax\UX\DataTables\Query\Intent\DefaultDataTableQueryIntentFactory;
 use Pentiminax\UX\DataTables\Rendering\RenderingPreparer;
@@ -30,6 +31,7 @@ final class DataTableInfrastructureTest extends TestCase
         $this->assertInstanceOf(DataTableRuntimeFactory::class, $infrastructure->runtimeFactory());
         $this->assertInstanceOf(DefaultDataTableQueryIntentFactory::class, $infrastructure->queryIntentFactory());
         $this->assertInstanceOf(QueryFilterPipeline::class, $infrastructure->queryFilterPipeline());
+        $this->assertNull($infrastructure->profiler());
     }
 
     #[Test]
@@ -40,6 +42,7 @@ final class DataTableInfrastructureTest extends TestCase
         $runtimeFactory      = new DataTableRuntimeFactory();
         $intentFactory       = new DefaultDataTableQueryIntentFactory();
         $queryFilterPipeline = new QueryFilterPipeline($intentFactory);
+        $profiler            = new DataTableProfiler();
 
         $infrastructure = DataTableInfrastructure::createDefault(
             columnResolver: $columnResolver,
@@ -47,6 +50,7 @@ final class DataTableInfrastructureTest extends TestCase
             runtimeFactory: $runtimeFactory,
             queryIntentFactory: $intentFactory,
             queryFilterPipeline: $queryFilterPipeline,
+            profiler: $profiler,
         );
 
         $this->assertSame($columnResolver, $infrastructure->columnResolver());
@@ -54,5 +58,6 @@ final class DataTableInfrastructureTest extends TestCase
         $this->assertSame($runtimeFactory, $infrastructure->runtimeFactory());
         $this->assertSame($intentFactory, $infrastructure->queryIntentFactory());
         $this->assertSame($queryFilterPipeline, $infrastructure->queryFilterPipeline());
+        $this->assertSame($profiler, $infrastructure->profiler());
     }
 }


### PR DESCRIPTION
- DataTableProfiler::collectAjaxQuery() was only ever called from AjaxDataController::collect(). A table using a custom ajax() URL never touched that controller, so its query never reached the profiler.
- Moved collection into AbstractDataTable::getResponse() itself — the one method both the built-in controller and any custom controller funnel through. Threaded DataTableProfiler through DataTableInfrastructure (new optional constructor arg + profiler() accessor).
- AjaxDataController drops its DataTableProfiler dependency and collect() method entirely — it now just returns $table->getResponse().
- Updated the profiler panel's own help text, which previously read as a blanket promise true only for the built-in route.
- Follow-up hardening: datatables.profiler/datatables.data_collector were registered unconditionally in every environment with no kernel.debug gate — and since this bundle calls into the profiler eagerly from application code (not just via a lazy collect() pulled by Symfony's own profiler chain), that meant real per-request cost in production for data nobody would ever read. Moved both services into a new config/profiler.php, imported only when %kernel.debug% is true, matching the existing conditional-import pattern already used for api_platform.php/form.php/mercure.php. Every consumer already null-checked the profiler, so this was the only change needed to make the whole chain a true no-op.

That last one is the big one - we never want profiling/debugging to trigger unless it's turned on to keep prod running speedy

This adds tests to make SURE we're not registering/using profiling pieces when we don't ask for them