### PR TITLE
fix(template-column): expose the mapRow array as Twig `payload`

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,13 @@
 # Upgrade Guide
 
-## `TemplateColumn` Twig `row` is the `mapRow()` object
+Each section covers one version bump. When you skip versions, apply every section between your
+current version and the target, oldest first.
+
+## v0.80 → v0.81
+
+Only `TemplateColumn` is affected. If you do not use it, there is nothing to do.
+
+### `TemplateColumn` Twig `row` is the `mapRow()` object
 
 In a `TemplateColumn` template, `row` used to be the **array** returned by `mapRow()`. It is now
 the **object** passed to `mapRow()` — the projected DTO when `projectPage()` is active, otherwise
@@ -12,9 +19,9 @@ the source object. The array is still available, under the new `payload` key.
 {{ row.fullName }}
 
 {# after #}
-<span class="badge">{{ data }}</span>          {# this cell's value #}
-{{ payload.fullName }}                          {# any other mapped key #}
-{{ row.getFullName() }}                         {# or read the object directly #}
+<span class="badge">{{ data }}</span>   {# this cell's value #}
+{{ payload.fullName }}                  {# any other mapped key #}
+{{ row.getFullName() }}                 {# or read the object directly #}
 ```
 
 `payload` is the exact value `row` used to hold, so a template that only read mapped keys migrates
@@ -32,7 +39,7 @@ What changed:
 - `item` is no longer provided. It used to be a second alias of `row`; pass it yourself through
   `setTemplate()` parameters if a template of yours needs that name
 
-Collapsible detail rows (`setCollapsibleTemplate()`) and edit modals also expose an `entity`
+Collapsible detail rows (`Action::collapsible()`) and edit modals also expose an `entity`
 variable. That one is unrelated to `TemplateColumn`, is not an alias, and is not deprecated — leave
 those templates alone.
 
@@ -40,7 +47,7 @@ Do not branch on `payload` for authorization or visibility. On the API Platform 
 rows are posted by the browser, so `payload` is client-controlled input; read `row` or `source`
 instead.
 
-## Reserved `TemplateColumn` template parameters now throw
+### Reserved `TemplateColumn` template parameters now throw
 
 Passing a reserved context key through `setTemplate()` used to be silently dropped, which made a
 collision render wrong HTML with no signal. It now fails at configuration time.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,61 @@
+# Upgrade Guide
+
+## `TemplateColumn` Twig `row` is the `mapRow()` object
+
+In a `TemplateColumn` template, `row` used to be the **array** returned by `mapRow()`. It is now
+the **object** passed to `mapRow()` — the projected DTO when `projectPage()` is active, otherwise
+the source object. The array is still available, under the new `payload` key.
+
+```twig
+{# before #}
+<span class="badge">{{ row.status }}</span>
+{{ row.fullName }}
+
+{# after #}
+<span class="badge">{{ data }}</span>          {# this cell's value #}
+{{ payload.fullName }}                          {# any other mapped key #}
+{{ row.getFullName() }}                         {# or read the object directly #}
+```
+
+`payload` is the exact value `row` used to hold, so a template that only read mapped keys migrates
+with a mechanical `row` → `payload` rename. As before, it does not contain cells rendered by other
+`TemplateColumn`s, nor the row action metadata.
+
+What changed:
+
+- `row` is the object passed to `mapRow()`; read domain properties from it
+- `payload` is the array returned by `mapRow()`; use it for a mapped key other than this cell's
+- `data` is unchanged: the resolved value of this cell
+- `source` is unchanged: the original hydrated object, same reference as `row` without a projector
+- `entity` still works as a deprecated alias of `row`, for `TemplateColumn` templates only. It will
+  be removed in a later release
+- `item` is no longer provided. It used to be a second alias of `row`; pass it yourself through
+  `setTemplate()` parameters if a template of yours needs that name
+
+Collapsible detail rows (`setCollapsibleTemplate()`) and edit modals also expose an `entity`
+variable. That one is unrelated to `TemplateColumn`, is not an alias, and is not deprecated — leave
+those templates alone.
+
+Do not branch on `payload` for authorization or visibility. On the API Platform render route the
+rows are posted by the browser, so `payload` is client-controlled input; read `row` or `source`
+instead.
+
+## Reserved `TemplateColumn` template parameters now throw
+
+Passing a reserved context key through `setTemplate()` used to be silently dropped, which made a
+collision render wrong HTML with no signal. It now fails at configuration time.
+
+```php
+use Pentiminax\UX\DataTables\Column\TemplateColumn;
+
+// throws InvalidArgumentException
+TemplateColumn::new('status_display')
+    ->setTemplate('datatable/columns/status.html.twig', ['row' => $somethingElse]);
+```
+
+What changed:
+
+- `setTemplate()` throws `InvalidArgumentException` when `$parameters` uses `row`, `source`,
+  `payload`, `data`, `column`, or `entity`
+- `payload` is newly reserved; rename such a parameter to something else
+- any other key still passes through untouched, `item` included

--- a/docs/src/content/docs/columns/template-column.mdx
+++ b/docs/src/content/docs/columns/template-column.mdx
@@ -27,12 +27,24 @@ Inside the template, the following variables are available:
 |---|---|
 | `row` | The object passed to `mapRow()` (the projected DTO when a page projector is active, otherwise the source object) |
 | `source` | The original hydrated object. Same reference as `row` when no projector is active |
+| `payload` | The array returned by `mapRow()`. Use it to read a mapped key other than this cell's |
 | `data` | The resolved field value for this cell |
 | `column` | Serialized column configuration array |
 
-`entity` is a deprecated alias of `row`. Prefer `row`.
+Read domain properties from `row`, this cell's value from `data`, and any other mapped key from `payload`.
 
-Templates do not receive the array returned by `mapRow()`. Read domain properties from `row` and this cell's value from `data`.
+`payload` holds the row as the earlier pipeline stages left it, so cells rendered by other `TemplateColumn`s and the row action metadata are absent from it. A `payload` entry can also be `null` while `data` is set: a `null` mapped value falls back to reading the object, and normalization writes `null` for objects that are not `DateTimeInterface`, `BackedEnum`, or `Stringable`.
+
+`entity` is a deprecated alias of `row` **in `TemplateColumn` templates**. Prefer `row`. Collapsible detail rows and edit modals expose their own unrelated `entity` variable, which is not deprecated.
+
+<Aside type="caution">
+  Never branch on `payload` for authorization or visibility. On the API Platform render route the
+  rows are posted by the browser, so `payload` is client-controlled input — read `row` or `source`
+  instead. On that same route, `row`, `source`, and `entity` fall back to the posted array when the
+  row cannot be rehydrated (no identifier, a composite primary key, or no matching record), so
+  guard method calls on them. For a bare `DataTable` whose `data()` you called by hand there is no
+  `mapRow()` at all: `row`, `source`, and `payload` are the same raw array.
+</Aside>
 
 Example template:
 
@@ -54,7 +66,7 @@ TemplateColumn::new('actions', 'Actions')
     ]);
 ```
 
-Parameters are merged into the template context. Keys `row`, `source`, `data`, `column`, and `entity` are reserved.
+Parameters are merged into the template context. The keys `row`, `source`, `payload`, `data`, `column`, and `entity` are reserved: passing one throws an `InvalidArgumentException`.
 
 ## API Reference
 
@@ -62,7 +74,7 @@ Parameters are merged into the template context. Keys `row`, `source`, `data`, `
   headers={['Method', 'Description']}
   rows={[
     ["`TemplateColumn::new(string $name, string $title = '')`", 'Creates a new TemplateColumn (type: `html`)'],
-    ['`setTemplate(string $template, array $parameters = [])`', 'Set the Twig template path and optional static parameters. Throws on empty path. Reserved context keys cannot be overridden.'],
+    ['`setTemplate(string $template, array $parameters = [])`', 'Set the Twig template path and optional static parameters. Throws on an empty path, and on a parameter using a reserved context key.'],
     ['`getTemplate(): string`', 'Returns the configured template path. Throws if not set.'],
     ['`getTemplateParameters(): array`', 'Returns the static parameters passed to the template'],
   ]}

--- a/skills/ux-datatables/references/columns.md
+++ b/skills/ux-datatables/references/columns.md
@@ -15,7 +15,7 @@ All columns live in `src/Column/`. Every type is created with the static factory
 | `EmailColumn` | `EmailColumn::new('email')` | `obfuscate(bool=true)`, `mask(bool=true)`, `setDisplayValue(string)`, `renderAsText(bool=true)` |
 | `ImageColumn` | `ImageColumn::new('photo')` | `setImageWidth(int)`, `setImageHeight(int)`, `setAlt(string)`, `setPlaceholder(string)`, `rounded()`, `lazy()`, `clickable()` |
 | `UrlColumn` | `UrlColumn::new('website')` | `linkToUrl(string\|callable)`, `linkToRoute(string $route, array\|callable\|null $params=null)`, `openInNewTab()`, `showExternalIcon(bool=true)`, `setDisplayValue(string)`, `setDefaultProtocol(string)`, `allowedProtocols(array)` |
-| `TemplateColumn` | `TemplateColumn::new('preview')` | `setTemplate(string $template, array $parameters=[])` — server-side Twig. Context: `row` (mapRow object), `source`, `data`, `column`. `entity` is a deprecated alias of `row`. |
+| `TemplateColumn` | `TemplateColumn::new('preview')` | `setTemplate(string $template, array $parameters=[])` — server-side Twig. Context: `row` (mapRow object), `source`, `payload` (mapRow array), `data`, `column`. `entity` is a deprecated alias of `row` **for TemplateColumn only** — detail rows and edit modals keep their own `entity`. Passing a reserved key as a parameter throws. |
 | `ActionColumn` | *(auto-generated from `configureActions()` — do not build manually)* | see `references/actions.md` |
 
 > `UrlColumn` supports `linkToRoute()`; `Action` (row actions) does **not** — it only has `linkToUrl()`.

--- a/skills/ux-datatables/references/defining-a-datatable.md
+++ b/skills/ux-datatables/references/defining-a-datatable.md
@@ -100,7 +100,7 @@ Rules and routing:
 - When a projector is active, the bundle pairs each source entity with its projected item (`RowContext`, `src/RowMapper/RowContext.php`) and routes them:
   - **Columns + TemplateColumn Twig (`row`)** read the **projected** item (the DTO).
   - **Actions, `UrlColumn`, and `permission()`** receive the **source** entity.
-  - Without a projector, both reference the same value. Twig `source` is that original object.
+  - Without a projector, both reference the same value. Twig `source` is that original object, and Twig `payload` is the array `mapRow()` returned.
 - A projected/computed column has no DB counterpart: mark it `->setOrderable(false)->setSearchable(false)`, or sort it via `->setOrderExpression(...)` backed by an `addSelect(... AS HIDDEN ...)` — see `references/server-side.md`.
 
 ## Maker

--- a/skills/ux-datatables/references/gotchas.md
+++ b/skills/ux-datatables/references/gotchas.md
@@ -42,5 +42,8 @@ The enum case is `COLUMN_VISIBILITY` (serialized value `'colvis'`), not `COL_VIS
 ## `projectPage()` must preserve page size and order
 A page projector that returns a different count (or reordered rows) throws `LogicException`. Map one-to-one. Remember the split: columns and TemplateColumn Twig (`row`) read the projected DTO, but actions/`UrlColumn`/`permission()` still receive the **source** entity — don't move identifiers needed by actions into the DTO only.
 
+## TemplateColumn Twig `row` is the object, not the `mapRow()` array
+`row` is the object passed to `mapRow()`; the array it returned is `payload`. A template reading a mapped key must use `{{ data }}` (this cell) or `{{ payload.someKey }}` (any other key) — `{{ row.someMappedKey }}` renders empty for computed keys with no DB counterpart. `entity` is a deprecated alias of `row` here only; the `entity` of detail rows and edit modals is unrelated. Never authorize on `payload`: on the API Platform render route it is the browser-posted row.
+
 ## Sorting a computed column needs `setOrderExpression()`
 A column with no real entity property (e.g. an `addSelect(... AS HIDDEN <alias>)` subquery) can't sort via the default `<alias>.<field>` — it resolves to a nonexistent `e.<field>` and errors. Either `->setOrderExpression('<alias>')` (and `->setSearchable(false)`), or `->setOrderable(false)->setSearchable(false)`.

--- a/src/Column/Rendering/TemplateColumnRenderer.php
+++ b/src/Column/Rendering/TemplateColumnRenderer.php
@@ -14,9 +14,13 @@ final class TemplateColumnRenderer
     /**
      * Twig keys reserved by the renderer.
      *
-     * `entity` is a deprecated alias of `row` and remains reserved until it is removed.
+     * `row` is the object passed to mapRow(), `payload` the array it returned.
+     *
+     * `entity` is a deprecated alias of `row` for TemplateColumn templates only, and remains
+     * reserved until it is removed. Detail rows and the edit modal expose their own `entity`,
+     * which is neither an alias nor deprecated.
      */
-    public const array RESERVED_CONTEXT_KEYS = ['entity', 'data', 'column', 'row', 'source'];
+    public const array RESERVED_CONTEXT_KEYS = ['entity', 'data', 'column', 'row', 'source', 'payload'];
 
     public function __construct(
         private readonly ?Environment $twig = null,
@@ -51,11 +55,12 @@ final class TemplateColumnRenderer
             );
 
             $context = [
-                'row'    => $contextRow,
-                'source' => $source,
-                'data'   => $data,
-                'column' => $column->jsonSerialize(),
-                'entity' => $contextRow,
+                'row'     => $contextRow,
+                'source'  => $source,
+                'payload' => $payload,
+                'data'    => $data,
+                'column'  => $column->jsonSerialize(),
+                'entity'  => $contextRow,
             ];
 
             foreach ($column->getTemplateParameters() as $key => $value) {

--- a/src/Column/TemplateColumn.php
+++ b/src/Column/TemplateColumn.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pentiminax\UX\DataTables\Column;
 
+use Pentiminax\UX\DataTables\Column\Rendering\TemplateColumnRenderer;
 use Pentiminax\UX\DataTables\Contracts\TemplateAwareColumnInterface;
 use Pentiminax\UX\DataTables\Enum\ColumnType;
 
@@ -23,14 +24,20 @@ class TemplateColumn extends AbstractColumn implements TemplateAwareColumnInterf
     }
 
     /**
-     * @param array<string, mixed> $parameters Extra Twig variables. Keys `row`, `source`, `data`,
-     *                                         `column`, and the deprecated alias `entity` are reserved.
+     * @param array<string, mixed> $parameters Extra Twig variables. Keys `row`, `source`, `payload`,
+     *                                         `data`, `column`, and the deprecated alias `entity`
+     *                                         are reserved and throw when passed.
      */
     public function setTemplate(string $template, array $parameters = []): static
     {
         $template = trim($template);
         if ('' === $template) {
             throw new \InvalidArgumentException('Template path cannot be empty.');
+        }
+
+        $reserved = array_intersect_key($parameters, array_flip(TemplateColumnRenderer::RESERVED_CONTEXT_KEYS));
+        if ([] !== $reserved) {
+            throw new \InvalidArgumentException(\sprintf('Template parameters "%s" are reserved by the renderer and cannot be overridden on column "%s".', implode('", "', array_keys($reserved)), $this->getName()));
         }
 
         $this->setCustomOption(self::OPTION_TEMPLATE_PATH, $template);

--- a/tests/Unit/Column/TemplateColumnRendererTest.php
+++ b/tests/Unit/Column/TemplateColumnRendererTest.php
@@ -136,6 +136,33 @@ final class TemplateColumnRendererTest extends TestCase
             ['id' => 42, 'status_display' => 'verified-42-status_display'],
         ];
 
+        yield 'payload exposes the mapRow() array including keys of other columns' => [
+            ['column.html.twig' => '{{ payload.fullName }} ({{ payload.id }}) - {{ data }}'],
+            [TemplateColumn::new('status_display')->setField('status')->setTemplate('column.html.twig')],
+            ['id' => 7, 'fullName' => 'Ada Lovelace', 'status' => 'active'],
+            new TemplateEntity(id: 7, status: 'active'),
+            [
+                'id'             => 7,
+                'fullName'       => 'Ada Lovelace',
+                'status'         => 'active',
+                'status_display' => 'Ada Lovelace (7) - active',
+            ],
+        ];
+
+        yield 'payload is not mutated by a template column rendered earlier in the same row' => [
+            [
+                'first.html.twig'  => 'first:{{ data }}',
+                'second.html.twig' => 'second:{{ payload.first_badge }}|{{ data }}',
+            ],
+            [
+                TemplateColumn::new('first_badge')->setTemplate('first.html.twig'),
+                TemplateColumn::new('second_badge')->setTemplate('second.html.twig'),
+            ],
+            ['first_badge' => 'A', 'second_badge' => 'B'],
+            [],
+            ['first_badge' => 'first:A', 'second_badge' => 'second:A|B'],
+        ];
+
         yield 'entity remains a deprecated alias of row' => [
             ['column.html.twig' => '{{ entity.getStatus() }}'],
             [TemplateColumn::new('status_display')->setField('status')->setTemplate('column.html.twig')],

--- a/tests/Unit/Column/TemplateColumnTest.php
+++ b/tests/Unit/Column/TemplateColumnTest.php
@@ -57,6 +57,22 @@ final class TemplateColumnTest extends DataTableTestCase
             \LogicException::class,
             'Template path is not configured for column',
         ];
+
+        yield 'reserved parameter' => [
+            static fn () => TemplateColumn::new('status_display')->setTemplate('column.html.twig', ['payload' => []]),
+            \InvalidArgumentException::class,
+            'Template parameters "payload" are reserved by the renderer and cannot be overridden on column "status_display".',
+        ];
+
+        yield 'several reserved parameters are all reported' => [
+            static fn () => TemplateColumn::new('status_display')->setTemplate('column.html.twig', [
+                'row'         => 1,
+                'badge_class' => 'badge-success',
+                'entity'      => 2,
+            ]),
+            \InvalidArgumentException::class,
+            'Template parameters "row", "entity" are reserved',
+        ];
     }
 
     #[Test]
@@ -66,9 +82,9 @@ final class TemplateColumnTest extends DataTableTestCase
 
         $this->assertSame([], $column->getTemplateParameters());
 
-        $column->setTemplate('some/template.html.twig', ['badge_class' => 'badge-success', 'show_icon' => true]);
+        $column->setTemplate('some/template.html.twig', ['badge_class' => 'badge-success', 'show_icon' => true, 'item' => 'custom']);
 
-        $this->assertSame(['badge_class' => 'badge-success', 'show_icon' => true], $column->getTemplateParameters());
+        $this->assertSame(['badge_class' => 'badge-success', 'show_icon' => true, 'item' => 'custom'], $column->getTemplateParameters());
 
         $data = $column->jsonSerialize();
 


### PR DESCRIPTION
## Summary

Follow-up to #371. That PR made Twig `row` the `mapRow()` object and left the mapped array
unreachable, so a template reading a computed or sibling key (`{{ row.fullName }}`,
`{{ row.other_badge }}`) renders empty with no error and has no migration path — `data` only carries
the current cell's value.

- Expose the `mapRow()` array as the new reserved Twig key `payload`. It is the exact value `row`
  held in v0.80.0 (never mutated, so sibling `TemplateColumn` cells and row action metadata stay
  absent), which makes the migration a mechanical `row` → `payload` rename.
- `setTemplate()` now throws `InvalidArgumentException` when a parameter uses a reserved key.
  Reserved keys were silently dropped, so newly reserving `payload` would have swapped a user value
  for one of a different type with no signal — while the docs already claimed reserved keys could not
  be overridden.
- Scope the `entity` deprecation to `TemplateColumn`. `entity` is still the **current,
  non-deprecated** variable for collapsible detail rows (`DetailRowService`) and the edit modal
  (`EditModalRenderer`); the unscoped wording from #371 would have pushed users to "fix" working
  templates into undefined variables.
- Recreate `UPGRADE.md` (removed in dd4a6f8) to carry the migration, in its original format.
- Document the two paths where the context degrades: on the API Platform render route `payload` is
  the browser-posted row (never gate authorization on it), and `row`/`source`/`entity` fall back to
  that array when rehydration is impossible; for a bare `DataTable` with a hand-called `data()`
  there is no `mapRow()` at all.

Reserved keys are now `row`, `source`, `payload`, `data`, `column`, `entity`. `item` stays free.

## Test plan

- [x] `vendor/bin/phpunit` (1173 tests)
- [x] `composer fix`, `composer audit`
- [x] `npm run lint` and `npm run build` in `docs/`
- [x] `payload` exposes a mapped key belonging to another column
- [x] `payload` is unaffected by a `TemplateColumn` rendered earlier in the same row
- [x] every reserved key throws from `setTemplate()`; a non-reserved key (`item`) still passes through
- [x] `entity` left untouched in detail-row and edit-modal docs and templates
- [ ] Confirm a real app template migrating `{{ row.someMappedKey }}` → `{{ payload.someMappedKey }}`

## Out of scope

Two pre-existing issues found while tracing, not touched here:

- `DataTablesExtension` renders templates before `removeDeniedColumnValues()`, so templates on the
  hand-built client-side path see permission-denied column values. Pre-existing for `row`/`source`
  (both already the unfiltered array there); `payload` adds no new exposure.
- `ActionRowDataResolver` early-returns when a posted row already carries `__ux_datatables_actions`,
  letting a client skip action permission resolution for its own rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes TemplateColumn Twig contract and makes misconfigured `setTemplate()` fail at boot/config time; security guidance matters because `payload` can be client-posted on some routes.
> 
> **Overview**
> Follow-up to the change that made Twig **`row`** the `mapRow()` object: templates that still read sibling or computed mapped keys from **`row`** render empty with no error. This PR restores that data under a new reserved key **`payload`** (the unmutated `mapRow()` array, same as v0.80 **`row`**), so migration is mostly **`row` → `payload`** for mapped keys while **`row`** stays the object/DTO and **`data`** stays this cell’s value.
> 
> **`setTemplate()`** now throws **`InvalidArgumentException`** when static parameters collide with reserved keys (`row`, `source`, `payload`, `data`, `column`, `entity`) instead of silently dropping them—**`payload`** is newly reserved. Non-reserved names like **`item`** can still be passed via **`setTemplate()`**.
> 
> Docs and a recreated **`UPGRADE.md`** (v0.80 → v0.81) spell out **`entity`** deprecation **only for `TemplateColumn`**, warn against authorization on **`payload`** on API Platform render routes, and note degraded context when rows cannot be rehydrated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b0c707f7e98f1992c8577e067c28eca4ee2512f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->