### PR TITLE
fix: route paging feature options through layout

### DIFF
--- a/docs/src/content/docs/guide/configuration.mdx
+++ b/docs/src/content/docs/guide/configuration.mdx
@@ -135,8 +135,12 @@ data_tables:
 
 ### paging
 
-Sets the default pagination control layout for every table. Only the keys you declare need to be
-listed; the others keep their defaults.
+Sets the default **paging layout feature** for every table (button count, first/last, …), not the
+top-level DataTables boolean. At render time the bundle injects these keys into unmarked `layout`
+paging slots (`bottomEnd: paging` by default). An explicit `{ paging: { … } }` object in `layout`
+wins and is not overwritten.
+
+Only the keys you declare need to be listed; the others keep their defaults.
 
 ```yaml
 data_tables:

--- a/docs/src/content/docs/guide/options.mdx
+++ b/docs/src/content/docs/guide/options.mdx
@@ -125,7 +125,13 @@ $dataTable->withoutOrdering();
 
 ### paging / withoutPaging
 
-Configure pagination:
+Configure the DataTables **paging layout feature** (number of page buttons, first/last,
+previous/next, …). These keys are not the top-level boolean `paging` option: the bundle
+rewrites unmarked `layout` slots (`'paging'`, `{ paging: true }`, `{ paging: [] }`) to
+`{ paging: { … } }` when the table is serialized.
+
+An explicit `{ paging: { buttons: 3 } }` already placed in `layout()` is left as-is.
+`withoutPaging()` still disables pagination with `paging: false`.
 
 ```php
 $dataTable->paging(

--- a/src/Model/DataTable.php
+++ b/src/Model/DataTable.php
@@ -72,6 +72,7 @@ class DataTable
         $options['columns'] = $this->getColumnDefinitions();
 
         $this->addButtonsToLayout($options);
+        $this->applyPagingFeatureToLayout($options);
 
         if (null !== $this->mercureConfig) {
             $options['mercure'] = $this->mercureConfig->jsonSerialize();
@@ -250,6 +251,15 @@ class DataTable
         return $this;
     }
 
+    /**
+     * Configure DataTables paging feature options (boundaryNumbers, buttons, firstLast, numbers, previousNext).
+     *
+     * Stored internally as the top-level `paging` option. {@see getOptions()} rewrites
+     * unmarked `layout` paging slots to `{ paging: $options }` and sets top-level
+     * `paging` to `true`, which is the path DataTables 2/3 actually reads. An explicit
+     * `{ paging: { ... } }` layout object is left untouched. {@see withoutPaging()}
+     * still disables pagination via `paging: false`.
+     */
     public function paging(
         bool $boundaryNumbers = true,
         int $buttons = 7,
@@ -736,5 +746,58 @@ class DataTable
                 }
             }
         }
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function applyPagingFeatureToLayout(array &$options): void
+    {
+        $paging = $options['paging'] ?? null;
+
+        if (!\is_array($paging)) {
+            return;
+        }
+
+        $layout = $options['layout'] ?? null;
+
+        if (\is_array($layout)) {
+            foreach ($layout as $position => $value) {
+                $options['layout'][$position] = $this->injectPagingFeature($value, $paging);
+            }
+        }
+
+        $options['paging'] = true;
+    }
+
+    private function injectPagingFeature(mixed $value, array $pagingOptions): mixed
+    {
+        if (Feature::PAGING->value === $value) {
+            return ['paging' => $pagingOptions];
+        }
+
+        if (!\is_array($value)) {
+            return $value;
+        }
+
+        if (array_is_list($value)) {
+            foreach ($value as $index => $item) {
+                $value[$index] = $this->injectPagingFeature($item, $pagingOptions);
+            }
+
+            return $value;
+        }
+
+        if (!\array_key_exists('paging', $value)) {
+            return $value;
+        }
+
+        $pagingSlot = $value['paging'];
+
+        if (true === $pagingSlot || [] === $pagingSlot) {
+            $value['paging'] = $pagingOptions;
+        }
+
+        return $value;
     }
 }

--- a/tests/Unit/Model/AbstractDataTableConfigDefaultsTest.php
+++ b/tests/Unit/Model/AbstractDataTableConfigDefaultsTest.php
@@ -35,13 +35,19 @@ final class AbstractDataTableConfigDefaultsTest extends TestCase
     {
         $table = $this->configuredDataTable();
 
-        self::assertEquals([
+        $expectedPaging = [
             'boundaryNumbers' => true,
             'buttons'         => 5,
             'firstLast'       => false,
             'numbers'         => true,
             'previousNext'    => true,
-        ], $table->getOption('paging'));
+        ];
+
+        $paging = $table->getOption('paging');
+
+        self::assertEquals($expectedPaging, $paging);
+        self::assertTrue($table->getOptions()['paging']);
+        self::assertSame(['paging' => $paging], $table->getOptions()['layout']['bottomEnd']);
         self::assertSame(25, $table->getOption('pageLength'));
         self::assertSame(['class' => 'table table-striped'], $table->getAttributes());
         self::assertSame('multi', $table->getExtensions()['select']['style'] ?? null);

--- a/tests/Unit/Model/DataTableTest.php
+++ b/tests/Unit/Model/DataTableTest.php
@@ -122,6 +122,96 @@ final class DataTableTest extends TestCase
         $this->assertSame($expectedPaging, $table->getOption('paging'));
     }
 
+    #[Test]
+    public function it_rewrites_paging_markers_into_the_layout_feature(): void
+    {
+        $table = (new DataTable('testTable'))
+            ->layout([
+                'topStart'    => Feature::PAGE_LENGTH,
+                'topEnd'      => Feature::SEARCH,
+                'bottomStart' => Feature::INFO,
+                'bottomEnd'   => Feature::PAGING,
+            ])
+            ->paging(buttons: 5, firstLast: false);
+
+        $expectedPaging = [
+            'boundaryNumbers' => true,
+            'buttons'         => 5,
+            'firstLast'       => false,
+            'numbers'         => true,
+            'previousNext'    => true,
+        ];
+
+        $this->assertSame($expectedPaging, $table->getOption('paging'));
+        $this->assertTrue($table->getOptions()['paging']);
+        $this->assertSame(['paging' => $expectedPaging], $table->getOptions()['layout']['bottomEnd']);
+    }
+
+    #[Test]
+    public function without_paging_leaves_the_layout_marker_and_disables_pagination(): void
+    {
+        $table = (new DataTable('testTable'))
+            ->layout(['bottomEnd' => Feature::PAGING])
+            ->withoutPaging();
+
+        $this->assertFalse($table->getOptions()['paging']);
+        $this->assertSame('paging', $table->getOptions()['layout']['bottomEnd']);
+    }
+
+    #[Test]
+    public function an_explicit_layout_paging_object_wins_over_paging_options(): void
+    {
+        $table = (new DataTable('testTable'))
+            ->layout(['bottomEnd' => ['paging' => ['buttons' => 3]]])
+            ->paging(buttons: 5);
+
+        $this->assertTrue($table->getOptions()['paging']);
+        $this->assertSame(['paging' => ['buttons' => 3]], $table->getOptions()['layout']['bottomEnd']);
+    }
+
+    #[Test]
+    public function paging_options_do_not_invent_a_layout_slot(): void
+    {
+        $table = (new DataTable('testTable'))
+            ->layout(['bottomEnd' => Feature::INFO])
+            ->paging(buttons: 5);
+
+        $this->assertTrue($table->getOptions()['paging']);
+        $this->assertSame('info', $table->getOptions()['layout']['bottomEnd']);
+        $this->assertArrayNotHasKey('bottomStart', $table->getOptions()['layout']);
+    }
+
+    #[Test]
+    public function paging_options_replace_a_marker_inside_a_layout_list(): void
+    {
+        $table = (new DataTable('testTable'))
+            ->layout(['bottomEnd' => [Feature::INFO, Feature::PAGING]])
+            ->paging(buttons: 5, firstLast: false);
+
+        $expectedPaging = [
+            'boundaryNumbers' => true,
+            'buttons'         => 5,
+            'firstLast'       => false,
+            'numbers'         => true,
+            'previousNext'    => true,
+        ];
+
+        $this->assertSame(
+            ['info', ['paging' => $expectedPaging]],
+            $table->getOptions()['layout']['bottomEnd']
+        );
+    }
+
+    #[Test]
+    public function paging_options_fill_a_boolean_paging_feature_object(): void
+    {
+        $table = (new DataTable('testTable'))
+            ->layout(['bottomEnd' => ['paging' => true]])
+            ->paging(buttons: 5);
+
+        $this->assertSame(5, $table->getOptions()['layout']['bottomEnd']['paging']['buttons']);
+    }
+
     /**
      * @param string[] $topics
      * @param string[] $expectedTopics


### PR DESCRIPTION
## Summary
- DataTables 2/3 treats top-level `paging` as a boolean. Feature keys from `paging()` / `data_tables.options.paging` (`boundaryNumbers`, `buttons`, `firstLast`, `numbers`, `previousNext`) were serialized there and silently ignored.
- `getOptions()` now injects those keys into unmarked layout paging slots (`'paging'`, `{ paging: true }`, `{ paging: [] }`, list markers) and sets top-level `paging` to `true`.
- Explicit `{ paging: { … } }` layout objects are left untouched. `withoutPaging()` still emits `paging: false`. No slot is invented when layout has no pager.

Closes #300

## Test plan
- [x] `vendor/bin/phpunit tests/Unit/Model/DataTableTest.php tests/Unit/Model/AbstractDataTableConfigDefaultsTest.php`
- [x] Marker `bottomEnd: paging` + `paging(buttons: 5, firstLast: false)` → layout feature object, `paging === true`
- [x] `withoutPaging()` → `paging === false`, layout string intact
- [x] Explicit layout `{ paging: { buttons: 3 } }` wins over `paging(buttons: 5)`
- [x] Layout without paging does not gain a slot
- [x] List `['info', 'paging']` rewrites the marker item
- [x] YAML bundle defaults remap `bottomEnd`
- [ ] Render a table with `paging(buttons: 3, firstLast: false)` and confirm the pager matches


Made with [Cursor](https://cursor.com)