### PR TITLE
refactor(template-column): align Twig row with mapRow()

### DIFF
--- a/docs/src/content/docs/columns/action-column.mdx
+++ b/docs/src/content/docs/columns/action-column.mdx
@@ -47,13 +47,13 @@ final class UsersDataTable extends AbstractDataTable
             );
     }
 
-    protected function mapRow(mixed $item): array
+    protected function mapRow(mixed $row): array
     {
-        /** @var User $item */
+        /** @var User $row */
         return [
-            'id'     => $item->getId(),
-            'email'  => $item->getEmail(),
-            'status' => $item->getStatus(),
+            'id'     => $row->getId(),
+            'email'  => $row->getEmail(),
+            'status' => $row->getStatus(),
         ];
     }
 }

--- a/docs/src/content/docs/columns/boolean-column.mdx
+++ b/docs/src/content/docs/columns/boolean-column.mdx
@@ -105,12 +105,12 @@ final class UsersDataTable extends AbstractDataTable
         // Entity class is injected automatically from #[AsDataTable(User::class)]
     }
 
-    protected function mapRow(mixed $item): array
+    protected function mapRow(mixed $row): array
     {
         return [
-            'id'     => $item->getId(),
-            'email'  => $item->getEmail(),
-            'active' => $item->isActive(),
+            'id'     => $row->getId(),
+            'email'  => $row->getEmail(),
+            'active' => $row->isActive(),
         ];
     }
 }

--- a/docs/src/content/docs/columns/choice-column.mdx
+++ b/docs/src/content/docs/columns/choice-column.mdx
@@ -122,12 +122,12 @@ final class OrdersDataTable extends AbstractDataTable
             ]);
     }
 
-    protected function mapRow(mixed $item): array
+    protected function mapRow(mixed $row): array
     {
         return [
-            'id'        => $item->getId(),
-            'reference' => $item->getReference(),
-            'status'    => $item->getStatus()->value,
+            'id'        => $row->getId(),
+            'reference' => $row->getReference(),
+            'status'    => $row->getStatus()->value,
         ];
     }
 }

--- a/docs/src/content/docs/columns/date-column.mdx
+++ b/docs/src/content/docs/columns/date-column.mdx
@@ -81,13 +81,13 @@ final class ArticlesDataTable extends AbstractDataTable
         yield DateColumn::new('updatedAt', 'Updated')->setFormat('Y-m-d H:i');
     }
 
-    protected function mapRow(mixed $item): array
+    protected function mapRow(mixed $row): array
     {
         return [
-            'id'          => $item->getId(),
-            'title'       => $item->getTitle(),
-            'publishedAt' => $item->getPublishedAt()?->format('Y-m-d'),
-            'updatedAt'   => $item->getUpdatedAt()?->format('Y-m-d H:i'),
+            'id'          => $row->getId(),
+            'title'       => $row->getTitle(),
+            'publishedAt' => $row->getPublishedAt()?->format('Y-m-d'),
+            'updatedAt'   => $row->getUpdatedAt()?->format('Y-m-d H:i'),
         ];
     }
 }

--- a/docs/src/content/docs/columns/email-column.mdx
+++ b/docs/src/content/docs/columns/email-column.mdx
@@ -122,12 +122,12 @@ final class UsersDataTable extends AbstractDataTable
             ->mask();
     }
 
-    protected function mapRow(mixed $item): array
+    protected function mapRow(mixed $row): array
     {
         return [
-            'id'    => $item->getId(),
-            'name'  => $item->getName(),
-            'email' => $item->getEmail(),
+            'id'    => $row->getId(),
+            'name'  => $row->getName(),
+            'email' => $row->getEmail(),
         ];
     }
 }

--- a/docs/src/content/docs/columns/icon-column.mdx
+++ b/docs/src/content/docs/columns/icon-column.mdx
@@ -174,11 +174,11 @@ final class UsersDataTable extends AbstractDataTable
             ]);
     }
 
-    protected function mapRow(mixed $item): array
+    protected function mapRow(mixed $row): array
     {
         return [
-            'name'   => $item->getName(),
-            'status' => $item->getStatus(),
+            'name'   => $row->getName(),
+            'status' => $row->getStatus(),
         ];
     }
 }

--- a/docs/src/content/docs/columns/image-column.mdx
+++ b/docs/src/content/docs/columns/image-column.mdx
@@ -140,12 +140,12 @@ final class UsersDataTable extends AbstractDataTable
         yield TextColumn::new('name', 'Name');
     }
 
-    protected function mapRow(mixed $item): array
+    protected function mapRow(mixed $row): array
     {
         return [
-            'id'     => $item->getId(),
-            'avatar' => $item->getAvatarUrl(),
-            'name'   => $item->getName(),
+            'id'     => $row->getId(),
+            'avatar' => $row->getAvatarUrl(),
+            'name'   => $row->getName(),
         ];
     }
 }

--- a/docs/src/content/docs/columns/money-column.mdx
+++ b/docs/src/content/docs/columns/money-column.mdx
@@ -65,11 +65,11 @@ final class ProductsDataTable extends AbstractDataTable
         yield MoneyColumn::new('price', 'Price')->currency('EUR');
     }
 
-    protected function mapRow(mixed $item): array
+    protected function mapRow(mixed $row): array
     {
         return [
-            'name'  => $item->getName(),
-            'price' => $item->getPriceInCents(),
+            'name'  => $row->getName(),
+            'price' => $row->getPriceInCents(),
         ];
     }
 }

--- a/docs/src/content/docs/columns/number-column.mdx
+++ b/docs/src/content/docs/columns/number-column.mdx
@@ -91,13 +91,13 @@ final class ProductsDataTable extends AbstractDataTable
         yield NumberColumn::new('price', 'Price');
     }
 
-    protected function mapRow(mixed $item): array
+    protected function mapRow(mixed $row): array
     {
         return [
-            'id'    => $item->getId(),
-            'name'  => $item->getName(),
-            'stock' => $item->getStock(),
-            'price' => $item->getPrice(),
+            'id'    => $row->getId(),
+            'name'  => $row->getName(),
+            'stock' => $row->getStock(),
+            'price' => $row->getPrice(),
         ];
     }
 }

--- a/docs/src/content/docs/columns/template-column.mdx
+++ b/docs/src/content/docs/columns/template-column.mdx
@@ -5,7 +5,7 @@ order: 120
 navTitle: Template
 ---
 
-`TemplateColumn` delegates cell rendering to a Twig template. Use it when you need server-side HTML that depends on entity state, complex conditionals, or components that are impractical to build as a JavaScript `render` callback.
+`TemplateColumn` delegates cell rendering to a Twig template. Use it when you need server-side HTML that depends on row state, complex conditionals, or components that are impractical to build as a JavaScript `render` callback.
 
 ## Basic Usage
 
@@ -17,7 +17,7 @@ TemplateColumn::new('status_display', 'Status')
     ->setTemplate('datatable/columns/user_status.html.twig');
 ```
 
-The column name (`status_display`) is the key used in `mapRow()`. `setField()` tells the row mapper which property to read from the entity.
+The column name (`status_display`) is the key used in `mapRow()`. `setField()` tells the row mapper which property to read from the row object.
 
 ## Template Context
 
@@ -25,10 +25,14 @@ Inside the template, the following variables are available:
 
 | Variable | Value |
 |---|---|
-| `entity` | The source object from `mapRow()` |
-| `data` | The resolved field value |
+| `row` | The object passed to `mapRow()` (the projected DTO when a page projector is active, otherwise the source object) |
+| `source` | The original hydrated object. Same reference as `row` when no projector is active |
+| `data` | The resolved field value for this cell |
 | `column` | Serialized column configuration array |
-| `row` | The full row array |
+
+`entity` is a deprecated alias of `row`. Prefer `row`.
+
+Templates do not receive the array returned by `mapRow()`. Read domain properties from `row` and this cell's value from `data`.
 
 Example template:
 
@@ -50,7 +54,7 @@ TemplateColumn::new('actions', 'Actions')
     ]);
 ```
 
-Parameters are merged into the template context.
+Parameters are merged into the template context. Keys `row`, `source`, `data`, `column`, and `entity` are reserved.
 
 ## API Reference
 
@@ -58,7 +62,7 @@ Parameters are merged into the template context.
   headers={['Method', 'Description']}
   rows={[
     ["`TemplateColumn::new(string $name, string $title = '')`", 'Creates a new TemplateColumn (type: `html`)'],
-    ['`setTemplate(string $template, array $parameters = [])`', 'Set the Twig template path and optional static parameters. Throws on empty path.'],
+    ['`setTemplate(string $template, array $parameters = [])`', 'Set the Twig template path and optional static parameters. Throws on empty path. Reserved context keys cannot be overridden.'],
     ['`getTemplate(): string`', 'Returns the configured template path. Throws if not set.'],
     ['`getTemplateParameters(): array`', 'Returns the static parameters passed to the template'],
   ]}
@@ -85,12 +89,12 @@ final class ProductsDataTable extends AbstractDataTable
             ->setTemplate('datatable/columns/stock_badge.html.twig');
     }
 
-    protected function mapRow(mixed $item): array
+    protected function mapRow(mixed $row): array
     {
         return [
-            'id'         => $item->getId(),
-            'name'       => $item->getName(),
-            'stock_badge' => $item->getStock(),
+            'id'         => $row->getId(),
+            'name'       => $row->getName(),
+            'stock_badge' => $row->getStock(),
         ];
     }
 }

--- a/docs/src/content/docs/columns/text-column.mdx
+++ b/docs/src/content/docs/columns/text-column.mdx
@@ -70,12 +70,12 @@ final class UsersDataTable extends AbstractDataTable
         yield TextColumn::new('bio', 'Bio')->html()->utf8();
     }
 
-    protected function mapRow(mixed $item): array
+    protected function mapRow(mixed $row): array
     {
         return [
-            'id'   => $item->getId(),
-            'name' => $item->getName(),
-            'bio'  => $item->getBio(),
+            'id'   => $row->getId(),
+            'name' => $row->getName(),
+            'bio'  => $row->getBio(),
         ];
     }
 }

--- a/docs/src/content/docs/columns/url-column.mdx
+++ b/docs/src/content/docs/columns/url-column.mdx
@@ -191,12 +191,12 @@ final class UsersDataTable extends AbstractDataTable
             ->showExternalIcon();
     }
 
-    protected function mapRow(mixed $item): array
+    protected function mapRow(mixed $row): array
     {
         return [
-            'id'      => $item->getId(),
-            'name'    => $item->getName(),
-            'website' => $item->getWebsite(),
+            'id'      => $row->getId(),
+            'name'    => $row->getName(),
+            'website' => $row->getWebsite(),
         ];
     }
 }

--- a/docs/src/content/docs/getting-started/first-server-side-table.mdx
+++ b/docs/src/content/docs/getting-started/first-server-side-table.mdx
@@ -40,12 +40,12 @@ final class UsersDataTable extends AbstractDataTable
         return $table->serverSide()->processing();
     }
 
-    protected function mapRow(mixed $item): array
+    protected function mapRow(mixed $row): array
     {
-        /** @var User $item */
+        /** @var User $row */
         return [
-            'id'    => $item->getId(),
-            'email' => $item->getEmail(),
+            'id'    => $row->getId(),
+            'email' => $row->getEmail(),
         ];
     }
 }

--- a/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/docs/src/content/docs/getting-started/quick-start.mdx
@@ -157,14 +157,14 @@ final class UsersDataTable extends AbstractDataTable
         yield TextColumn::new('email', 'Email');
     }
 
-    protected function mapRow(mixed $item): array
+    protected function mapRow(mixed $row): array
     {
-        /** @var User $item */
+        /** @var User $row */
         return [
-            'id' => $item->getId(),
-            'firstName' => $item->getFirstName(),
-            'lastName' => $item->getLastName(),
-            'email' => $item->getEmail(),
+            'id' => $row->getId(),
+            'firstName' => $row->getFirstName(),
+            'lastName' => $row->getLastName(),
+            'email' => $row->getEmail(),
         ];
     }
 }

--- a/docs/src/content/docs/guide/client-side-processing.mdx
+++ b/docs/src/content/docs/guide/client-side-processing.mdx
@@ -124,13 +124,13 @@ final class UsersDataTable extends AbstractDataTable
         yield TextColumn::new('role', 'Role');
     }
 
-    protected function mapRow(mixed $item): array
+    protected function mapRow(mixed $row): array
     {
-        /** @var User $item */
+        /** @var User $row */
         return [
-            'fullName' => $item->getFirstName().' '.$item->getLastName(),
-            'email' => $item->getEmail(),
-            'role' => $item->getRole()->value,
+            'fullName' => $row->getFirstName().' '.$row->getLastName(),
+            'email' => $row->getEmail(),
+            'role' => $row->getRole()->value,
         ];
     }
 

--- a/docs/src/content/docs/recipes/doctrine-server-side.mdx
+++ b/docs/src/content/docs/recipes/doctrine-server-side.mdx
@@ -35,12 +35,12 @@ final class UsersDataTable extends AbstractDataTable
             ->processing();
     }
 
-    protected function mapRow(mixed $item): array
+    protected function mapRow(mixed $row): array
     {
-        /** @var User $item */
+        /** @var User $row */
         return [
-            'id'    => $item->getId(),
-            'email' => $item->getEmail(),
+            'id'    => $row->getId(),
+            'email' => $row->getEmail(),
         ];
     }
 }

--- a/docs/src/content/docs/recipes/money-column.mdx
+++ b/docs/src/content/docs/recipes/money-column.mdx
@@ -23,11 +23,11 @@ public function configureColumns(): iterable
         ->storedAsCents();
 }
 
-protected function mapRow(mixed $item): array
+protected function mapRow(mixed $row): array
 {
     return [
-        'name'  => $item->getName(),
-        'price' => $item->getPriceInCents(), // e.g. 1999 → €19.99
+        'name'  => $row->getName(),
+        'price' => $row->getPriceInCents(), // e.g. 1999 → €19.99
     ];
 }
 ```

--- a/docs/src/content/docs/reference/abstract-datatable.mdx
+++ b/docs/src/content/docs/reference/abstract-datatable.mdx
@@ -38,14 +38,14 @@ final class UsersDataTable extends AbstractDataTable
         yield TextColumn::new('email', 'Email');
     }
 
-    protected function mapRow(mixed $item): array
+    protected function mapRow(mixed $row): array
     {
-        /** @var User $item */
+        /** @var User $row */
         return [
-            'id' => $item->getId(),
-            'lastName' => $item->getLastName(),
-            'firstName' => $item->getFirstName(),
-            'email' => $item->getEmail(),
+            'id' => $row->getId(),
+            'lastName' => $row->getLastName(),
+            'firstName' => $row->getFirstName(),
+            'email' => $row->getEmail(),
         ];
     }
 }
@@ -330,7 +330,7 @@ the table declaratively and let the request-scoped boundaries do the rest:
     ['`fetchData(DataTableRequest $request)`', 'Fetch data using the provider'],
     ['`getRequest()`', 'Get the parsed DataTables request'],
     ['`getHttpRequest()`', 'Get the current Symfony HTTP request after `handleRequest()`'],
-    ['`mapRow(mixed $item)`', 'Map a single entity to array'],
+    ['`mapRow(mixed $row)`', 'Map a single row to array'],
     ['`setData(array $data)`', 'Set inline data through the same row-processing pipeline used by providers'],
     ['`createRowMapper()`', 'Protected helper returning the internal row-processing mapper'],
     ['`customizeQueryBuilder(QueryBuilder $qb, ...)`', 'Modify Doctrine query before DataTables filters are applied'],
@@ -372,10 +372,10 @@ final class CustomUsersDataTable extends AbstractDataTable
         return new ArrayDataProvider($rows, $this->createRowMapper());
     }
 
-    protected function mapRow(mixed $item): array
+    protected function mapRow(mixed $row): array
     {
         // For arrays, just return as-is
-        return is_array($item) ? $item : (array) $item;
+        return is_array($row) ? $row : (array) $row;
     }
 }
 ```

--- a/docs/src/content/docs/reference/maker.mdx
+++ b/docs/src/content/docs/reference/maker.mdx
@@ -67,14 +67,14 @@ final class UserDataTable extends AbstractDataTable
         // Add more columns as needed
     }
 
-    protected function mapRow(mixed $item): array
+    protected function mapRow(mixed $row): array
     {
-        /** @var User $item */
+        /** @var User $row */
         return [
-            'id' => $item->getId(),
-            'email' => $item->getEmail(),
-            'firstName' => $item->getFirstName(),
-            'lastName' => $item->getLastName(),
+            'id' => $row->getId(),
+            'email' => $row->getEmail(),
+            'firstName' => $row->getFirstName(),
+            'lastName' => $row->getLastName(),
         ];
     }
 }

--- a/skills/ux-datatables/references/columns.md
+++ b/skills/ux-datatables/references/columns.md
@@ -15,7 +15,7 @@ All columns live in `src/Column/`. Every type is created with the static factory
 | `EmailColumn` | `EmailColumn::new('email')` | `obfuscate(bool=true)`, `mask(bool=true)`, `setDisplayValue(string)`, `renderAsText(bool=true)` |
 | `ImageColumn` | `ImageColumn::new('photo')` | `setImageWidth(int)`, `setImageHeight(int)`, `setAlt(string)`, `setPlaceholder(string)`, `rounded()`, `lazy()`, `clickable()` |
 | `UrlColumn` | `UrlColumn::new('website')` | `linkToUrl(string\|callable)`, `linkToRoute(string $route, array\|callable\|null $params=null)`, `openInNewTab()`, `showExternalIcon(bool=true)`, `setDisplayValue(string)`, `setDefaultProtocol(string)`, `allowedProtocols(array)` |
-| `TemplateColumn` | `TemplateColumn::new('preview')` | `setTemplate(string $template, array $parameters=[])` — server-side Twig rendering |
+| `TemplateColumn` | `TemplateColumn::new('preview')` | `setTemplate(string $template, array $parameters=[])` — server-side Twig. Context: `row` (mapRow object), `source`, `data`, `column`. `entity` is a deprecated alias of `row`. |
 | `ActionColumn` | *(auto-generated from `configureActions()` — do not build manually)* | see `references/actions.md` |
 
 > `UrlColumn` supports `linkToRoute()`; `Action` (row actions) does **not** — it only has `linkToUrl()`.

--- a/skills/ux-datatables/references/defining-a-datatable.md
+++ b/skills/ux-datatables/references/defining-a-datatable.md
@@ -98,9 +98,9 @@ Rules and routing:
 
 - Return `null` (the default) to disable projection. The returned list **must preserve the count and order** of `$items` — otherwise a `LogicException` is thrown.
 - When a projector is active, the bundle pairs each source entity with its projected item (`RowContext`, `src/RowMapper/RowContext.php`) and routes them:
-  - **Columns + Twig rendering** read the **projected** item (the DTO).
+  - **Columns + TemplateColumn Twig (`row`)** read the **projected** item (the DTO).
   - **Actions, `UrlColumn`, and `permission()`** receive the **source** entity.
-  - Without a projector, both reference the same value.
+  - Without a projector, both reference the same value. Twig `source` is that original object.
 - A projected/computed column has no DB counterpart: mark it `->setOrderable(false)->setSearchable(false)`, or sort it via `->setOrderExpression(...)` backed by an `addSelect(... AS HIDDEN ...)` — see `references/server-side.md`.
 
 ## Maker

--- a/skills/ux-datatables/references/gotchas.md
+++ b/skills/ux-datatables/references/gotchas.md
@@ -40,7 +40,7 @@ Static `permission()` on actions/columns is evaluated server-side before seriali
 The enum case is `COLUMN_VISIBILITY` (serialized value `'colvis'`), not `COL_VIS`.
 
 ## `projectPage()` must preserve page size and order
-A page projector that returns a different count (or reordered rows) throws `LogicException`. Map one-to-one. Remember the split: columns/Twig read the projected DTO, but actions/`UrlColumn`/`permission()` still receive the **source** entity — don't move identifiers needed by actions into the DTO only.
+A page projector that returns a different count (or reordered rows) throws `LogicException`. Map one-to-one. Remember the split: columns and TemplateColumn Twig (`row`) read the projected DTO, but actions/`UrlColumn`/`permission()` still receive the **source** entity — don't move identifiers needed by actions into the DTO only.
 
 ## Sorting a computed column needs `setOrderExpression()`
 A column with no real entity property (e.g. an `addSelect(... AS HIDDEN <alias>)` subquery) can't sort via the default `<alias>.<field>` — it resolves to a nonexistent `e.<field>` and errors. Either `->setOrderExpression('<alias>')` (and `->setSearchable(false)`), or `->setOrderable(false)->setSearchable(false)`.

--- a/src/Column/Rendering/TemplateColumnRenderer.php
+++ b/src/Column/Rendering/TemplateColumnRenderer.php
@@ -11,7 +11,12 @@ use Twig\Environment;
 
 final class TemplateColumnRenderer
 {
-    public const array RESERVED_CONTEXT_KEYS = ['entity', 'data', 'column', 'row', 'source', 'item'];
+    /**
+     * Twig keys reserved by the renderer.
+     *
+     * `entity` is a deprecated alias of `row` and remains reserved until it is removed.
+     */
+    public const array RESERVED_CONTEXT_KEYS = ['entity', 'data', 'column', 'row', 'source'];
 
     public function __construct(
         private readonly ?Environment $twig = null,
@@ -24,10 +29,10 @@ final class TemplateColumnRenderer
     public function renderRow(array $row, mixed $mappedRow, iterable $columns): array
     {
         $renderedRow = $row;
-        $contextRow  = $row;
+        $payload     = $row;
 
-        $source = $mappedRow instanceof RowContext ? $mappedRow->source : $mappedRow;
-        $item   = $mappedRow instanceof RowContext ? $mappedRow->item : $mappedRow;
+        $source     = $mappedRow instanceof RowContext ? $mappedRow->source : $mappedRow;
+        $contextRow = $mappedRow instanceof RowContext ? $mappedRow->item : $mappedRow;
 
         foreach ($columns as $column) {
             if (!$column instanceof TemplateAwareColumnInterface) {
@@ -39,15 +44,18 @@ final class TemplateColumnRenderer
                 continue;
             }
 
-            $data = $this->resolveData(mappedRow: $item, row: $contextRow, field: ColumnKeyResolver::readPath($column, $rowKey));
+            $data = $this->resolveData(
+                mappedRow: $contextRow,
+                row: $payload,
+                field: ColumnKeyResolver::readPath($column, $rowKey),
+            );
 
             $context = [
-                'entity' => $item,
-                'data'   => $data,
-                'column' => $column->jsonSerialize(),
                 'row'    => $contextRow,
                 'source' => $source,
-                'item'   => $item,
+                'data'   => $data,
+                'column' => $column->jsonSerialize(),
+                'entity' => $contextRow,
             ];
 
             foreach ($column->getTemplateParameters() as $key => $value) {

--- a/src/Column/TemplateColumn.php
+++ b/src/Column/TemplateColumn.php
@@ -22,6 +22,10 @@ class TemplateColumn extends AbstractColumn implements TemplateAwareColumnInterf
             ->disableGlobalSearch();
     }
 
+    /**
+     * @param array<string, mixed> $parameters Extra Twig variables. Keys `row`, `source`, `data`,
+     *                                         `column`, and the deprecated alias `entity` are reserved.
+     */
     public function setTemplate(string $template, array $parameters = []): static
     {
         $template = trim($template);

--- a/src/Contracts/TemplateAwareColumnInterface.php
+++ b/src/Contracts/TemplateAwareColumnInterface.php
@@ -8,7 +8,7 @@ namespace Pentiminax\UX\DataTables\Contracts;
  * Marker interface for columns whose cell value is rendered by a Twig template.
  *
  * Implementations are picked up by the template renderer to render their cell
- * value at row-mapping time, with the row data and any extra parameters as context.
+ * value at row-mapping time, with the mapRow object, cell value, and extra parameters as context.
  */
 interface TemplateAwareColumnInterface extends ColumnInterface
 {

--- a/src/Model/AbstractDataTable.php
+++ b/src/Model/AbstractDataTable.php
@@ -375,8 +375,8 @@ abstract class AbstractDataTable
      *
      * Override to batch-enrich the page (load metrics, project to DTOs) without an N+1.
      * Return null (the default) to disable projection. When projecting, the returned list
-     * must preserve the count and order of $items: columns and Twig then read the projected
-     * item, while actions still receive the source entity.
+     * must preserve the count and order of $items: columns and TemplateColumn Twig (`row`) then
+     * read the projected item, while actions still receive the source entity.
      *
      * @param list<mixed> $items
      *

--- a/src/RowMapper/RowContext.php
+++ b/src/RowMapper/RowContext.php
@@ -8,9 +8,9 @@ namespace Pentiminax\UX\DataTables\RowMapper;
  * Pairs the original source item hydrated by the data source with the projected
  * item produced by a page projector.
  *
- * Columns and Twig read displayed values from {@see self::$item}; actions, URLs,
- * and permission checks receive {@see self::$source}. When no projector is active,
- * both reference the same value.
+ * Columns read displayed values from {@see self::$item}; TemplateColumn Twig
+ * receives that value as `row`. Actions, URLs, and permission checks receive
+ * {@see self::$source}. When no projector is active, both reference the same value.
  */
 final readonly class RowContext
 {

--- a/tests/Kernel/templates/datatable/columns/entity_status_badge.html.twig
+++ b/tests/Kernel/templates/datatable/columns/entity_status_badge.html.twig
@@ -1,1 +1,1 @@
-<span class="badge">{{ entity.templateLabel }}-{{ data }}</span>
+<span class="badge">{{ row.templateLabel }}-{{ data }}</span>

--- a/tests/Unit/Column/TemplateColumnRendererTest.php
+++ b/tests/Unit/Column/TemplateColumnRendererTest.php
@@ -128,21 +128,40 @@ final class TemplateColumnRendererTest extends TestCase
             ],
         ];
 
-        yield 'entity, row and column exposed in the twig context' => [
-            ['column.html.twig' => '{{ entity.getStatus() }}-{{ row.id }}-{{ column.name }}'],
+        yield 'row is the mapRow object, not the payload array' => [
+            ['column.html.twig' => '{{ row.getStatus() }}-{{ row.id }}-{{ column.name }}'],
             [TemplateColumn::new('status_display')->setField('status')->setTemplate('column.html.twig')],
             ['id' => 42],
             new TemplateEntity(id: 42, status: 'verified'),
             ['id' => 42, 'status_display' => 'verified-42-status_display'],
         ];
 
-        // entity (back-compat) and item both resolve to the projected DTO; source stays the original.
-        yield 'projected item and original source of a row context' => [
-            ['column.html.twig' => '{{ item.getStatus() }}|{{ source.getStatus() }}|{{ entity.getStatus() }}'],
+        yield 'entity remains a deprecated alias of row' => [
+            ['column.html.twig' => '{{ entity.getStatus() }}'],
+            [TemplateColumn::new('status_display')->setField('status')->setTemplate('column.html.twig')],
+            ['id' => 42],
+            new TemplateEntity(id: 42, status: 'verified'),
+            ['id' => 42, 'status_display' => 'verified'],
+        ];
+
+        yield 'projected row and original source of a row context' => [
+            ['column.html.twig' => '{{ row.getStatus() }}|{{ source.getStatus() }}|{{ entity.getStatus() }}'],
             [TemplateColumn::new('status_display')->setField('status')->setTemplate('column.html.twig')],
             ['id' => 1],
             new RowContext(new TemplateEntity(id: 1, status: 'raw'), new TemplateEntity(id: 1, status: 'projected')),
             ['id' => 1, 'status_display' => 'projected|raw|projected'],
+        ];
+
+        yield 'item is not reserved and can be passed as a template parameter' => [
+            ['column.html.twig' => '{{ item }}: {{ data }}'],
+            [
+                TemplateColumn::new('status_display')
+                    ->setField('status')
+                    ->setTemplate('column.html.twig', ['item' => 'custom']),
+            ],
+            ['status' => 'active'],
+            [],
+            ['status' => 'active', 'status_display' => 'custom: active'],
         ];
     }
 


### PR DESCRIPTION
## Summary
- TemplateColumn Twig `row` is now the object passed to `mapRow()`, not the mapped payload array (that name collided with `mapRow(mixed $row)`).
- Context is `row`, `source` (page projector original), `data`, `column`. `entity` stays as a deprecated alias of `row` for one cycle. `item` is no longer reserved.
- Docs examples use `mapRow(mixed $row)` to match the PHP signature.

## Test plan
- [x] `vendor/bin/phpunit` (1169 tests)
- [x] `composer audit`
- [x] `npm run lint` in `docs/`
- [x] Confirm a TemplateColumn that used `{{ row.someMappedKey }}` still works via `{{ data }}` / `{{ row.domainProperty }}`
- [x] Confirm templates still using `{{ entity }}` keep rendering
- [x] Confirm `projectPage()` templates: `row` is the DTO, `source` is the original


Made with [Cursor](https://cursor.com)