### PR TITLE
feat: allow ColumnControl overrides on the generated actions column

### DIFF
--- a/docs/src/content/docs/extensions/column-control.mdx
+++ b/docs/src/content/docs/extensions/column-control.mdx
@@ -49,6 +49,24 @@ require `ColumnControlExtension` to be added to the table — the frontend only 
 ColumnControl plugin bundle when the table-level extension is present, so a column-level override
 or a disabled column stays inert without it.
 
+### Overriding The Actions Column
+
+The auto-generated actions column is built internally and has ColumnControl disabled by default, so
+`setColumnControl()` on `AbstractColumn` doesn't reach it. Use `Actions::setColumnControl()` in
+`configureActions()` instead — it flows through to the generated column the same way
+`setColumnClassName()` already does:
+
+```php
+use Pentiminax\UX\DataTables\Model\Actions;
+
+public function configureActions(Actions $actions): Actions
+{
+    return $actions
+        ->setColumnControl(['colvisDropdown'])
+        ->add(Action::edit());
+}
+```
+
 ## Custom Content Types
 
 ColumnControl resolves the content descriptors above against `DataTable.ColumnControl.content`, a

--- a/skills/ux-datatables/references/actions.md
+++ b/skills/ux-datatables/references/actions.md
@@ -10,6 +10,7 @@ public function configureActions(Actions $actions): Actions
     return $actions
         ->setColumnLabel('Operations')          // header (default: 'Actions')
         ->setColumnClassName('text-end')
+        ->setColumnControl(['colvisDropdown'])  // requires ColumnControlExtension on the table
         ->add(Action::edit())
         ->add(
             Action::delete('Delete')

--- a/src/Model/AbstractDataTable.php
+++ b/src/Model/AbstractDataTable.php
@@ -548,6 +548,12 @@ abstract class AbstractDataTable
             $actionColumn->setClassName($className);
         }
 
+        $columnControl = $actions->getColumnControl();
+
+        if (null !== $columnControl) {
+            $actionColumn->setColumnControl($columnControl);
+        }
+
         return $actionColumn;
     }
 }

--- a/src/Model/Actions.php
+++ b/src/Model/Actions.php
@@ -22,6 +22,8 @@ final class Actions implements \JsonSerializable
 
     private ?ActionsAlignment $alignment = null;
 
+    private ?array $columnControl = null;
+
     public function add(Action $action): self
     {
         $name = $action->getName();
@@ -116,6 +118,26 @@ final class Actions implements \JsonSerializable
     }
 
     /**
+     * Override the ColumnControl content for the generated actions column, using the same
+     * content descriptors as AbstractColumn::setColumnControl() (e.g. `['colvisDropdown']`).
+     *
+     * Requires `ColumnControlExtension` to be added to the table to have any visible effect.
+     *
+     * @param list<mixed> $columnControl
+     */
+    public function setColumnControl(array $columnControl): self
+    {
+        $this->columnControl = $columnControl;
+
+        return $this;
+    }
+
+    public function getColumnControl(): ?array
+    {
+        return $this->columnControl;
+    }
+
+    /**
      * Split the actions into position-grouped collections.
      *
      * Each action is placed in the group matching its own position when set,
@@ -185,6 +207,7 @@ final class Actions implements \JsonSerializable
         $clone->columnClassName = $this->columnClassName;
         $clone->position        = $this->position;
         $clone->alignment       = $this->alignment;
+        $clone->columnControl   = $this->columnControl;
 
         return $clone;
     }

--- a/tests/Unit/Model/AbstractDataTableActionsTest.php
+++ b/tests/Unit/Model/AbstractDataTableActionsTest.php
@@ -76,6 +76,32 @@ final class AbstractDataTableActionsTest extends TestCase
     }
 
     #[Test]
+    public function it_applies_the_actions_column_control_override(): void
+    {
+        $table = self::tableWith(static fn (Actions $actions): Actions => $actions
+            ->setColumnControl(['colvisDropdown'])
+            ->add(Action::detail()));
+
+        $column = $table->getColumnByName('actions');
+
+        $this->assertInstanceOf(ActionColumn::class, $column);
+        $this->assertSame(['colvisDropdown'], $column->getColumnControl());
+        $this->assertSame(['colvisDropdown'], $column->jsonSerialize()['columnControl']);
+    }
+
+    #[Test]
+    public function it_leaves_the_actions_column_control_disabled_by_default(): void
+    {
+        $table = self::tableWith(static fn (Actions $actions): Actions => $actions->add(Action::detail()));
+
+        $column = $table->getColumnByName('actions');
+
+        $this->assertInstanceOf(ActionColumn::class, $column);
+        $this->assertNull($column->getColumnControl());
+        $this->assertSame([], $column->jsonSerialize()['columnControl']);
+    }
+
+    #[Test]
     public function it_keeps_explicit_action_entity_class(): void
     {
         $column = (new ExplicitActionEntityClassTestTable())->getColumnByName('actions');

--- a/tests/Unit/Model/ActionsTest.php
+++ b/tests/Unit/Model/ActionsTest.php
@@ -34,6 +34,7 @@ final class ActionsTest extends TestCase
         $this->assertNull($actions->getColumnClassName());
         $this->assertSame(ActionsPosition::AfterColumns, $actions->getPosition());
         $this->assertNull($actions->getAlignment());
+        $this->assertNull($actions->getColumnControl());
     }
 
     #[Test]
@@ -58,13 +59,15 @@ final class ActionsTest extends TestCase
             ->setColumnLabel('Operations')
             ->setColumnClassName('dt-center')
             ->position(ActionsPosition::BeforeColumns)
-            ->alignment(ActionsAlignment::Center);
+            ->alignment(ActionsAlignment::Center)
+            ->setColumnControl(['colvisDropdown']);
 
         $this->assertSame('Operations', $actions->getColumnLabel());
         $this->assertSame('dt-center', $actions->getColumnClassName());
         $this->assertSame(ActionsPosition::BeforeColumns, $actions->getPosition());
         $this->assertSame(ActionsAlignment::Center, $actions->getAlignment());
         $this->assertSame('dt-center', $actions->getAlignment()->cssClass());
+        $this->assertSame(['colvisDropdown'], $actions->getColumnControl());
     }
 
     #[Test]
@@ -198,6 +201,7 @@ final class ActionsTest extends TestCase
             ->setColumnLabel('Ops')
             ->setColumnClassName('dt-center')
             ->alignment(ActionsAlignment::Center)
+            ->setColumnControl(['colvisDropdown'])
             ->add(Action::detail()->position(ActionsPosition::BeforeColumns));
 
         $group = $actions->partitionByPosition()[ActionsPosition::BeforeColumns->value];
@@ -205,5 +209,6 @@ final class ActionsTest extends TestCase
         $this->assertSame('Ops', $group->getColumnLabel());
         $this->assertSame('dt-center', $group->getColumnClassName());
         $this->assertSame(ActionsAlignment::Center, $group->getAlignment());
+        $this->assertSame(['colvisDropdown'], $group->getColumnControl());
     }
 }


### PR DESCRIPTION
- The auto-generated actions column is built internally and has ColumnControl disabled by default, so setColumnControl() on AbstractColumn doesn't reach it.
- Adds Actions::setColumnControl(), used in configureActions() — flows through to the generated column the same way setColumnClassName() already does.