### PR TITLE
feat: surface ColumnControl search/list state in the profiler panel

### DIFF
--- a/src/Profiler/DataTableProfiler.php
+++ b/src/Profiler/DataTableProfiler.php
@@ -247,7 +247,7 @@ final class DataTableProfiler
      * above -- summarized separately here so it shows up in the panel at all instead of
      * being silently dropped alongside the request.
      *
-     * @return array{value: ?string, logic: ?string, type: ?string, list: list<mixed>}|null
+     * @return array{value: ?string, logic: ?string, type: ?string, list: list<string>}|null
      */
     private function summarizeColumnControl(?ColumnControl $columnControl): ?array
     {
@@ -265,7 +265,28 @@ final class DataTableProfiler
             'value' => $search?->value,
             'logic' => $search?->logic->value,
             'type'  => $search?->type,
-            'list'  => $columnControl->list,
+            'list'  => $this->normalizeColumnControlList($columnControl->list),
         ];
+    }
+
+    /**
+     * ColumnControl::$list is unvalidated request input (ColumnControl::fromArray() reads
+     * $data['list'] ?? [] verbatim) -- a client can submit a nested array for one entry (e.g.
+     * columns[0][columnControl][list][0][x]=y), which the panel's join() filter cannot render
+     * as a string. Reduce every entry to a safe scalar here so the template never has to
+     * account for what a request happened to send.
+     *
+     * @param list<mixed> $list
+     *
+     * @return list<string>
+     */
+    private function normalizeColumnControlList(array $list): array
+    {
+        return array_map(
+            static fn (mixed $value): string => \is_scalar($value) || null === $value
+                ? (string) $value
+                : \sprintf('(invalid %s value)', get_debug_type($value)),
+            $list,
+        );
     }
 }

--- a/src/Profiler/DataTableProfiler.php
+++ b/src/Profiler/DataTableProfiler.php
@@ -8,6 +8,7 @@ use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
 use Pentiminax\UX\DataTables\Contracts\ExtensionInterface;
 use Pentiminax\UX\DataTables\Contracts\LayoutAwareExtensionInterface;
 use Pentiminax\UX\DataTables\DataTableRequest\Column;
+use Pentiminax\UX\DataTables\DataTableRequest\ColumnControl;
 use Pentiminax\UX\DataTables\DataTableRequest\DataTableRequest;
 use Pentiminax\UX\DataTables\DataTableRequest\Order;
 use Pentiminax\UX\DataTables\Model\DataTable;
@@ -227,15 +228,44 @@ final class DataTableProfiler
             \assert($column instanceof Column);
 
             $columns[] = [
-                'index'       => $index++,
-                'data'        => $column->data,
-                'name'        => $column->name,
-                'searchable'  => $column->searchable,
-                'orderable'   => $column->orderable,
-                'searchValue' => $column->search?->value,
+                'index'         => $index++,
+                'data'          => $column->data,
+                'name'          => $column->name,
+                'searchable'    => $column->searchable,
+                'orderable'     => $column->orderable,
+                'searchValue'   => $column->search?->value,
+                'columnControl' => $this->summarizeColumnControl($column->columnControl),
             ];
         }
 
         return $columns;
+    }
+
+    /**
+     * ColumnControl submits its own scalar search (value/logic/type) and searchList
+     * (checkbox list of selected values) independently of the plain column search box
+     * above -- summarized separately here so it shows up in the panel at all instead of
+     * being silently dropped alongside the request.
+     *
+     * @return array{value: ?string, logic: ?string, type: ?string, list: list<mixed>}|null
+     */
+    private function summarizeColumnControl(?ColumnControl $columnControl): ?array
+    {
+        if (null === $columnControl) {
+            return null;
+        }
+
+        $search = $columnControl->search;
+
+        if (null === $search && [] === $columnControl->list) {
+            return null;
+        }
+
+        return [
+            'value' => $search?->value,
+            'logic' => $search?->logic->value,
+            'type'  => $search?->type,
+            'list'  => $columnControl->list,
+        ];
     }
 }

--- a/templates/Collector/data_collector.html.twig
+++ b/templates/Collector/data_collector.html.twig
@@ -312,6 +312,7 @@
                                 <th>Searchable</th>
                                 <th>Orderable</th>
                                 <th>Column search</th>
+                                <th>ColumnControl</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -323,6 +324,17 @@
                                     <td>{{ column.searchable ? 'yes' : 'no' }}</td>
                                     <td>{{ column.orderable ? 'yes' : 'no' }}</td>
                                     <td>{{ column.searchValue is empty ? '—' : column.searchValue }}</td>
+                                    <td>
+                                        {%- if column.columnControl is empty -%}
+                                            —
+                                        {%- elseif column.columnControl.list is not empty -%}
+                                            list: {{ column.columnControl.list|map(v => v == '' ? '(empty)' : v)|join(', ') }}
+                                        {%- elseif column.columnControl.value is not empty -%}
+                                            {{ column.columnControl.logic }}: <code>{{ column.columnControl.value }}</code>
+                                        {%- else -%}
+                                            —
+                                        {%- endif -%}
+                                    </td>
                                 </tr>
                             {% endfor %}
                         </tbody>

--- a/templates/Collector/data_collector.html.twig
+++ b/templates/Collector/data_collector.html.twig
@@ -323,14 +323,14 @@
                                     <td>{{ column.data }}</td>
                                     <td>{{ column.searchable ? 'yes' : 'no' }}</td>
                                     <td>{{ column.orderable ? 'yes' : 'no' }}</td>
-                                    <td>{{ column.searchValue is empty ? '—' : column.searchValue }}</td>
+                                    <td>{{ (column.searchValue is null or column.searchValue == '') ? '—' : column.searchValue }}</td>
                                     <td>
                                         {%- if column.columnControl is empty -%}
                                             —
                                         {%- elseif column.columnControl.list is not empty -%}
                                             list: {{ column.columnControl.list|map(v => v == '' ? '(empty)' : v)|join(', ') }}
-                                        {%- elseif column.columnControl.value is not empty -%}
-                                            {{ column.columnControl.logic }}: <code>{{ column.columnControl.value }}</code>
+                                        {%- elseif column.columnControl.value is not null -%}
+                                            {{ column.columnControl.logic }}: <code>{{ column.columnControl.value == '' ? '(empty)' : column.columnControl.value }}</code>
                                         {%- else -%}
                                             —
                                         {%- endif -%}

--- a/tests/Unit/DataCollector/DataTablePanelRenderTest.php
+++ b/tests/Unit/DataCollector/DataTablePanelRenderTest.php
@@ -78,6 +78,97 @@ final class DataTablePanelRenderTest extends TestCase
         $this->assertStringNotContainsString('Sensitive-Row-Value', $panel);
     }
 
+    /**
+     * The value "0" is a real, meaningful search predicate, not the absence of one -- covered
+     * end to end through the real render pipeline alongside the null-check refinement in
+     * DataTableProfiler that also distinguishes a genuine empty-string search from no search
+     * at all (rendered as "(empty)" rather than collapsed into the same "—" as no search).
+     */
+    #[Test]
+    public function the_panel_renders_a_zero_string_search_value_instead_of_the_empty_placeholder(): void
+    {
+        $kernel = new ProfilerPanelAppKernel('test', true);
+        $kernel->boot();
+        $container = $kernel->getContainer()->get('test.service_container');
+
+        /** @var DataTableProfiler $profiler */
+        $profiler = $container->get('test.datatables.profiler');
+        $profiler->collectAjaxQuery(
+            class: 'App\\ProductDataTable',
+            token: 'token',
+            request: DataTableRequest::fromRequest(Request::create('/datatables', 'GET', [
+                'draw'    => '1',
+                'columns' => [
+                    [
+                        'data'          => '0', 'name' => 'quantity', 'searchable' => 'true', 'orderable' => 'true',
+                        'search'        => ['value' => '0', 'regex' => 'false'],
+                        'columnControl' => ['search' => ['value' => '0', 'logic' => 'equal', 'type' => 'text']],
+                    ],
+                ],
+            ])),
+            recordsTotal: 1,
+            recordsFiltered: 1,
+            durationMs: 0.5,
+        );
+
+        /** @var DataTableCollector $collector */
+        $collector = $container->get('test.datatables.data_collector');
+        $collector->collect(Request::create('/'), new Response());
+
+        /** @var Environment $twig */
+        $twig  = $container->get('test.twig');
+        $panel = $twig->load('@DataTables/Collector/data_collector.html.twig')
+            ->renderBlock('panel', ['collector' => $collector]);
+
+        $this->assertStringContainsString('equal: <code>0</code>', $panel);
+        $this->assertMatchesRegularExpression('/<td>0<\/td>\s*<td>yes<\/td>\s*<td>yes<\/td>\s*<td>0<\/td>/', $panel);
+    }
+
+    /**
+     * Regression test: ColumnControl::$list is unvalidated request input, so a client can
+     * submit a nested array for one entry. The panel used to forward it unchanged into a
+     * `|join(', ')` filter, which cannot render an array as a string and threw a
+     * Twig\Error\RuntimeError ("Array to string conversion"), crashing the entire panel --
+     * not just that one row.
+     */
+    #[Test]
+    public function the_panel_renders_a_non_scalar_search_list_entry_without_crashing(): void
+    {
+        $kernel = new ProfilerPanelAppKernel('test', true);
+        $kernel->boot();
+        $container = $kernel->getContainer()->get('test.service_container');
+
+        /** @var DataTableProfiler $profiler */
+        $profiler = $container->get('test.datatables.profiler');
+        $profiler->collectAjaxQuery(
+            class: 'App\\ProductDataTable',
+            token: 'token',
+            request: DataTableRequest::fromRequest(Request::create('/datatables', 'GET', [
+                'draw'    => '1',
+                'columns' => [
+                    [
+                        'data'          => '0', 'name' => 'department', 'searchable' => 'true', 'orderable' => 'true',
+                        'columnControl' => ['list' => ['Sales', ['nested' => 'value']]],
+                    ],
+                ],
+            ])),
+            recordsTotal: 1,
+            recordsFiltered: 1,
+            durationMs: 0.5,
+        );
+
+        /** @var DataTableCollector $collector */
+        $collector = $container->get('test.datatables.data_collector');
+        $collector->collect(Request::create('/'), new Response());
+
+        /** @var Environment $twig */
+        $twig  = $container->get('test.twig');
+        $panel = $twig->load('@DataTables/Collector/data_collector.html.twig')
+            ->renderBlock('panel', ['collector' => $collector]);
+
+        $this->assertStringContainsString('list: Sales, (invalid array value)', $panel);
+    }
+
     private function createTable(): DataTable
     {
         $table = new DataTable('products');

--- a/tests/Unit/Profiler/DataTableProfilerTest.php
+++ b/tests/Unit/Profiler/DataTableProfilerTest.php
@@ -229,6 +229,36 @@ final class DataTableProfilerTest extends TestCase
         ], $summary['columns'][0]['columnControl']);
     }
 
+    /**
+     * ColumnControl::$list is unvalidated request input -- ColumnControl::fromArray() reads
+     * $data['list'] ?? [] verbatim, so a client can submit a nested array for one entry. The
+     * panel's join() filter cannot render an array as a string and used to crash the whole
+     * profiler panel; every entry must reduce to a safe scalar before it ever reaches Twig.
+     */
+    #[Test]
+    public function it_normalizes_a_non_scalar_search_list_entry_instead_of_forwarding_it_unchanged(): void
+    {
+        $request = DataTableRequest::fromRequest(Request::create('/datatables', 'GET', [
+            'draw'    => '1',
+            'columns' => [
+                [
+                    'data'          => '0', 'name' => 'department', 'searchable' => 'true', 'orderable' => 'true',
+                    'columnControl' => ['list' => ['Sales', ['nested' => 'value']]],
+                ],
+            ],
+        ]));
+
+        $profiler = new DataTableProfiler();
+        $profiler->collectAjaxQuery('App\\ProductDataTable', 'token', $request, 10, 10, 1.0);
+
+        $summary = $profiler->getAjaxQueries()[0]['requestSummary'];
+
+        $this->assertSame(
+            ['Sales', '(invalid array value)'],
+            $summary['columns'][0]['columnControl']['list'],
+        );
+    }
+
     #[Test]
     public function it_omits_column_control_when_the_column_declares_it_without_a_search_or_list(): void
     {

--- a/tests/Unit/Profiler/DataTableProfilerTest.php
+++ b/tests/Unit/Profiler/DataTableProfilerTest.php
@@ -161,9 +161,93 @@ final class DataTableProfilerTest extends TestCase
         $this->assertSame([['column' => 1, 'name' => 'name', 'dir' => 'desc']], $summary['order']);
         $this->assertSame(['status' => 'active'], $summary['filters']);
         $this->assertSame([
-            ['index' => 0, 'data' => '0', 'name' => 'id', 'searchable' => false, 'orderable' => true, 'searchValue' => null],
-            ['index' => 1, 'data' => '1', 'name' => 'name', 'searchable' => true, 'orderable' => true, 'searchValue' => 'bar'],
+            ['index' => 0, 'data' => '0', 'name' => 'id', 'searchable' => false, 'orderable' => true, 'searchValue' => null, 'columnControl' => null],
+            ['index' => 1, 'data' => '1', 'name' => 'name', 'searchable' => true, 'orderable' => true, 'searchValue' => 'bar', 'columnControl' => null],
         ], $summary['columns']);
+    }
+
+    /**
+     * ColumnControl submits its own scalar search (value/logic/type) independently of the
+     * plain column search box above -- summarizeRequestColumns() used to read only
+     * $column->search, silently dropping this even though it drives real query filtering
+     * via ColumnControlSearchFilter.
+     */
+    #[Test]
+    public function it_summarizes_a_column_controls_scalar_search(): void
+    {
+        $request = DataTableRequest::fromRequest(Request::create('/datatables', 'GET', [
+            'draw'    => '1',
+            'columns' => [
+                [
+                    'data'          => '0', 'name' => 'status', 'searchable' => 'true', 'orderable' => 'true',
+                    'columnControl' => ['search' => ['value' => 'active', 'logic' => 'equal', 'type' => 'text']],
+                ],
+            ],
+        ]));
+
+        $profiler = new DataTableProfiler();
+        $profiler->collectAjaxQuery('App\\ProductDataTable', 'token', $request, 10, 10, 1.0);
+
+        $summary = $profiler->getAjaxQueries()[0]['requestSummary'];
+
+        $this->assertSame([
+            'value' => 'active',
+            'logic' => 'equal',
+            'type'  => 'text',
+            'list'  => [],
+        ], $summary['columns'][0]['columnControl']);
+    }
+
+    /**
+     * ColumnControl's searchList (a checkbox list of selected values, e.g. the "Empty"
+     * option matching NULL rows) is a second, independent piece of ColumnControl state --
+     * also dropped before this, alongside the scalar search.
+     */
+    #[Test]
+    public function it_summarizes_a_column_controls_search_list(): void
+    {
+        $request = DataTableRequest::fromRequest(Request::create('/datatables', 'GET', [
+            'draw'    => '1',
+            'columns' => [
+                [
+                    'data'          => '0', 'name' => 'department', 'searchable' => 'true', 'orderable' => 'true',
+                    'columnControl' => ['list' => ['Sales', '']],
+                ],
+            ],
+        ]));
+
+        $profiler = new DataTableProfiler();
+        $profiler->collectAjaxQuery('App\\ProductDataTable', 'token', $request, 10, 10, 1.0);
+
+        $summary = $profiler->getAjaxQueries()[0]['requestSummary'];
+
+        $this->assertSame([
+            'value' => null,
+            'logic' => null,
+            'type'  => null,
+            'list'  => ['Sales', ''],
+        ], $summary['columns'][0]['columnControl']);
+    }
+
+    #[Test]
+    public function it_omits_column_control_when_the_column_declares_it_without_a_search_or_list(): void
+    {
+        $request = DataTableRequest::fromRequest(Request::create('/datatables', 'GET', [
+            'draw'    => '1',
+            'columns' => [
+                [
+                    'data'          => '0', 'name' => 'status', 'searchable' => 'true', 'orderable' => 'true',
+                    'columnControl' => [],
+                ],
+            ],
+        ]));
+
+        $profiler = new DataTableProfiler();
+        $profiler->collectAjaxQuery('App\\ProductDataTable', 'token', $request, 10, 10, 1.0);
+
+        $summary = $profiler->getAjaxQueries()[0]['requestSummary'];
+
+        $this->assertNull($summary['columns'][0]['columnControl']);
     }
 
     #[Test]


### PR DESCRIPTION
- DataTableProfiler::summarizeRequestColumns() read $column->search (the plain per-column search box) but never $column->columnControl — ColumnControl's own scalar search (value/logic/type) and searchList (checkbox list of selected values, including the "" empty-value entry that matches IS NULL rows per the earlier ColumnControlSearchFilter fix) were both silently absent from every recorded AJAX query.
- Added summarizeColumnControl(), returning null when a column has no ColumnControl state at all (or declares it with neither a search nor a list), so the panel shows a plain "—" instead of a payload of nulls.
- The panel's "Request columns" table gets a new ColumnControl column: a searchList renders as list: a, b, (empty) (blank entries labeled, not rendered invisibly); a scalar search renders as logic: value.
- Kept as its own column rather than merging into "Column search" — ColumnSearchFilter and ColumnControlSearchFilter can both fire on the same column independently, and merging would hide which mechanism actually produced a given predicate.