### PR TITLE
feat(column-control): let control groups target any header or footer row

### DIFF
--- a/docs/src/content/docs/extensions/column-control.mdx
+++ b/docs/src/content/docs/extensions/column-control.mdx
@@ -30,6 +30,44 @@ test `IS NULL` / `IS NOT NULL` on those columns — they must not compare the id
 empty string. See
 [Searching UUID and ULID columns](/ux-datatables/guide/server-side-processing/#searching-uuid-and-ulid-columns).
 
+## Choosing Where The Controls Go
+
+Each control group targets one row: a header row index (`0`, `1`, ...) or a `tfoot` string
+(`'tfoot'`, `'tfoot:1'`). Pass a target to replace the defaults with that single group.
+
+```php
+// Per-column search inputs in the table footer instead of the second header row.
+$dataTable->columnControl(target: 'tfoot');
+
+// A specific content type in a header row.
+$dataTable->columnControl(target: 1, content: ['searchText']);
+```
+
+ColumnControl creates the targeted row when the table does not render one, so a footer target
+needs no `<tfoot>` markup — `render_datatable()` emits an empty `<table>` and every row is built
+at initialization.
+
+Naming a target drops the default order controls. Keep both by building the extension directly:
+
+```php
+use Pentiminax\UX\DataTables\Model\Extensions\ColumnControlExtension;
+
+$dataTable->addExtension(
+    (new ColumnControlExtension([]))
+        ->add(0, ['order'])
+        ->add('tfoot', ['search'])
+);
+```
+
+`new ColumnControlExtension()` keeps the defaults, `new ColumnControlExtension([])` starts from
+nothing, and `add()` appends one group per call in call order.
+
+<Aside type="note">
+  `content: ['search']` picks the input for the column's type — text, number, date, or a value list.
+  Use `searchText`, `searchNumber`, `searchDateTime`, or `searchList` to pin one, and
+  `searchDropdown` for a dropdown trigger rather than an always-visible input.
+</Aside>
+
 ## Per-column Overrides
 
 Override the control content for a single column with `setColumnControl()`, using the same content
@@ -130,6 +168,8 @@ own construction, which is all a plugin registration needs.
   `ColumnControlExtension` on the table (`$table->columnControl()`); the column-level setting is
   silently inert because the frontend never loads the plugin bundle.
 - Enabling it without ensuring the target columns are searchable/orderable.
+- Passing a target and expecting the default order controls to stay — they are replaced. Add them
+  back with `add(0, ['order'])`.
 - Expecting partial search (`contains`, `starts`) to work on a UUID or ULID column.
 - Registering a custom content type on `datatables:pre-connect` instead of `datatables:pre-init` —
   `pre-connect` fires before the DataTable library and its extensions have even loaded, so its

--- a/docs/src/content/docs/extensions/column-control.mdx
+++ b/docs/src/content/docs/extensions/column-control.mdx
@@ -62,6 +62,9 @@ $dataTable->addExtension(
 `new ColumnControlExtension()` keeps the defaults, `new ColumnControlExtension([])` starts from
 nothing, and `add()` appends one group per call in call order.
 
+`content` needs a target to be placed in: `columnControl(content: ['searchText'])` throws rather
+than silently keeping the defaults.
+
 <Aside type="note">
   `content: ['search']` picks the input for the column's type — text, number, date, or a value list.
   Use `searchText`, `searchNumber`, `searchDateTime`, or `searchList` to pin one, and

--- a/docs/src/content/docs/reference/datatable.mdx
+++ b/docs/src/content/docs/reference/datatable.mdx
@@ -151,7 +151,11 @@ new DataTable(
     ['`extensions(array $extensions)`', 'Set multiple extensions'],
     ['`getExtensions(): array`', 'Return configured extensions'],
     ['`setExtensions(DataTableExtensions $extensions)`', 'Replace extension collection'],
-    ['`responsive()`, `columnControl()`', 'Convenience helpers for common extensions'],
+    ['`responsive()`', 'Convenience helper for the Responsive extension'],
+    [
+      '`columnControl(int|string|null $target = null, array $content = [\'search\'])`',
+      'Add Column Control; a target replaces the defaults with that single control group',
+    ],
   ]}
 />
 

--- a/docs/src/content/docs/reference/datatable.mdx
+++ b/docs/src/content/docs/reference/datatable.mdx
@@ -153,7 +153,7 @@ new DataTable(
     ['`setExtensions(DataTableExtensions $extensions)`', 'Replace extension collection'],
     ['`responsive()`', 'Convenience helper for the Responsive extension'],
     [
-      '`columnControl(int|string|null $target = null, array $content = [\'search\'])`',
+      '`columnControl(int|string|null $target = null, ?array $content = null)`',
       'Add Column Control; a target replaces the defaults with that single control group',
     ],
   ]}

--- a/src/Model/DataTable.php
+++ b/src/Model/DataTable.php
@@ -667,9 +667,28 @@ class DataTable
         return $this;
     }
 
-    public function columnControl(): static
+    /**
+     * Add the ColumnControl extension.
+     *
+     * Called without a target it keeps the bundled defaults: order controls on the first header
+     * row and a search input on the second. Naming a target replaces them with that single control
+     * group, so `columnControl(target: 'tfoot')` moves the per-column search inputs to the footer.
+     * ColumnControl creates the targeted row itself, so no `<tfoot>` markup is needed.
+     *
+     * Combine several groups by building the extension directly:
+     * `addExtension((new ColumnControlExtension([]))->add(0, ['order'])->add('tfoot', ['search']))`.
+     *
+     * @param int|string|null $target  header row index, or a `tfoot` string (`'tfoot'`, `'tfoot:1'`)
+     * @param list<mixed>     $content content descriptors, as in the DataTables `columnControl`
+     *                                 option
+     */
+    public function columnControl(int|string|null $target = null, array $content = ['search']): static
     {
-        $this->extensions->addExtension(new ColumnControlExtension());
+        $extension = null === $target
+            ? new ColumnControlExtension()
+            : (new ColumnControlExtension([]))->add($target, $content);
+
+        $this->extensions->addExtension($extension);
 
         return $this;
     }

--- a/src/Model/DataTable.php
+++ b/src/Model/DataTable.php
@@ -678,17 +678,29 @@ class DataTable
      * Combine several groups by building the extension directly:
      * `addExtension((new ColumnControlExtension([]))->add(0, ['order'])->add('tfoot', ['search']))`.
      *
-     * @param int|string|null $target  header row index, or a `tfoot` string (`'tfoot'`, `'tfoot:1'`)
-     * @param list<mixed>     $content content descriptors, as in the DataTables `columnControl`
-     *                                 option
+     * @param int|string|null  $target  header row index, or a `tfoot` string (`'tfoot'`,
+     *                                  `'tfoot:1'`)
+     * @param list<mixed>|null $content content descriptors, as in the DataTables `columnControl`
+     *                                  option; defaults to a search input
+     *
+     * @throws \InvalidArgumentException when content is given without a target, since there is no
+     *                                   row to place it in
      */
-    public function columnControl(int|string|null $target = null, array $content = ['search']): static
+    public function columnControl(int|string|null $target = null, ?array $content = null): static
     {
-        $extension = null === $target
-            ? new ColumnControlExtension()
-            : (new ColumnControlExtension([]))->add($target, $content);
+        if (null === $target) {
+            if (null !== $content) {
+                throw new \InvalidArgumentException('Column control content needs a target row. Pass a header row index or a "tfoot" string, for example columnControl(target: 1, content: [\'searchText\']).');
+            }
 
-        $this->extensions->addExtension($extension);
+            $this->extensions->addExtension(new ColumnControlExtension());
+
+            return $this;
+        }
+
+        $this->extensions->addExtension(
+            (new ColumnControlExtension([]))->add($target, $content ?? ['search'])
+        );
 
         return $this;
     }

--- a/src/Model/Extensions/ColumnControlExtension.php
+++ b/src/Model/Extensions/ColumnControlExtension.php
@@ -4,8 +4,72 @@ declare(strict_types=1);
 
 namespace Pentiminax\UX\DataTables\Model\Extensions;
 
+/**
+ * ColumnControl's `columnControl` configuration: a list of control groups, each placing content in
+ * one header or footer row.
+ *
+ * A target is either a header row index (`0`, `1`, ...) or a `tfoot` string (`'tfoot'`,
+ * `'tfoot:1'`). ColumnControl creates the targeted row when the table does not render one, so a
+ * footer target needs no `<tfoot>` markup.
+ *
+ * Constructed without arguments it serializes {@see self::DEFAULT_CONTROLS}: order controls on the
+ * first header row and a search input on the second. Pass an explicit list to replace them, `[]`
+ * to start from nothing, or call {@see self::add()} to build the list up.
+ */
 class ColumnControlExtension extends AbstractExtension
 {
+    /**
+     * @var list<array{target: int|string, content: list<mixed>}>
+     */
+    public const DEFAULT_CONTROLS = [
+        [
+            'target'  => 0,
+            'content' => [
+                'order',
+                [
+                    'orderAsc',
+                    'orderDesc',
+                    'spacer',
+                    'orderAddAsc',
+                    'orderAddDesc',
+                    'spacer',
+                    'orderRemove',
+                ],
+            ],
+        ],
+        [
+            'target'  => 1,
+            'content' => ['search'],
+        ],
+    ];
+
+    /**
+     * @param list<array{target: int|string, content: list<mixed>}>|null $controls null keeps the
+     *                                                                             defaults
+     */
+    public function __construct(
+        private ?array $controls = null,
+    ) {
+    }
+
+    /**
+     * Append one control group, dropping the defaults on the first call so an explicitly built
+     * configuration never inherits them.
+     *
+     * @param list<mixed> $content content descriptors, as in the DataTables `columnControl` option
+     */
+    public function add(int|string $target, array $content): static
+    {
+        $this->controls ??= [];
+
+        $this->controls[] = [
+            'target'  => $target,
+            'content' => $content,
+        ];
+
+        return $this;
+    }
+
     public function getKey(): string
     {
         return 'columnControl';
@@ -13,26 +77,6 @@ class ColumnControlExtension extends AbstractExtension
 
     public function jsonSerialize(): array
     {
-        return [
-            [
-                'target'  => 0,
-                'content' => [
-                    'order',
-                    [
-                        'orderAsc',
-                        'orderDesc',
-                        'spacer',
-                        'orderAddAsc',
-                        'orderAddDesc',
-                        'spacer',
-                        'orderRemove',
-                    ],
-                ],
-            ],
-            [
-                'target'  => 1,
-                'content' => ['search'],
-            ],
-        ];
+        return $this->controls ?? self::DEFAULT_CONTROLS;
     }
 }

--- a/tests/Unit/Model/DataTableTest.php
+++ b/tests/Unit/Model/DataTableTest.php
@@ -320,6 +320,15 @@ final class DataTableTest extends TestCase
     }
 
     #[Test]
+    public function it_rejects_column_control_content_without_a_target(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Column control content needs a target row. Pass a header row index or a "tfoot" string, for example columnControl(target: 1, content: [\'searchText\']).');
+
+        (new DataTable('books'))->columnControl(content: ['searchText']);
+    }
+
+    #[Test]
     public function it_keeps_the_column_control_defaults_when_no_target_is_given(): void
     {
         $table = (new DataTable('books'))->columnControl();

--- a/tests/Unit/Model/DataTableTest.php
+++ b/tests/Unit/Model/DataTableTest.php
@@ -319,6 +319,39 @@ final class DataTableTest extends TestCase
         $this->assertSame('Email', $table->getColumnDefinitions()[0]['title']);
     }
 
+    #[Test]
+    public function it_keeps_the_column_control_defaults_when_no_target_is_given(): void
+    {
+        $table = (new DataTable('books'))->columnControl();
+
+        $this->assertSame(
+            (new ColumnControlExtension())->jsonSerialize(),
+            $table->getExtensionsCollection()->jsonSerialize()['columnControl']
+        );
+    }
+
+    #[Test]
+    public function it_targets_the_footer_with_a_search_control(): void
+    {
+        $table = (new DataTable('books'))->columnControl(target: 'tfoot');
+
+        $this->assertSame(
+            [['target' => 'tfoot', 'content' => ['search']]],
+            $table->getExtensionsCollection()->jsonSerialize()['columnControl']
+        );
+    }
+
+    #[Test]
+    public function it_targets_a_header_row_with_explicit_control_content(): void
+    {
+        $table = (new DataTable('books'))->columnControl(target: 1, content: ['searchText']);
+
+        $this->assertSame(
+            [['target' => 1, 'content' => ['searchText']]],
+            $table->getExtensionsCollection()->jsonSerialize()['columnControl']
+        );
+    }
+
     /**
      * @param array<string, bool>  $keys
      * @param array<string, mixed> $expected

--- a/tests/Unit/Model/Extensions/ColumnControlExtensionTest.php
+++ b/tests/Unit/Model/Extensions/ColumnControlExtensionTest.php
@@ -44,4 +44,51 @@ final class ColumnControlExtensionTest extends TestCase
 
         $this->assertEquals($expectedArray, $extension->jsonSerialize());
     }
+
+    #[Test]
+    public function it_serializes_only_the_added_controls(): void
+    {
+        $extension = (new ColumnControlExtension([]))->add('tfoot', ['search']);
+
+        $this->assertSame([
+            ['target' => 'tfoot', 'content' => ['search']],
+        ], $extension->jsonSerialize());
+    }
+
+    #[Test]
+    public function it_appends_every_added_control_in_call_order(): void
+    {
+        $extension = (new ColumnControlExtension([]))
+            ->add(0, ['order'])
+            ->add('tfoot', ['searchText']);
+
+        $this->assertSame([
+            ['target' => 0, 'content' => ['order']],
+            ['target' => 'tfoot', 'content' => ['searchText']],
+        ], $extension->jsonSerialize());
+    }
+
+    #[Test]
+    public function it_drops_the_defaults_as_soon_as_a_control_is_added(): void
+    {
+        $extension = (new ColumnControlExtension())->add('tfoot', ['search']);
+
+        $this->assertSame([
+            ['target' => 'tfoot', 'content' => ['search']],
+        ], $extension->jsonSerialize());
+    }
+
+    #[Test]
+    public function it_serializes_an_explicitly_empty_configuration(): void
+    {
+        $this->assertSame([], (new ColumnControlExtension([]))->jsonSerialize());
+    }
+
+    #[Test]
+    public function it_serializes_a_configuration_passed_to_the_constructor(): void
+    {
+        $controls = [['target' => 'tfoot:1', 'content' => ['searchNumber']]];
+
+        $this->assertSame($controls, (new ColumnControlExtension($controls))->jsonSerialize());
+    }
 }


### PR DESCRIPTION
Closes #394.

## Why

`ColumnControlExtension` hardcoded its control groups: order controls on header row 0, a search input on header row 1. Reaching any other row — a footer in particular — meant writing a custom extension class.

This came out of #394, which asked for a new opt-in `DataTable::columnSearchInputs()` rendering its own `<tfoot>` row of per-column search inputs, driven by a new frontend module. That request is already covered by the extension the bundle ships:

- `content: ['search']` is an always-visible, type-aware input, not a dropdown — it dispatches to `searchText`, `searchNumber`, `searchDateTime`, or `searchList`. The dropdown behavior is the separate `searchDropdown` type. So `$dataTable->columnControl()` was already rendering one search input per column.
- ColumnControl already resolves footer targets: `assetTarget()` accepts a `'tfoot'` target and creates the row with one cell per column when the table renders none, and DataTables always creates a `<tfoot>` element at initialization when the markup has none. An empty `render_datatable()` table is enough.
- Both request paths converge server-side: `ColumnSearchFilter` and `ColumnControlSearchFilter` each delegate to `SearchStrategyRegistry`, so `setSearchField()`, `addSearchJoin()`, and `setSearchPredicate()` already applied to ColumnControl search.

Building `columnSearchInputs()` would have added a third per-column search mechanism next to declarative filters and ColumnControl, for two thin gains (skipping the ColumnControl bundle download, and the standard `columns[i][search][value]` protocol). Making the existing extension configurable covers the request and removes the limitation instead.

## What changed

`DataTable::columnControl(int|string|null $target = null, array $content = ['search'])`:

```php
// Unchanged: order controls on header row 0, search inputs on header row 1.
$dataTable->columnControl();

// #394's request: per-column search inputs in the footer.
$dataTable->columnControl(target: 'tfoot');

// A pinned content type in a header row.
$dataTable->columnControl(target: 1, content: ['searchText']);
```

A target is a header row index or a `tfoot` string (`'tfoot'`, `'tfoot:1'`).

`ColumnControlExtension` becomes configurable:

- `new ColumnControlExtension()` keeps `DEFAULT_CONTROLS` — the previous behavior, unchanged.
- `new ColumnControlExtension([])` starts from nothing.
- `new ColumnControlExtension($controls)` uses that list verbatim.
- `add(int|string $target, array $content)` appends one group, dropping the defaults on the first call so a built-up configuration never inherits them.

Several groups compose through the existing `addExtension()` path:

```php
$dataTable->addExtension(
    (new ColumnControlExtension([]))
        ->add(0, ['order'])
        ->add('tfoot', ['search'])
);
```

## For the reviewer

**Backward compatible.** The no-argument `columnControl()` and `new ColumnControlExtension()` both serialize exactly what they did before; the existing `ColumnControlExtensionTest` assertion is untouched. `DataTableExtensions::addColumnControlExtension()` still installs the defaults.

**PHP only.** No frontend change and no `assets/dist/` rebuild. `normalizeDisabledColumnControls()` already resolved string targets, and its suite already covered a `'tfoot'` target, so `disableColumnControl()` keeps working against a footer group.

**Two calls I made that are worth a second opinion:**

1. Naming a target *replaces* the defaults, so the order controls disappear unless re-added. The alternative — accumulating across repeated `columnControl()` calls — needs reading the installed extension back out of the collection, since `addExtension()` indexes by key. More state for less clarity. Documented as a pitfall.
2. `content` defaults to `['search']`, so `columnControl(target: 'tfoot')` covers the headline case in one argument.

**Verified against the real library**, not just by reading it: a throwaway Vitest probe with `columnControl: [{target: 'tfoot', content: ['search']}]` and no footer markup produced

```
tfootInputCount: 2
<tfoot><tr data-dt-order="disable"><td data-dt-column="0" …>
  <div class="dt-column-footer">…<div class="dtcc-content dtcc-search dtcc-searchText dtcc-search_active">
```

confirming DataTables creates the `<tfoot>`, ColumnControl creates the row, and each cell gets a type-aware search input.

## Checks

- `composer fix` (1 file reformatted), `composer audit` (no advisories)
- `vendor/bin/phpunit`: 1362 tests. One failure, **pre-existing and unrelated**: `ImportmapCoverageTest::it_declares_every_published_import_for_asset_mapper` asserts against `assets/dist/vendor/`, which `.gitignore` excludes, so it fails on any tree where a local `npm run build` has produced that directory — including a clean `main`. Reproduced on `main` with the changes stashed.
- `npm test` in `assets/`: 495 tests
- `npm run lint` and `npm run build` in `docs/`
- `git diff --check` clean

GitNexus `detect_changes` reports critical risk, which is a line-shift artifact: it marks the whole `DataTable` class as touched for a one-method edit, then counts every process traversing it. The behavioral surface is `DataTable::columnControl()` and `ColumnControlExtension::jsonSerialize()`.

Not tested: live browser integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
