### PR TITLE
Expose columns.responsivePriority on AbstractColumn

### DIFF
--- a/docs/src/content/docs/columns/action-column.mdx
+++ b/docs/src/content/docs/columns/action-column.mdx
@@ -59,7 +59,7 @@ final class UsersDataTable extends AbstractDataTable
 }
 ```
 
-When `configureActions()` returns at least one action, `AbstractDataTable` automatically appends an `ActionColumn` named `actions`.
+When `configureActions()` returns at least one action, `AbstractDataTable` automatically appends an `ActionColumn` named `actions`. That column serializes with `responsivePriority: 1` so action buttons stay visible when the Responsive extension hides overflow columns. Override it with `setResponsivePriority()` if another column should remain visible first.
 
 <Aside type="tip">
   When your table uses `#[AsDataTable(Entity::class)]`, the entity class is injected automatically

--- a/docs/src/content/docs/columns/overview.mdx
+++ b/docs/src/content/docs/columns/overview.mdx
@@ -54,6 +54,7 @@ $column
     ->setTitle('Full Name')           // Header label
     ->setClassName('text-primary')    // CSS class on each cell
     ->setWidth('200px')               // Column width
+    ->setResponsivePriority(1)        // Stay visible longer with Responsive
     ->setVisible(false)               // Hide the column
     ->setDefaultContent('N/A');       // Fallback for null values
 ```

--- a/docs/src/content/docs/extensions/responsive.mdx
+++ b/docs/src/content/docs/extensions/responsive.mdx
@@ -34,6 +34,27 @@ $dataTable->addExtension(
 details control entirely. Pass `breakpoints` (a list of `['name' => string, 'width' => int]` pairs)
 to override DataTables' built-in breakpoint list; omit it to keep the defaults.
 
+## Column Priority
+
+By default Responsive hides columns from the right. Use `setResponsivePriority()` when a column
+must stay visible longer than its position would imply. Lower numbers stay visible first; omitted
+columns use DataTables' default of `10000`.
+
+```php
+use Pentiminax\UX\DataTables\Column\NumberColumn;
+use Pentiminax\UX\DataTables\Column\TextColumn;
+
+public function configureColumns(): iterable
+{
+    yield NumberColumn::new('id', 'ID')->setResponsivePriority(1);
+    yield TextColumn::new('email', 'Email')->setResponsivePriority(2);
+    yield TextColumn::new('notes', 'Notes')->setResponsivePriority(4);
+}
+```
+
+`ActionColumn` already defaults to priority `1` so row actions stay on screen. Override it with
+`setResponsivePriority()` when another column should win.
+
 ## Frequent Pitfalls
 
 - Not setting column priorities when too many columns compete for visibility.
@@ -43,3 +64,4 @@ to override DataTables' built-in breakpoint list; omit it to keep the defaults.
 
 - [/ux-datatables/extensions/select/](/ux-datatables/extensions/select/)
 - [/ux-datatables/extensions/fixed-columns/](/ux-datatables/extensions/fixed-columns/)
+- [/ux-datatables/columns/overview/](/ux-datatables/columns/overview/)

--- a/docs/src/content/docs/reference/attributes.mdx
+++ b/docs/src/content/docs/reference/attributes.mdx
@@ -91,7 +91,7 @@ Arguments:
     ],
     [
       'Rendering',
-      '`width`, `className`, `cellType`, `defaultContent`, `renderAsBadges`',
+      '`width`, `className`, `cellType`, `defaultContent`, `renderAsBadges`, `responsivePriority`',
     ],
     ['Data mapping', '`field`, `format`, `position`'],
   ]}

--- a/src/Attribute/Column.php
+++ b/src/Attribute/Column.php
@@ -25,6 +25,7 @@ final class Column
         public readonly array|bool $renderAsBadges = false,
         public readonly bool $hideWhenUpdating = false,
         public readonly ?int $position = null,
+        public readonly ?int $responsivePriority = null,
     ) {
     }
 }

--- a/src/Column/AbstractColumn.php
+++ b/src/Column/AbstractColumn.php
@@ -14,7 +14,8 @@ use Pentiminax\UX\DataTables\Enum\ColumnType;
  * Not meant to be extended directly to build a custom column type — extend a concrete column
  * class instead, or implement {@see ColumnInterface} directly for something that shares nothing
  * with the bundled types. Every public method here (setField(), setColumnControl(),
- * setClassName(), setCustomOption(), setVisible(), disableGlobalSearch(), ...) is part of the
+ * setClassName(), setCustomOption(), setVisible(), setResponsivePriority(),
+ * disableGlobalSearch(), ...) is part of the
  * bundle's documented column-configuration API and is inherited unchanged by every concrete
  * column — see the "Columns" documentation for usage. Only createWithType() below is genuinely
  * internal, restricted to how the bundled column types build themselves.
@@ -40,6 +41,7 @@ abstract class AbstractColumn implements ColumnInterface, PermissionAwareColumnI
     protected ?array $columnControl      = null;
     protected array $customOptions       = [];
     protected ?string $permission        = null;
+    protected ?int $responsivePriority   = null;
 
     /**
      * Convenient factory helper used by concrete columns to set their type.
@@ -182,6 +184,25 @@ abstract class AbstractColumn implements ColumnInterface, PermissionAwareColumnI
         $this->width = $width;
 
         return $this;
+    }
+
+    /**
+     * Set the DataTables Responsive visibility priority for this column.
+     *
+     * Lower numbers stay visible longer. Omitted (null) lets Responsive use its default of 10000.
+     * Negative values are allowed and increase priority further. Has a visible effect only when
+     * the Responsive extension is enabled on the table.
+     */
+    public function setResponsivePriority(?int $priority): static
+    {
+        $this->responsivePriority = $priority;
+
+        return $this;
+    }
+
+    public function getResponsivePriority(): ?int
+    {
+        return $this->responsivePriority;
     }
 
     public function getTitle(): ?string
@@ -371,19 +392,20 @@ abstract class AbstractColumn implements ColumnInterface, PermissionAwareColumnI
         }
 
         $options = array_filter([
-            'cellType'       => $this->cellType,
-            'className'      => $className,
-            'data'           => $this->data,
-            'defaultContent' => $this->defaultContent,
-            'name'           => $this->name,
-            'orderable'      => $this->orderable,
-            'searchable'     => $this->searchable,
-            'title'          => $this->title,
-            'type'           => $this->type->value,
-            'visible'        => $this->visible,
-            'width'          => $this->width,
-            'field'          => $this->getField(),
-            'customOptions'  => $this->customOptions,
+            'cellType'           => $this->cellType,
+            'className'          => $className,
+            'data'               => $this->data,
+            'defaultContent'     => $this->defaultContent,
+            'name'               => $this->name,
+            'orderable'          => $this->orderable,
+            'searchable'         => $this->searchable,
+            'title'              => $this->title,
+            'type'               => $this->type->value,
+            'visible'            => $this->visible,
+            'width'              => $this->width,
+            'field'              => $this->getField(),
+            'customOptions'      => $this->customOptions,
+            'responsivePriority' => $this->responsivePriority,
         ], static fn (mixed $value) => null !== $value && '' !== $value && [] !== $value);
 
         if (null !== $this->columnControl) {

--- a/src/Column/ActionColumn.php
+++ b/src/Column/ActionColumn.php
@@ -37,7 +37,8 @@ class ActionColumn extends AbstractColumn implements ActionsProvidingColumnInter
             ->disableGlobalSearch()
             ->disableColumnControl()
             ->setType(ColumnType::STRING)
-            ->setExportable(false);
+            ->setExportable(false)
+            ->setResponsivePriority(1);
     }
 
     public function getActions(): ?Actions
@@ -55,8 +56,7 @@ class ActionColumn extends AbstractColumn implements ActionsProvidingColumnInter
     public function jsonSerialize(): array
     {
         return array_merge(parent::jsonSerialize(), [
-            'actions'            => $this->actions?->jsonSerialize(),
-            'responsivePriority' => 1,
+            'actions' => $this->actions?->jsonSerialize(),
         ]);
     }
 }

--- a/src/Column/AttributeColumnReader.php
+++ b/src/Column/AttributeColumnReader.php
@@ -81,6 +81,10 @@ final class AttributeColumnReader
             $column->setWidth($attr->width);
         }
 
+        if (null !== $attr->responsivePriority) {
+            $column->setResponsivePriority($attr->responsivePriority);
+        }
+
         if (null !== $attr->className) {
             $column->setClassName($attr->className);
         }

--- a/tests/Unit/Column/AbstractColumnTest.php
+++ b/tests/Unit/Column/AbstractColumnTest.php
@@ -55,9 +55,11 @@ final class AbstractColumnTest extends TestCase
         $this->assertNull($column->getClassName());
         $this->assertNull($column->getCellType());
         $this->assertNull($column->getDefaultContent());
+        $this->assertNull($column->getResponsivePriority());
         $this->assertSame([], $column->getCustomOptions());
         $this->assertNull($column->getCustomOption('unknown'));
         $this->assertArrayNotHasKey('columnControl', $column->jsonSerialize());
+        $this->assertArrayNotHasKey('responsivePriority', $column->jsonSerialize());
     }
 
     #[Test]
@@ -135,6 +137,31 @@ final class AbstractColumnTest extends TestCase
     }
 
     #[Test]
+    public function it_omits_responsive_priority_until_it_is_set(): void
+    {
+        $column = (new class extends AbstractColumn {})
+            ->setType(ColumnType::STRING)
+            ->setName('email');
+
+        $this->assertNull($column->getResponsivePriority());
+        $this->assertArrayNotHasKey('responsivePriority', $column->jsonSerialize());
+
+        $this->assertSame($column, $column->setResponsivePriority(1));
+        $this->assertSame(1, $column->getResponsivePriority());
+        $this->assertSame(1, $column->jsonSerialize()['responsivePriority']);
+
+        $column->setResponsivePriority(0);
+        $this->assertSame(0, $column->jsonSerialize()['responsivePriority']);
+
+        $column->setResponsivePriority(-1);
+        $this->assertSame(-1, $column->jsonSerialize()['responsivePriority']);
+
+        $column->setResponsivePriority(null);
+        $this->assertNull($column->getResponsivePriority());
+        $this->assertArrayNotHasKey('responsivePriority', $column->jsonSerialize());
+    }
+
+    #[Test]
     public function permission_is_stored_server_side_and_never_serialized(): void
     {
         $column = (new class extends AbstractColumn {})
@@ -149,8 +176,9 @@ final class AbstractColumnTest extends TestCase
     }
 
     /**
-     * setField(), setColumnControl(), setClassName(), setCustomOption(), setVisible(), and
-     * disableGlobalSearch() are documented public API (see columns/overview.mdx) inherited
+     * setField(), setColumnControl(), setClassName(), setCustomOption(), setVisible(),
+     * setResponsivePriority(), and disableGlobalSearch() are documented public API
+     * (see columns/overview.mdx) inherited
      * unchanged by every concrete column type. A class-level @internal here previously made
      * static analysis tools such as Psalm flag every one of those calls from application code
      * as touching an internal class, even though only createWithType() is actually meant to

--- a/tests/Unit/Column/ActionColumnTest.php
+++ b/tests/Unit/Column/ActionColumnTest.php
@@ -65,4 +65,22 @@ final class ActionColumnTest extends TestCase
         $this->assertSame(1, $actions->count());
         $this->assertTrue($clone->getActions()?->isEmpty());
     }
+
+    #[Test]
+    public function it_allows_overriding_the_default_responsive_priority(): void
+    {
+        $column = ActionColumn::fromActions(
+            'actions',
+            'Actions',
+            (new Actions())->add(Action::detail()->linkToUrl('/books/42'))
+        );
+
+        $this->assertSame(1, $column->getResponsivePriority());
+        $this->assertSame(1, $column->jsonSerialize()['responsivePriority']);
+
+        $column->setResponsivePriority(2);
+
+        $this->assertSame(2, $column->getResponsivePriority());
+        $this->assertSame(2, $column->jsonSerialize()['responsivePriority']);
+    }
 }

--- a/tests/Unit/Column/AttributeColumnReaderTest.php
+++ b/tests/Unit/Column/AttributeColumnReaderTest.php
@@ -102,6 +102,7 @@ final class AttributeColumnReaderTest extends TestCase
         $this->assertFalse($data['searchable']);
         $this->assertFalse($data['visible']);
         $this->assertSame('120px', $data['width']);
+        $this->assertSame(2, $data['responsivePriority']);
         $this->assertSame('text-center not-exportable', $data['className']);
         $this->assertSame('th', $data['cellType']);
         $this->assertArrayNotHasKey('render', $data);
@@ -207,6 +208,7 @@ final class OptionsFixture
         exportable: false,
         globalSearchable: false,
         width: '120px',
+        responsivePriority: 2,
         className: 'text-center',
         cellType: 'th',
         defaultContent: 'N/A',


### PR DESCRIPTION
## Summary
- Add `setResponsivePriority()` / `getResponsivePriority()` on `AbstractColumn` and serialize the DataTables `columns.responsivePriority` option when set.
- Keep `ActionColumn` defaulting to priority `1` so row actions stay visible, while allowing override.
- Expose the same option on `#[Column]` and document usage with the Responsive extension.

## Test plan
- [x] `composer fix`
- [x] `composer audit`
- [x] `vendor/bin/phpunit tests/Unit/Column tests/Unit/Contracts/ColumnInterfaceTest.php tests/Unit/Model/AbstractDataTableActionsTest.php`
- [x] `npm run lint` in `docs/`
- [ ] Spot-check a table with Responsive enabled: identity/actions stay visible, secondary columns hide first

Closes #364

Made with [Cursor](https://cursor.com)