### PR TITLE
fix: apply customizeQueryBuilder() to recordsTotal, not just recordsFiltered and the page

### DIFF
--- a/docs/src/content/docs/reference/abstract-datatable.mdx
+++ b/docs/src/content/docs/reference/abstract-datatable.mdx
@@ -187,6 +187,11 @@ final class ActiveUsersDataTable extends AbstractDataTable
 }
 ```
 
+`customizeQueryBuilder()`'s constraints apply to `recordsTotal` as well as `recordsFiltered` and the
+returned page — the deleted/inactive rows excluded above are never counted at all, not just hidden
+from search results. Only the bundle's own interactive search, ordering, and column/user filters
+are layered on top for `recordsFiltered`; `recordsTotal` reflects your base dataset alone.
+
 ### Dynamic Filtering
 
 Use request parameters for dynamic filters:

--- a/src/DataProvider/AutoDataProviderFactory.php
+++ b/src/DataProvider/AutoDataProviderFactory.php
@@ -19,13 +19,15 @@ final class AutoDataProviderFactory
     }
 
     /**
-     * @param callable(QueryBuilder, DataTableRequest):QueryBuilder $configureQueryBuilder
+     * @param callable(QueryBuilder, DataTableRequest):QueryBuilder      $configureQueryBuilder
+     * @param callable(QueryBuilder, DataTableRequest):QueryBuilder|null $configureBaseQueryBuilder
      */
     public function create(
         ?AsDataTable $asDataTable,
         RowMapperInterface $rowMapper,
         callable $configureQueryBuilder,
         ?\Closure $pageProjector = null,
+        ?callable $configureBaseQueryBuilder = null,
     ): ?DataProviderInterface {
         if (null === $asDataTable) {
             return null;
@@ -41,6 +43,7 @@ final class AutoDataProviderFactory
             rowMapper: $rowMapper,
             configureQueryBuilder: $configureQueryBuilder,
             pageProjector: $pageProjector,
+            configureBaseQueryBuilder: $configureBaseQueryBuilder,
         );
     }
 }

--- a/src/DataProvider/DataProviderResolver.php
+++ b/src/DataProvider/DataProviderResolver.php
@@ -18,7 +18,8 @@ final class DataProviderResolver
     }
 
     /**
-     * @param callable(QueryBuilder, DataTableRequest):QueryBuilder $configureQueryBuilder
+     * @param callable(QueryBuilder, DataTableRequest):QueryBuilder      $configureQueryBuilder
+     * @param callable(QueryBuilder, DataTableRequest):QueryBuilder|null $configureBaseQueryBuilder
      */
     public function resolve(
         ?DataProviderInterface $manualDataProvider,
@@ -26,7 +27,8 @@ final class DataProviderResolver
         RowMapperInterface $rowMapper,
         callable $configureQueryBuilder,
         ?\Closure $pageProjector = null,
+        ?callable $configureBaseQueryBuilder = null,
     ): ?DataProviderInterface {
-        return $manualDataProvider ?? $this->autoDataProviderFactory->create($asDataTable, $rowMapper, $configureQueryBuilder, $pageProjector);
+        return $manualDataProvider ?? $this->autoDataProviderFactory->create($asDataTable, $rowMapper, $configureQueryBuilder, $pageProjector, $configureBaseQueryBuilder);
     }
 }

--- a/src/DataProvider/DoctrineDataProvider.php
+++ b/src/DataProvider/DoctrineDataProvider.php
@@ -22,6 +22,17 @@ class DoctrineDataProvider implements DataProviderInterface
         private $configureQueryBuilder = null,
         /** @var (\Closure(list<object>):(list<mixed>|null))|null */
         private readonly ?\Closure $pageProjector = null,
+        /**
+         * Applied to recordsTotal's count query. Unlike $configureQueryBuilder (the app's
+         * customizeQueryBuilder() plus the bundle's own interactive search/order/filter
+         * pipeline), this never includes request-driven search terms -- only the app's own
+         * permanent scoping (customizeQueryBuilder() alone), matching what DataTables expects
+         * recordsTotal to mean: the size of the developer's own base dataset, before the
+         * user's interactive search narrows it further.
+         *
+         * @var callable(QueryBuilder, DataTableRequest):QueryBuilder|null
+         */
+        private $configureBaseQueryBuilder = null,
     ) {
     }
 
@@ -29,12 +40,24 @@ class DoctrineDataProvider implements DataProviderInterface
     {
         $alias = 'e';
 
-        $countQb = $this->em
+        $baseQb = $this->em
             ->createQueryBuilder()
-            ->select("COUNT($alias)")
+            ->select($alias)
             ->from($this->entityClass, $alias);
 
-        $recordsTotal = (int) $countQb->getQuery()->getSingleScalarResult();
+        if ($this->configureBaseQueryBuilder) {
+            $baseQb = ($this->configureBaseQueryBuilder)($baseQb, $request);
+        }
+
+        // A to-many join added by configureBaseQueryBuilder() (permanent business-rule
+        // scoping, e.g. an active-only filter joining a relation) would inflate a plain
+        // COUNT(e) the same way a searchable join does for $filteredCountQb below --
+        // COUNT(DISTINCT e) counts distinct root entities instead.
+        $recordsTotal = (int) (clone $baseQb)
+            ->select("COUNT(DISTINCT $alias)")
+            ->resetDQLPart('orderBy')
+            ->getQuery()
+            ->getSingleScalarResult();
 
         $qb = $this->em
             ->createQueryBuilder()

--- a/src/DataProvider/DoctrineDataProvider.php
+++ b/src/DataProvider/DoctrineDataProvider.php
@@ -49,15 +49,7 @@ class DoctrineDataProvider implements DataProviderInterface
             $baseQb = ($this->configureBaseQueryBuilder)($baseQb, $request);
         }
 
-        // A to-many join added by configureBaseQueryBuilder() (permanent business-rule
-        // scoping, e.g. an active-only filter joining a relation) would inflate a plain
-        // COUNT(e) the same way a searchable join does for $filteredCountQb below --
-        // COUNT(DISTINCT e) counts distinct root entities instead.
-        $recordsTotal = (int) (clone $baseQb)
-            ->select("COUNT(DISTINCT $alias)")
-            ->resetDQLPart('orderBy')
-            ->getQuery()
-            ->getSingleScalarResult();
+        $recordsTotal = $this->count($baseQb, $alias);
 
         $qb = $this->em
             ->createQueryBuilder()
@@ -68,19 +60,7 @@ class DoctrineDataProvider implements DataProviderInterface
             $qb = ($this->configureQueryBuilder)($qb, $request);
         }
 
-        // Filters supplied by configureQueryBuilder may add joins (e.g. searching over a
-        // relation). When such a join traverses a to-many association, a plain COUNT(e) is
-        // inflated by row multiplication. COUNT(DISTINCT e) counts distinct root entities, so
-        // recordsFiltered stays correct and pagination does not break.
-        // Note: this assumes a single-column primary key (Doctrine resolves COUNT(DISTINCT e) to
-        // the first identifier column); entities with composite keys would need a subquery over
-        // the identifiers instead.
-        $filteredCountQb = clone $qb;
-        $filteredCount   = (int) $filteredCountQb
-            ->select("COUNT(DISTINCT $alias)")
-            ->resetDQLPart('orderBy')
-            ->getQuery()
-            ->getSingleScalarResult();
+        $filteredCount = $this->count($qb, $alias);
 
         if ($request->start) {
             $qb->setFirstResult($request->start);
@@ -112,5 +92,34 @@ class DoctrineDataProvider implements DataProviderInterface
             recordsFiltered: $filteredCount,
             data: $rows
         );
+    }
+
+    /**
+     * A permanent GROUP BY/HAVING added by customizeQueryBuilder() (e.g. grouping by a related
+     * entity and using HAVING to filter groups by an aggregate condition) already collapses the
+     * dataset into one row per qualifying group. Re-selecting COUNT(DISTINCT $alias) on top of
+     * that GROUP BY still returns one count per group, so getSingleScalarResult() throws
+     * NonUniqueResultException once there is more than one group. In that case the number of
+     * groups the query already yields IS the correct total, so the count is the row count of the
+     * query's own result instead of a re-selected aggregate.
+     *
+     * A to-many join (searchable or permanent) would inflate a plain COUNT($alias) by row
+     * multiplication when there's no GROUP BY; COUNT(DISTINCT $alias) counts distinct root
+     * entities instead. This assumes a single-column primary key (Doctrine resolves
+     * COUNT(DISTINCT $alias) to the first identifier column); entities with composite keys would
+     * need a subquery over the identifiers instead.
+     */
+    private function count(QueryBuilder $qb, string $alias): int
+    {
+        $qb = (clone $qb)->resetDQLPart('orderBy');
+
+        if ([] !== $qb->getDQLPart('groupBy')) {
+            return \count($qb->getQuery()->getScalarResult());
+        }
+
+        return (int) $qb
+            ->select("COUNT(DISTINCT $alias)")
+            ->getQuery()
+            ->getSingleScalarResult();
     }
 }

--- a/src/Model/AbstractDataTable.php
+++ b/src/Model/AbstractDataTable.php
@@ -456,6 +456,7 @@ abstract class AbstractDataTable
             manualDataProviderFactory: $this->createDataProvider(...),
             configureQueryBuilder: $this->configureQueryBuilder(...),
             pageProjector: $this->projectPage(...),
+            configureBaseQueryBuilder: $this->customizeQueryBuilder(...),
         );
     }
 

--- a/src/Runtime/DataTableRuntimeFactory.php
+++ b/src/Runtime/DataTableRuntimeFactory.php
@@ -70,6 +70,7 @@ final class DataTableRuntimeFactory
         \Closure $manualDataProviderFactory,
         callable $configureQueryBuilder,
         ?\Closure $pageProjector = null,
+        ?callable $configureBaseQueryBuilder = null,
     ): DataTableRuntime {
         $rowMapper = $this->createRowMapper($baseMapper, $columns);
 
@@ -81,6 +82,7 @@ final class DataTableRuntimeFactory
                 rowMapper: $rowMapper,
                 configureQueryBuilder: $configureQueryBuilder,
                 pageProjector: $pageProjector,
+                configureBaseQueryBuilder: $configureBaseQueryBuilder,
             ),
         );
     }
@@ -91,6 +93,7 @@ final class DataTableRuntimeFactory
         RowMapperInterface $rowMapper,
         callable $configureQueryBuilder,
         ?\Closure $pageProjector = null,
+        ?callable $configureBaseQueryBuilder = null,
     ): ?DataProviderInterface {
         return $this->getDataProviderResolver()->resolve(
             manualDataProvider: $manualDataProviderFactory(),
@@ -98,6 +101,7 @@ final class DataTableRuntimeFactory
             rowMapper: $rowMapper,
             configureQueryBuilder: $configureQueryBuilder,
             pageProjector: $pageProjector,
+            configureBaseQueryBuilder: $configureBaseQueryBuilder,
         );
     }
 

--- a/tests/Unit/DataProvider/DoctrineDataProviderGroupedCountTest.php
+++ b/tests/Unit/DataProvider/DoctrineDataProviderGroupedCountTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Unit\DataProvider;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\QueryBuilder;
+use Pentiminax\UX\DataTables\Contracts\RowMapperInterface;
+use Pentiminax\UX\DataTables\DataProvider\DoctrineDataProvider;
+use Pentiminax\UX\DataTables\DataTableRequest\Columns;
+use Pentiminax\UX\DataTables\DataTableRequest\DataTableRequest;
+use Pentiminax\UX\DataTables\Tests\Fixtures\Count\CountCustomer;
+use Pentiminax\UX\DataTables\Tests\Fixtures\Count\CountTag;
+use Pentiminax\UX\DataTables\Tests\Support\BuildsEntityManager;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * When customizeQueryBuilder() adds GROUP BY/HAVING as permanent dataset scoping (e.g.
+ * grouping by a related entity and using HAVING to keep only groups matching an aggregate
+ * condition), the count queries used to clone that query builder, replace the select with
+ * COUNT(DISTINCT e), and call getSingleScalarResult() -- but a clone still carries the
+ * GROUP BY, so the count query returned one scalar per group instead of one overall total,
+ * and getSingleScalarResult() threw NonUniqueResultException as soon as more than one group
+ * qualified.
+ *
+ * @internal
+ */
+#[CoversClass(DoctrineDataProvider::class)]
+final class DoctrineDataProviderGroupedCountTest extends TestCase
+{
+    use BuildsEntityManager;
+
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $this->em = $this->createEntityManager(CountCustomer::class, CountTag::class);
+
+        // Three customers with a varying number of tags: grouping by customer and keeping
+        // only groups with more than one tag (HAVING COUNT(t) > 1) qualifies two of them.
+        $alpha = new CountCustomer(1, 'Alpha');
+        $alpha->addTag(new CountTag(10, 'red'));
+        $alpha->addTag(new CountTag(11, 'green'));
+
+        $beta = new CountCustomer(2, 'Beta');
+        $beta->addTag(new CountTag(20, 'red'));
+
+        $gamma = new CountCustomer(3, 'Gamma');
+        $gamma->addTag(new CountTag(30, 'red'));
+        $gamma->addTag(new CountTag(31, 'green'));
+        $gamma->addTag(new CountTag(32, 'blue'));
+
+        $this->em->persist($alpha);
+        $this->em->persist($beta);
+        $this->em->persist($gamma);
+        $this->em->flush();
+        $this->em->clear();
+    }
+
+    #[Test]
+    public function records_total_and_filtered_count_handle_a_grouped_permanent_scope_without_throwing(): void
+    {
+        $groupByCustomersWithMultipleTags = static fn (QueryBuilder $qb): QueryBuilder => $qb
+            ->leftJoin('e.tags', 't')
+            ->groupBy('e.id')
+            ->having('COUNT(t.id) > 1');
+
+        $provider = new DoctrineDataProvider(
+            em: $this->em,
+            entityClass: CountCustomer::class,
+            rowMapper: new class implements RowMapperInterface {
+                public function map(mixed $row): array
+                {
+                    return ['id' => $row->id];
+                }
+            },
+            configureQueryBuilder: $groupByCustomersWithMultipleTags,
+            configureBaseQueryBuilder: $groupByCustomersWithMultipleTags,
+        );
+
+        $result = $provider->fetchData($this->request());
+
+        // Alpha (2 tags) and Gamma (3 tags) qualify; Beta (1 tag) does not.
+        $this->assertSame(2, $result->recordsTotal);
+        $this->assertSame(2, $result->recordsFiltered);
+        $this->assertCount(2, iterator_to_array($result->data));
+    }
+
+    private function request(): DataTableRequest
+    {
+        return new DataTableRequest(draw: 1, columns: new Columns([]), start: 0, length: 10);
+    }
+}

--- a/tests/Unit/DataProvider/DoctrineDataProviderRecordsTotalTest.php
+++ b/tests/Unit/DataProvider/DoctrineDataProviderRecordsTotalTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Unit\DataProvider;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\QueryBuilder;
+use Pentiminax\UX\DataTables\Contracts\RowMapperInterface;
+use Pentiminax\UX\DataTables\DataProvider\DoctrineDataProvider;
+use Pentiminax\UX\DataTables\DataTableRequest\Columns;
+use Pentiminax\UX\DataTables\DataTableRequest\DataTableRequest;
+use Pentiminax\UX\DataTables\Tests\Fixtures\Count\CountCustomer;
+use Pentiminax\UX\DataTables\Tests\Fixtures\Count\CountTag;
+use Pentiminax\UX\DataTables\Tests\Support\BuildsEntityManager;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * recordsTotal used to run through a completely separate, unconfigured
+ * "COUNT(e) FROM Entity e" query that never called configureQueryBuilder() at all. A
+ * permanent, business-rule WHERE clause added via AbstractDataTable::customizeQueryBuilder()
+ * (e.g. "only active rows") correctly excluded those rows from the page and from
+ * recordsFiltered, but recordsTotal still counted every row in the underlying table --
+ * including ones the app never intends to be visible at all. DataTables would then show
+ * something like "2 of 3 entries" as if a user search hid a real row, when that row is
+ * permanently excluded by business rule and should never be counted in the first place.
+ *
+ * @internal
+ */
+#[CoversClass(DoctrineDataProvider::class)]
+final class DoctrineDataProviderRecordsTotalTest extends TestCase
+{
+    use BuildsEntityManager;
+
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $this->em = $this->createEntityManager(CountCustomer::class, CountTag::class);
+
+        $this->em->persist(new CountCustomer(1, 'Alpha'));
+        $this->em->persist(new CountCustomer(2, 'Beta'));
+        $this->em->persist(new CountCustomer(3, 'Gamma'));
+        $this->em->flush();
+        $this->em->clear();
+    }
+
+    #[Test]
+    public function records_total_respects_the_base_query_builder_customization(): void
+    {
+        $excludeBeta = static fn (QueryBuilder $qb): QueryBuilder => $qb->andWhere("e.name != 'Beta'");
+
+        $provider = new DoctrineDataProvider(
+            em: $this->em,
+            entityClass: CountCustomer::class,
+            rowMapper: $this->rowMapper(),
+            configureQueryBuilder: $excludeBeta,
+            configureBaseQueryBuilder: $excludeBeta,
+        );
+
+        $result = $provider->fetchData($this->request());
+
+        $this->assertSame(2, $result->recordsTotal);
+        $this->assertSame(2, $result->recordsFiltered);
+    }
+
+    /**
+     * recordsTotal must reflect the app's own permanent scoping, but never the request's
+     * own interactive search/filter terms -- that distinction is what recordsFiltered
+     * exists to report. configureBaseQueryBuilder only ever receives
+     * customizeQueryBuilder() (see AbstractDataTable::runtime()), never the interactive
+     * pipeline, so simulating "an interactive filter applied only to the full query" here
+     * proves recordsTotal stays unaffected by it.
+     */
+    #[Test]
+    public function records_total_is_unaffected_by_a_filter_applied_only_to_the_full_query_builder(): void
+    {
+        $interactiveSearchOnly = static fn (QueryBuilder $qb): QueryBuilder => $qb->andWhere("e.name = 'Alpha'");
+
+        $provider = new DoctrineDataProvider(
+            em: $this->em,
+            entityClass: CountCustomer::class,
+            rowMapper: $this->rowMapper(),
+            configureQueryBuilder: $interactiveSearchOnly,
+            // configureBaseQueryBuilder intentionally omitted: an interactive search term
+            // narrows the full query only, never the base query recordsTotal counts.
+        );
+
+        $result = $provider->fetchData($this->request());
+
+        $this->assertSame(3, $result->recordsTotal);
+        $this->assertSame(1, $result->recordsFiltered);
+    }
+
+    #[Test]
+    public function records_total_counts_every_row_without_a_base_query_builder_customization(): void
+    {
+        $provider = new DoctrineDataProvider(
+            em: $this->em,
+            entityClass: CountCustomer::class,
+            rowMapper: $this->rowMapper(),
+        );
+
+        $result = $provider->fetchData($this->request());
+
+        $this->assertSame(3, $result->recordsTotal);
+        $this->assertSame(3, $result->recordsFiltered);
+    }
+
+    private function rowMapper(): RowMapperInterface
+    {
+        return new class implements RowMapperInterface {
+            public function map(mixed $row): array
+            {
+                return ['id' => $row->id];
+            }
+        };
+    }
+
+    private function request(): DataTableRequest
+    {
+        return new DataTableRequest(draw: 1, columns: new Columns([]), start: 0, length: 10);
+    }
+}

--- a/tests/Unit/Model/AbstractDataTableRecordsTotalTest.php
+++ b/tests/Unit/Model/AbstractDataTableRecordsTotalTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Unit\Model;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\QueryBuilder;
+use Pentiminax\UX\DataTables\Attribute\AsDataTable;
+use Pentiminax\UX\DataTables\Column\NumberColumn;
+use Pentiminax\UX\DataTables\Column\TextColumn;
+use Pentiminax\UX\DataTables\DataProvider\AutoDataProviderFactory;
+use Pentiminax\UX\DataTables\DataProvider\DataProviderResolver;
+use Pentiminax\UX\DataTables\DataTableRequest\DataTableRequest;
+use Pentiminax\UX\DataTables\Model\AbstractDataTable;
+use Pentiminax\UX\DataTables\Runtime\DataTableInfrastructure;
+use Pentiminax\UX\DataTables\Runtime\DataTableRuntimeFactory;
+use Pentiminax\UX\DataTables\Tests\Fixtures\Count\CountCustomer;
+use Pentiminax\UX\DataTables\Tests\Support\BuildsEntityManager;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * End-to-end regression test for the recordsTotal / customizeQueryBuilder() gap: proves the
+ * wiring all the way from AbstractDataTable::runtime() through DataTableRuntimeFactory,
+ * DataProviderResolver, and AutoDataProviderFactory into DoctrineDataProvider, not just the
+ * DoctrineDataProvider unit itself. A business-rule override that excludes a row must be
+ * reflected in recordsTotal in the real JSON response, the same way it already was in
+ * recordsFiltered and the returned page.
+ *
+ * @internal
+ */
+#[CoversClass(AbstractDataTable::class)]
+final class AbstractDataTableRecordsTotalTest extends TestCase
+{
+    use BuildsEntityManager;
+
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $this->em = $this->createEntityManager(CountCustomer::class);
+
+        $this->em->persist(new CountCustomer(1, 'Alpha'));
+        $this->em->persist(new CountCustomer(2, 'Beta'));
+        $this->em->persist(new CountCustomer(3, 'Gamma'));
+        $this->em->flush();
+        $this->em->clear();
+    }
+
+    #[Test]
+    public function records_total_reflects_a_customize_query_builder_business_rule(): void
+    {
+        $table = new ExcludeBetaCustomerTable();
+        $table->setDataTableInfrastructure(DataTableInfrastructure::createDefault(
+            runtimeFactory: new DataTableRuntimeFactory(
+                dataProviderResolver: new DataProviderResolver(new AutoDataProviderFactory($this->em)),
+            ),
+        ));
+
+        $table->handleRequest(new Request(query: ['draw' => 1, 'start' => 0, 'length' => 10]));
+
+        $payload = json_decode((string) $table->getResponse()->getContent(), true);
+
+        $this->assertSame(2, $payload['recordsTotal']);
+        $this->assertSame(2, $payload['recordsFiltered']);
+        $this->assertCount(2, $payload['data']);
+    }
+}
+
+#[AsDataTable(entityClass: CountCustomer::class)]
+final class ExcludeBetaCustomerTable extends AbstractDataTable
+{
+    public function configureColumns(): iterable
+    {
+        yield NumberColumn::new('id');
+        yield TextColumn::new('name');
+    }
+
+    protected function customizeQueryBuilder(QueryBuilder $qb, DataTableRequest $request): QueryBuilder
+    {
+        return $qb->andWhere("e.name != 'Beta'");
+    }
+}


### PR DESCRIPTION
- recordsTotal was computed from a fully independent, unconfigured count query — customizeQueryBuilder()'s constraints never reached it, only recordsFiltered and the returned page.
- Threaded a second, narrower callable end to end: AbstractDataTable::runtime() now passes $this->customizeQueryBuilder(...) itself (not the full configureQueryBuilder(), which also layers on the interactive search/order/filter pipeline) through DataTableRuntimeFactory → DataProviderResolver → AutoDataProviderFactory into a new DoctrineDataProvider constructor argument, $configureBaseQueryBuilder.
- recordsTotal's count query now receives only that narrower customization, mirroring the existing COUNT(DISTINCT e) / resetDQLPart('orderBy') defensive handling already used for recordsFiltered — a to-many join added by a business rule can inflate a plain COUNT(e) the same way a searchable join already could.
- $configureBaseQueryBuilder is a new, independent argument rather than derived by cloning the fully-configured query builder, because AbstractDataTable::configureQueryBuilder() already calls customizeQueryBuilder() as its own first step — cloning and reapplying would double-apply the app's WHERE clauses and joins (silently wrong for AND conditions, a hard "duplicate alias" error for joins).