### PR TITLE
Align permissions with Symfony expressions

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -5,6 +5,33 @@ current version and the target, oldest first.
 
 ## v0.84 → v0.85
 
+### Permission configuration uses `setPermission()`
+
+The fluent `permission()` method on columns and actions has been renamed to `setPermission()`.
+This is an intentional breaking rename: update every `->permission(...)` call before upgrading.
+
+```php
+// before
+TextColumn::new('salary')->permission('ROLE_ADMIN');
+
+// after
+TextColumn::new('salary')->setPermission('ROLE_ADMIN');
+```
+
+Permissions also accept `Symfony\Component\ExpressionLanguage\Expression` objects. Install the
+optional component in applications that use expressions:
+
+```bash
+composer require symfony/expression-language
+```
+
+Direct `ColumnInterface` implementations do not need to add `setPermission()`; the setter is
+provided by `AbstractColumn`. Their existing `getPermission()` implementation remains valid for
+string permissions. Return `string|Expression|null` when a custom column needs to expose an
+expression permission.
+
+### Search configuration changes
+
 No source change is required. Columns extending `AbstractColumn` — every bundled column type and
 any subclass of one — gain the new search configuration automatically, and a class implementing
 `Contracts\ColumnInterface` directly keeps working unchanged. Two runtime behaviors around

--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
     "openspout/openspout": "To enable server-side CSV and XLSX export via Button::csv(serverSide: true) and Button::excel(serverSide: true).",
     "symfony/maker-bundle": "To use the make:datatable command.",
     "symfony/form": "To enable inline edit modal with auto-generated forms.",
+    "symfony/expression-language": "To use Symfony Expression objects with setPermission().",
     "symfony/mercure-bundle": "To enable real-time DataTable updates via Mercure SSE.",
     "symfony/twig-bundle": "To render edit form and TwigColumn",
     "symfony/translation": "To translate DataTable column titles and the filter bar labels (Filters/Reset/Apply/All)."

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
     "doctrine/orm": "^3.0",
     "friendsofphp/php-cs-fixer": "^3.95",
     "phpunit/phpunit": "^11.5",
+    "symfony/expression-language": "^7.0 || ^8.0",
     "symfony/framework-bundle": "^7.0 || ^8.0",
     "symfony/phpunit-bridge": "^7.0 || ^8.0",
     "symfony/property-info": "^7.0 || ^8.0",

--- a/docs/src/content/docs/columns/action-column.mdx
+++ b/docs/src/content/docs/columns/action-column.mdx
@@ -97,10 +97,27 @@ When `configureActions()` returns at least one action, `AbstractDataTable` autom
     ['`linkToRoute(string $routeName, array|callable|null $params = null)`', 'Target a Symfony route generated per row (static parameters array, or a callable receiving the raw row). Mutually exclusive with `linkToUrl()`: the last call wins'],
     ["`asAjaxRequest(string|callable $csrfTokenId, string $method = 'POST')`", 'Send the action as a same-origin Ajax request instead of navigating. `$method` accepts `POST` or `DELETE`. The CSRF token id is resolved per row and its value is posted as `_token`. See [Ajax Actions](#ajax-actions)'],
     ['`collapsible(string $template, array $parameters = [])`', 'Render a `detail` action as an expand/collapse control that lazily loads a Twig child row (the template receives the row as `entity`, plus any extra `$parameters`). Only meaningful for `Action::detail()`'],
-    ['`permission(string $attribute, ?callable $subjectResolver = null)`', 'Restrict the action with a Symfony security attribute (role/voter/expression). Without a resolver it is evaluated once before serialization; with a resolver it is evaluated per row (the resolver receives the raw source row). Denied actions are removed and never serialized to the client'],
+    ['`setPermission(string|Expression $attribute, ?callable $subjectResolver = null)`', 'Restrict the action with a Symfony security attribute (role/voter/expression). Without a resolver it is evaluated once before serialization; with a resolver it is evaluated per row (the resolver receives the raw source row). Denied actions are removed and never serialized to the client'],
     ['`position(?ActionsPosition $position)`', 'Override the column placement for this action only (`null` inherits the `Actions` collection position). See [Column Position & Alignment](#column-position--alignment)'],
   ]}
 />
+
+`setPermission()` also accepts Symfony's `Expression` object. Install the optional component in
+your application before using expressions:
+
+```bash
+composer require symfony/expression-language
+```
+
+```php
+use Symfony\Component\ExpressionLanguage\Expression;
+
+Action::new('publish', 'Publish')
+    ->setPermission(new Expression('"ROLE_EDITOR" in role_names and "ROLE_EXTERNAL" not in role_names'));
+```
+
+Symfony evaluates the expression with its standard security variables, including `user`,
+`role_names`, `token`, and `subject` when a subject resolver is configured.
 
 ### Action Icons
 
@@ -144,7 +161,7 @@ Each built-in factory has a reserved name, so adding two `Action::detail()` thro
 `InvalidArgumentException`. To render several independent link actions in the same column, use
 `Action::new()` with a unique `$name` for each. Custom actions are rendered as `<a href>`
 links and support `icon()`, `askConfirmation()`, `displayIf()`, `htmlAttributes()`,
-`permission()`, and `position()` like any other action.
+`setPermission()`, and `position()` like any other action.
 
 ```php
 use App\Entity\Invoice;
@@ -193,7 +210,7 @@ public function configureActions(Actions $actions): Actions
             ->linkToRoute('book_publish', fn (Book $book): array => ['id' => $book->getId()])
             ->asAjaxRequest('publish_book')
             ->askConfirmation('Publish this book?')
-            ->permission('PUBLISH', fn (Book $book): Book => $book)
+            ->setPermission('PUBLISH', fn (Book $book): Book => $book)
     );
 }
 ```
@@ -223,7 +240,7 @@ After a successful response the controller dispatches `datatables:action:success
 A failed request dispatches `datatables:action:error` and re-enables the button.
 
 <Aside type="caution">
-  `permission()` only decides whether the button is rendered. It replaces neither `#[IsGranted]`
+  `setPermission()` only decides whether the button is rendered. It replaces neither `#[IsGranted]`
   nor `#[IsCsrfTokenValid]` on the endpoint — the route stays the security boundary. Ajax actions
   are refused when their URL is not same-origin, and are not rendered at all when no CSRF token
   can be issued (no session, no token manager).
@@ -425,7 +442,7 @@ The template receives the located entity as `entity`, plus any extra parameters 
 `collapsible()`. Auto-escaping applies as usual.
 
 Access is checked before the template renders, mirroring what the rendering pipeline evaluated for
-that action: a per-row `permission()` resolver receives the located entity, a static `permission()`
+that action: a per-row `setPermission()` resolver receives the located entity, a static `setPermission()`
 is evaluated as-is, and an action with no configured permission falls back to `VIEW` on the entity —
 the same convention delete and edit follow. An action the user cannot see is an action they cannot
 fetch.
@@ -444,4 +461,3 @@ fetch.
 - [Securing Ajax Routes](/ux-datatables/getting-started/security/)
 - [Recipe: Actions with CSRF and voter](/ux-datatables/recipes/actions-csrf-voter/)
 - [Columns Overview](/ux-datatables/columns/overview/)
-

--- a/docs/src/content/docs/reference/abstract-datatable.mdx
+++ b/docs/src/content/docs/reference/abstract-datatable.mdx
@@ -314,7 +314,7 @@ Do not read the current HTTP request, the security token, the session, the
 locale, or any other per-request service from a `configure*()` method. Configure
 the table declaratively and let the request-scoped boundaries do the rest:
 
-- `permission()` on columns and actions for authorization -- it is evaluated per
+- `setPermission()` on columns and actions for authorization -- it is evaluated per
   request, per row, at the output boundary.
 - `customizeQueryBuilder()` and `getRequest()` for anything that depends on the
   incoming request.
@@ -521,4 +521,3 @@ This includes:
 - [Filters](/ux-datatables/guide/filters/)
 - [Recipe: Doctrine Server-Side](/ux-datatables/recipes/doctrine-server-side/)
 - [Securing Ajax Routes](/ux-datatables/getting-started/security/)
-

--- a/skills/ux-datatables/references/actions.md
+++ b/skills/ux-datatables/references/actions.md
@@ -16,7 +16,7 @@ public function configureActions(Actions $actions): Actions
             Action::delete('Delete')
                 ->icon('bi bi-trash')
                 ->askConfirmation('Delete this row?')
-                ->permission('ROLE_ADMIN')
+                ->setPermission('ROLE_ADMIN')
         );
 }
 ```
@@ -49,19 +49,19 @@ Action::detail()
     ->setEntityClass(User::class)              // entity for permission subject
     ->collapsible('detail.html.twig', [...])   // detail-only: expand into a child row (see below)
     ->position(ActionsPosition::BeforeColumns) // pin THIS action's column (null = inherit collection)
-    ->permission('EDIT', fn (User $u) => $u->getId() !== 1);  // see below
+    ->setPermission('EDIT', fn (User $u) => $u->getId() !== 1);  // see below
 ```
 
 > `Action` has `linkToUrl()` only — there is no `linkToRoute()` on actions. For route-based links, build the URL in the callable, or use a `UrlColumn` (which does support `linkToRoute()`).
 
 ## Permissions: static vs per-row
 
-`permission(string $attribute, ?callable $subjectResolver = null)`:
+`setPermission(string|Expression $attribute, ?callable $subjectResolver = null)`:
 
-- **Static** (no resolver) — evaluated once before serialization. If not granted, the action is removed entirely. Use for role checks: `->permission('ROLE_ADMIN')`.
-- **Per-row** (with resolver) — evaluated per row; the resolver receives the raw row and returns the voter subject: `->permission('EDIT', fn ($row) => $row)`.
+- **Static** (no resolver) — evaluated once before serialization. If not granted, the action is removed entirely. Use for role checks: `->setPermission('ROLE_ADMIN')`.
+- **Per-row** (with resolver) — evaluated per row; the resolver receives the raw row and returns the voter subject: `->setPermission('EDIT', fn ($row) => $row)`.
 
-Same model applies to columns (`AbstractColumn::permission()`), but columns only support the static form.
+Same model applies to columns (`AbstractColumn::setPermission()`), but columns only support the static form.
 
 Delete actions and inline boolean toggles require an active session for CSRF protection. In a
 stateless or session-less rendering context, the payload exposes `mutationsEnabled: false` and the

--- a/skills/ux-datatables/references/columns.md
+++ b/skills/ux-datatables/references/columns.md
@@ -39,12 +39,12 @@ TextColumn::new('email', 'Email')
     ->setDefaultContent('—')       // fallback when value is null/missing
     ->setExportable(false)         // exclude from export (adds 'not-exportable' class)
     ->hideWhenUpdating()           // hide field in the edit modal
-    ->permission('ROLE_ADMIN')     // hide column unless granted (evaluated server-side, never sent to client)
+    ->setPermission('ROLE_ADMIN')     // hide column unless granted (evaluated server-side, never sent to client)
     ->setCustomOption('key', 'value');
 ```
 
 Notes:
 - `setField()` vs `setData()`: `field` is the entity/query path used for server-side filtering & ordering; `data` is the JSON path the front-end reads. Set `field` when the displayed property differs from the queried one (e.g. joined relations).
-- `permission()` on a column is evaluated once before serialization — the attribute name is never exposed to the browser.
+- `setPermission()` on a column is evaluated once before serialization — the attribute or expression is never exposed to the browser.
 - Define custom JavaScript render callbacks with the Stimulus `datatables:pre-connect` event (see `references/server-side.md`).
 - `setOrderExpression()` is for computed columns sorted on a subquery: pair it with an `addSelect(... AS HIDDEN <alias>)` in `customizeQueryBuilder()` — see `references/server-side.md`.

--- a/skills/ux-datatables/references/defining-a-datatable.md
+++ b/skills/ux-datatables/references/defining-a-datatable.md
@@ -99,7 +99,7 @@ Rules and routing:
 - Return `null` (the default) to disable projection. The returned list **must preserve the count and order** of `$items` — otherwise a `LogicException` is thrown.
 - When a projector is active, the bundle pairs each source entity with its projected item (`RowContext`, `src/RowMapper/RowContext.php`) and routes them:
   - **Columns + TemplateColumn Twig (`row`)** read the **projected** item (the DTO).
-  - **Actions, `UrlColumn`, and `permission()`** receive the **source** entity.
+  - **Actions, `UrlColumn`, and `setPermission()`** receive the **source** entity.
   - Without a projector, both reference the same value. Twig `source` is that original object, and Twig `payload` is the array `mapRow()` returned.
 - A projected/computed column has no DB counterpart: mark it `->setOrderable(false)->setSearchable(false)`, or sort it via `->setOrderExpression(...)` backed by an `addSelect(... AS HIDDEN ...)` — see `references/server-side.md`.
 - **Server-side export calls the projector per batch, not per page.** An export streams every filtered row, so `projectPage()` runs once per batch (250 rows by default for `DoctrineDataProvider`), not once over the whole result set. Project each item from itself — map it, or batch-load data keyed by it. A projector whose output depends on which other items share the call (rank, running total, share of the batch maximum) yields different values in an export than on screen. Need a larger batch? Build the provider yourself in `createDataProvider()` with a bigger `exportChunkSize`.

--- a/skills/ux-datatables/references/gotchas.md
+++ b/skills/ux-datatables/references/gotchas.md
@@ -33,14 +33,14 @@ Computed or template columns have no DB counterpart. Set `->setOrderable(false)-
 ## API Platform / Mercure are opt-in
 Neither activates implicitly. Set `apiPlatform: true` / call `apiPlatform()`, and `mercure: true` / call `mercure()`. Define API Platform filters on the resource so searchable/orderable columns map to enabled filters.
 
-## `permission()` removes, never hides client-side
-Static `permission()` on actions/columns is evaluated server-side before serialization; ungranted items are dropped and the attribute name is never sent to the browser. Don't rely on it for purely visual toggling — use `displayIf()` (actions) or `setVisible()` (columns) for that.
+## `setPermission()` removes, never hides client-side
+Static `setPermission()` on actions/columns is evaluated server-side before serialization; ungranted items are dropped and the attribute or expression is never sent to the browser. Don't rely on it for purely visual toggling — use `displayIf()` (actions) or `setVisible()` (columns) for that.
 
 ## `ButtonType::COLUMN_VISIBILITY`
 The enum case is `COLUMN_VISIBILITY` (serialized value `'colvis'`), not `COL_VIS`.
 
 ## `projectPage()` must preserve page size and order
-A page projector that returns a different count (or reordered rows) throws `LogicException`. Map one-to-one. Remember the split: columns and TemplateColumn Twig (`row`) read the projected DTO, but actions/`UrlColumn`/`permission()` still receive the **source** entity — don't move identifiers needed by actions into the DTO only.
+A page projector that returns a different count (or reordered rows) throws `LogicException`. Map one-to-one. Remember the split: columns and TemplateColumn Twig (`row`) read the projected DTO, but actions/`UrlColumn`/`setPermission()` still receive the **source** entity — don't move identifiers needed by actions into the DTO only.
 
 ## `projectPage()` sees batches, not the whole set, during a server-side export
 An export streams every filtered row, so the projector runs once per batch (250 rows by default) instead of once per page. Per-item mapping and batch loading behave identically; a projector computing something relative to the items it received (rank, running total, percentage of the batch maximum) returns different values than on screen. Raise `exportChunkSize` by building the provider in `createDataProvider()` if a bigger batch is required.

--- a/src/Ajax/DetailRowService.php
+++ b/src/Ajax/DetailRowService.php
@@ -64,11 +64,11 @@ final readonly class DetailRowService
         if ($action->hasPerRowPermission()) {
             $resolver = $action->getPermissionSubjectResolver();
 
-            return $this->permissionChecker->isGranted((string) $action->getPermission(), $resolver($entity));
+            return $this->permissionChecker->isGranted($action->getPermission(), $resolver($entity));
         }
 
         if ($action->hasStaticPermission()) {
-            return $this->permissionChecker->isGranted((string) $action->getPermission());
+            return $this->permissionChecker->isGranted($action->getPermission());
         }
 
         return $this->permissionChecker->isGranted('VIEW', $entity);

--- a/src/Column/AbstractColumn.php
+++ b/src/Column/AbstractColumn.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\QueryBuilder;
 use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
 use Pentiminax\UX\DataTables\Contracts\SearchableColumnInterface;
 use Pentiminax\UX\DataTables\Enum\ColumnType;
+use Symfony\Component\ExpressionLanguage\Expression;
 
 /**
  * Base implementation shared by every bundled column type (TextColumn, DateColumn, ...).
@@ -42,7 +43,7 @@ abstract class AbstractColumn implements SearchableColumnInterface
     protected bool $columnControlEnabled = true;
     protected ?array $columnControl      = null;
     protected array $customOptions       = [];
-    protected ?string $permission        = null;
+    protected string|Expression|null $permission = null;
     protected ?int $responsivePriority   = null;
 
     /** @var list<array{join: string, alias: string, conditionType: ?string, condition: ?string}> */
@@ -481,18 +482,18 @@ abstract class AbstractColumn implements SearchableColumnInterface
     }
 
     /**
-     * Restrict the column visibility with a Symfony security attribute (role, voter, expression).
+     * Restrict the column visibility with a Symfony security attribute or expression.
      *
      * Evaluated once before serialization. The attribute name is never sent to the client.
      */
-    public function permission(string $attribute): static
+    public function setPermission(string|Expression $attribute): static
     {
         $this->permission = $attribute;
 
         return $this;
     }
 
-    public function getPermission(): ?string
+    public function getPermission(): string|Expression|null
     {
         return $this->permission;
     }

--- a/src/Column/Rendering/ActionRowDataResolver.php
+++ b/src/Column/Rendering/ActionRowDataResolver.php
@@ -57,7 +57,7 @@ final class ActionRowDataResolver
 
             foreach ($column->getActions()?->getActions() ?? [] as $action) {
                 if ($action->hasStaticPermission()
-                    && !$this->permissionChecker->isGranted((string) $action->getPermission())
+                    && !$this->permissionChecker->isGranted($action->getPermission())
                 ) {
                     continue;
                 }
@@ -66,7 +66,7 @@ final class ActionRowDataResolver
                     $resolver = $action->getPermissionSubjectResolver();
                     $subject  = null !== $resolver ? $resolver($sourceRow) : null;
 
-                    if (!$this->permissionChecker->isGranted((string) $action->getPermission(), $subject)) {
+                    if (!$this->permissionChecker->isGranted($action->getPermission(), $subject)) {
                         continue;
                     }
                 }

--- a/src/Contracts/ColumnInterface.php
+++ b/src/Contracts/ColumnInterface.php
@@ -67,8 +67,6 @@ interface ColumnInterface extends \JsonSerializable
 
     public function getCustomOptions(): array;
 
-    public function setPermission(string|Expression $attribute): static;
-
     /**
      * Security attribute or expression required to see this column, or null when it is always visible.
      */

--- a/src/Contracts/ColumnInterface.php
+++ b/src/Contracts/ColumnInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pentiminax\UX\DataTables\Contracts;
 
 use Pentiminax\UX\DataTables\Enum\ColumnType;
+use Symfony\Component\ExpressionLanguage\Expression;
 
 /**
  * One column of a table's configuration: the JSON handed to DataTables.net, the entity field the
@@ -13,8 +14,8 @@ use Pentiminax\UX\DataTables\Enum\ColumnType;
  * Implementations must behave as immutable-once-configured value objects. Every accessor is called
  * while AbstractDataTable resolves its columns -- on a container-shared instance -- and again for
  * each row, so none of them may read the request, the security token, or the locale.
- * getPermission() only names the required security attribute; ColumnResolver evaluates it per
- * request at the serialization and query boundaries.
+ * getPermission() only names the required security attribute or expression; ColumnResolver
+ * evaluates it per request at the serialization and query boundaries.
  *
  * Extend {@see \Pentiminax\UX\DataTables\Column\AbstractColumn} instead of implementing this
  * directly: it provides the fluent setters, the ColumnType handling, and jsonSerialize(). Add
@@ -66,8 +67,10 @@ interface ColumnInterface extends \JsonSerializable
 
     public function getCustomOptions(): array;
 
+    public function setPermission(string|Expression $attribute): static;
+
     /**
-     * Security attribute required to see this column, or null when it is always visible.
+     * Security attribute or expression required to see this column, or null when it is always visible.
      */
-    public function getPermission(): ?string;
+    public function getPermission(): string|Expression|null;
 }

--- a/src/Model/AbstractDataTable.php
+++ b/src/Model/AbstractDataTable.php
@@ -44,7 +44,7 @@ use Symfony\Component\HttpFoundation\Request;
  * the security token, the session, or the locale. See the purity contract in
  * docs/src/content/docs/reference/abstract-datatable.mdx ("Configuration Methods Must Be Pure").
  *
- * Request-dependent behavior belongs at the request-scoped boundaries instead: permission() on
+ * Request-dependent behavior belongs at the request-scoped boundaries instead: setPermission() on
  * columns and actions, customizeQueryBuilder() and getRequest() for the query, and setData() --
  * the sanctioned way to inject rows a controller has already resolved -- for inline data, which
  * runs them through the same row-processing pipeline a provider would use.

--- a/src/Model/Action.php
+++ b/src/Model/Action.php
@@ -7,6 +7,7 @@ namespace Pentiminax\UX\DataTables\Model;
 use Pentiminax\UX\DataTables\Enum\ActionsPosition;
 use Pentiminax\UX\DataTables\Enum\ActionType;
 use Pentiminax\UX\DataTables\Enum\Icon;
+use Symfony\Component\ExpressionLanguage\Expression;
 
 final class Action implements \JsonSerializable
 {
@@ -29,7 +30,7 @@ final class Action implements \JsonSerializable
     private ?string $ajaxMethod                  = null;
     private ?string $csrfTokenId                 = null;
     private ?\Closure $csrfTokenIdResolver       = null;
-    private ?string $permission                  = null;
+    private string|Expression|null $permission   = null;
     private ?\Closure $permissionSubjectResolver = null;
     private ?string $collapsibleTemplate         = null;
     private array $collapsibleParameters         = [];
@@ -324,13 +325,13 @@ final class Action implements \JsonSerializable
     }
 
     /**
-     * Restrict this action with a Symfony security attribute (role, voter, expression).
+     * Restrict this action with a Symfony security attribute or expression.
      *
      * Without a subject resolver, the attribute is evaluated once before serialization
      * (e.g. `ROLE_ADMIN`). With a resolver, the attribute is evaluated per row and
      * the resolver receives the raw row passed to the rendering pipeline.
      */
-    public function permission(string $attribute, ?callable $subjectResolver = null): self
+    public function setPermission(string|Expression $attribute, ?callable $subjectResolver = null): self
     {
         $this->permission                = $attribute;
         $this->permissionSubjectResolver = null === $subjectResolver
@@ -340,7 +341,7 @@ final class Action implements \JsonSerializable
         return $this;
     }
 
-    public function getPermission(): ?string
+    public function getPermission(): string|Expression|null
     {
         return $this->permission;
     }

--- a/src/Model/Actions.php
+++ b/src/Model/Actions.php
@@ -189,7 +189,7 @@ final class Actions implements \JsonSerializable
                 continue;
             }
 
-            if (!$checker->isGranted((string) $action->getPermission())) {
+            if (!$checker->isGranted($action->getPermission())) {
                 unset($this->actions[$key]);
             }
         }

--- a/src/Security/PermissionChecker.php
+++ b/src/Security/PermissionChecker.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pentiminax\UX\DataTables\Security;
 
+use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 
@@ -20,7 +21,7 @@ final class PermissionChecker
     ) {
     }
 
-    public function isGranted(string $attribute, mixed $subject = null): bool
+    public function isGranted(string|Expression $attribute, mixed $subject = null): bool
     {
         if (null === $this->checker) {
             return true;

--- a/tests/Unit/Ajax/DetailRowServiceTest.php
+++ b/tests/Unit/Ajax/DetailRowServiceTest.php
@@ -221,7 +221,7 @@ final class StaticPermissionDetailDataTable extends AbstractDataTable
     public function configureActions(Actions $actions): Actions
     {
         return $actions->add(
-            Action::detail()->collapsible('detail.html.twig')->permission('SHOW_DETAIL')
+            Action::detail()->collapsible('detail.html.twig')->setPermission('SHOW_DETAIL')
         );
     }
 }
@@ -239,7 +239,7 @@ final class PerRowPermissionDetailDataTable extends AbstractDataTable
         return $actions->add(
             Action::detail()
                 ->collapsible('detail.html.twig')
-                ->permission('SHOW_DETAIL', static fn (DetailRowEntity $entity): string => $entity->email)
+                ->setPermission('SHOW_DETAIL', static fn (DetailRowEntity $entity): string => $entity->email)
         );
     }
 }

--- a/tests/Unit/Column/AbstractColumnTest.php
+++ b/tests/Unit/Column/AbstractColumnTest.php
@@ -9,6 +9,7 @@ use Pentiminax\UX\DataTables\Enum\ColumnType;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\ExpressionLanguage\Expression;
 
 /**
  * @internal
@@ -170,8 +171,21 @@ final class AbstractColumnTest extends TestCase
 
         $this->assertNull($column->getPermission());
 
-        $this->assertSame($column, $column->permission('ROLE_HR'));
+        $this->assertSame($column, $column->setPermission('ROLE_HR'));
         $this->assertSame('ROLE_HR', $column->getPermission());
+        $this->assertArrayNotHasKey('permission', $column->jsonSerialize());
+    }
+
+    #[Test]
+    public function it_stores_expression_permissions_without_serializing_them(): void
+    {
+        $expression = new Expression('"ROLE_ADMIN" in role_names');
+        $column     = (new class extends AbstractColumn {})
+            ->setType(ColumnType::STRING)
+            ->setName('salary')
+            ->setPermission($expression);
+
+        $this->assertSame($expression, $column->getPermission());
         $this->assertArrayNotHasKey('permission', $column->jsonSerialize());
     }
 

--- a/tests/Unit/Column/ColumnResolverTest.php
+++ b/tests/Unit/Column/ColumnResolverTest.php
@@ -184,9 +184,9 @@ final class ColumnResolverTest extends TestCase
             ['ROLE_PUBLIC', null, true],
         ]);
 
-        $salary = TextColumn::new('salary', 'Salary')->permission('ROLE_HR');
+        $salary = TextColumn::new('salary', 'Salary')->setPermission('ROLE_HR');
         $name   = TextColumn::new('name', 'Name');
-        $public = TextColumn::new('public', 'Public')->permission('ROLE_PUBLIC');
+        $public = TextColumn::new('public', 'Public')->setPermission('ROLE_PUBLIC');
 
         $filtered = $resolver->filterStaticPermissions([$salary, $name, $public]);
 
@@ -202,8 +202,8 @@ final class ColumnResolverTest extends TestCase
         ]);
 
         $actions = new Actions();
-        $actions->add(Action::delete()->permission('ROLE_ADMIN'));
-        $actions->add(Action::edit()->permission('ROLE_EDITOR'));
+        $actions->add(Action::delete()->setPermission('ROLE_ADMIN'));
+        $actions->add(Action::edit()->setPermission('ROLE_EDITOR'));
 
         $filtered = $resolver->filterStaticPermissions([ActionColumn::fromActions('actions', '', $actions)]);
 
@@ -234,7 +234,7 @@ final class ColumnResolverTest extends TestCase
      */
     public static function provideDeniedColumnValueRemovals(): iterable
     {
-        $salary = TextColumn::new('salary', 'Salary')->permission('ROLE_HR');
+        $salary = TextColumn::new('salary', 'Salary')->setPermission('ROLE_HR');
         $name   = TextColumn::new('name', 'Name');
 
         yield 'flat unauthorized key' => [
@@ -245,43 +245,43 @@ final class ColumnResolverTest extends TestCase
 
         yield 'literal dotted unauthorized key' => [
             ['user.email' => 'secret', 'name' => 'Ada'],
-            [TextColumn::new('user.email', 'Email')->permission('ROLE_HR'), $name],
+            [TextColumn::new('user.email', 'Email')->setPermission('ROLE_HR'), $name],
             ['name' => 'Ada'],
         ];
 
         yield 'nested unauthorized dotted path' => [
             ['user' => ['email' => 'secret', 'role' => 'admin'], 'name' => 'Ada'],
-            [TextColumn::new('user.email', 'Email')->permission('ROLE_HR'), $name],
+            [TextColumn::new('user.email', 'Email')->setPermission('ROLE_HR'), $name],
             ['user' => ['role' => 'admin'], 'name' => 'Ada'],
         ];
 
         yield 'literal and nested representations of the same path' => [
             ['user.email' => 'literal', 'user' => ['email' => 'nested', 'role' => 'admin'], 'name' => 'Ada'],
-            [TextColumn::new('user.email', 'Email')->permission('ROLE_HR'), $name],
+            [TextColumn::new('user.email', 'Email')->setPermission('ROLE_HR'), $name],
             ['user' => ['role' => 'admin'], 'name' => 'Ada'],
         ];
 
         yield 'nested field path when the row key differs' => [
             ['email' => 'top-level', 'user' => ['email' => 'secret', 'role' => 'admin'], 'name' => 'Ada'],
-            [TextColumn::new('email', 'Email')->setField('user.email')->permission('ROLE_HR'), $name],
+            [TextColumn::new('email', 'Email')->setField('user.email')->setPermission('ROLE_HR'), $name],
             ['user' => ['role' => 'admin'], 'name' => 'Ada'],
         ];
 
         yield 'missing nested path is a no-op' => [
             ['name' => 'Ada', 'extra' => 'kept'],
-            [TextColumn::new('user.email', 'Email')->permission('ROLE_HR'), $name],
+            [TextColumn::new('user.email', 'Email')->setPermission('ROLE_HR'), $name],
             ['name' => 'Ada', 'extra' => 'kept'],
         ];
 
         yield 'object-backed nested path' => [
             ['value' => (object) ['name' => 'secret', 'role' => 'admin'], 'kept' => true],
-            [TextColumn::new('value.name', 'Name')->permission('ROLE_HR'), $name],
+            [TextColumn::new('value.name', 'Name')->setPermission('ROLE_HR'), $name],
             ['value' => ['role' => 'admin'], 'kept' => true],
         ];
 
         yield 'array-object nested path' => [
             ['value' => new \ArrayObject(['name' => 'secret', 'role' => 'admin']), 'kept' => true],
-            [TextColumn::new('value.name', 'Name')->permission('ROLE_HR'), $name],
+            [TextColumn::new('value.name', 'Name')->setPermission('ROLE_HR'), $name],
             ['value' => ['role' => 'admin'], 'kept' => true],
         ];
 
@@ -292,7 +292,7 @@ final class ColumnResolverTest extends TestCase
                     return ['name' => 'secret', 'role' => 'admin'];
                 }
             }, 'kept' => true],
-            [TextColumn::new('value.name', 'Name')->permission('ROLE_HR'), $name],
+            [TextColumn::new('value.name', 'Name')->setPermission('ROLE_HR'), $name],
             ['value' => ['role' => 'admin'], 'kept' => true],
         ];
 
@@ -304,7 +304,7 @@ final class ColumnResolverTest extends TestCase
                 ],
                 'name' => 'Ada',
             ],
-            [TextColumn::new('user.profile.email', 'Email')->permission('ROLE_HR'), $name],
+            [TextColumn::new('user.profile.email', 'Email')->setPermission('ROLE_HR'), $name],
             ['user' => ['profile' => ['id' => 7], 'role' => 'admin'], 'name' => 'Ada'],
         ];
     }
@@ -318,7 +318,7 @@ final class ColumnResolverTest extends TestCase
         $filtered = $resolver->removeDeniedColumnValues(
             ['value' => $value, 'name' => 'Ada'],
             [
-                TextColumn::new('value.name', 'Name')->permission('ROLE_HR'),
+                TextColumn::new('value.name', 'Name')->setPermission('ROLE_HR'),
                 TextColumn::new('name', 'Name'),
             ],
         );
@@ -335,7 +335,7 @@ final class ColumnResolverTest extends TestCase
 
         $actions = new Actions();
         $actions->add(Action::delete());
-        $actionColumn = ActionColumn::fromActions('actions', '', $actions)->permission('ROLE_MANAGER');
+        $actionColumn = ActionColumn::fromActions('actions', '', $actions)->setPermission('ROLE_MANAGER');
 
         $this->assertSame([], $resolver->filterStaticPermissions([$actionColumn]));
     }
@@ -346,7 +346,7 @@ final class ColumnResolverTest extends TestCase
         $resolver = $this->createResolverWithPermissions([['ROLE_ADMIN', null, false]]);
 
         $actions = new Actions();
-        $actions->add(Action::delete()->permission('ROLE_ADMIN'));
+        $actions->add(Action::delete()->setPermission('ROLE_ADMIN'));
 
         $resolver->filterActionsByStaticPermissions($actions);
 
@@ -365,7 +365,7 @@ final class ColumnResolverTest extends TestCase
      */
     public static function provideColumnsKeptWithoutPermissionCheck(): iterable
     {
-        yield 'permission granted by the default checker' => [TextColumn::new('salary', 'Salary')->permission('ROLE_HR')];
+        yield 'permission granted by the default checker' => [TextColumn::new('salary', 'Salary')->setPermission('ROLE_HR')];
         yield 'custom column implementing ColumnInterface with no permission' => [self::createStub(ColumnInterface::class)];
     }
 

--- a/tests/Unit/Column/Rendering/ActionRowDataResolverTest.php
+++ b/tests/Unit/Column/Rendering/ActionRowDataResolverTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -103,7 +104,7 @@ final class ActionRowDataResolverTest extends TestCase
             [
                 Action::edit()
                     ->linkToUrl(static fn (object $r) => '/items/'.$r->id)
-                    ->permission('EDIT', static fn ($r) => $r),
+                    ->setPermission('EDIT', static fn ($r) => $r),
             ],
             (object) ['id' => 7],
             ['EDIT' => ['url' => '/items/7', 'id' => 7]],
@@ -132,13 +133,38 @@ final class ActionRowDataResolverTest extends TestCase
 
         $action = Action::edit()
             ->linkToUrl(static fn (object $r) => '/items/'.$r->id.'/edit')
-            ->permission('EDIT', static fn ($r) => $r);
+            ->setPermission('EDIT', static fn ($r) => $r);
 
         $result = $this->resolveRow(new ActionRowDataResolver(new PermissionChecker($inner)), $sourceRow, $action);
 
         $this->assertSame(
             $granted ? ['EDIT' => ['url' => '/items/7/edit', 'id' => 7]] : null,
             $result[ActionRowDataResolver::ROW_ACTIONS_KEY] ?? null,
+        );
+    }
+
+    #[Test]
+    public function passes_expression_permission_with_resolved_subject(): void
+    {
+        $expression = new Expression('"ROLE_EDITOR" in role_names');
+        $sourceRow  = (object) ['id' => 7];
+
+        $inner = $this->createMock(AuthorizationCheckerInterface::class);
+        $inner
+            ->expects($this->once())
+            ->method('isGranted')
+            ->with($expression, $sourceRow)
+            ->willReturn(true);
+
+        $action = Action::edit()
+            ->linkToUrl(static fn (object $r) => '/items/'.$r->id.'/edit')
+            ->setPermission($expression, static fn ($r) => $r);
+
+        $result = $this->resolveRow(new ActionRowDataResolver(new PermissionChecker($inner)), $sourceRow, $action);
+
+        $this->assertSame(
+            ['EDIT' => ['url' => '/items/7/edit', 'id' => 7]],
+            $result[ActionRowDataResolver::ROW_ACTIONS_KEY],
         );
     }
 
@@ -156,7 +182,7 @@ final class ActionRowDataResolverTest extends TestCase
 
         $action = Action::edit()
             ->linkToUrl(static fn (object $r) => '/items/'.$r->id.'/edit')
-            ->permission('ROLE_EDITOR');
+            ->setPermission('ROLE_EDITOR');
 
         $result = $this->resolveRow(
             new ActionRowDataResolver(new PermissionChecker($inner)),
@@ -182,7 +208,7 @@ final class ActionRowDataResolverTest extends TestCase
 
         $action = Action::edit()
             ->linkToUrl(static fn (object $r) => '/items/'.$r->owner)
-            ->permission('OWNS', static fn (object $r) => $r->owner);
+            ->setPermission('OWNS', static fn (object $r) => $r->owner);
 
         $this->resolveRow(new ActionRowDataResolver(new PermissionChecker($inner)), (object) ['owner' => 'alice'], $action);
     }

--- a/tests/Unit/Model/AbstractDataTableResetTest.php
+++ b/tests/Unit/Model/AbstractDataTableResetTest.php
@@ -101,7 +101,7 @@ final class AbstractDataTableResetTest extends TestCase
 
         $table = $this->tableWithAction(
             Action::detail()
-                ->permission('ROLE_ADMIN')
+                ->setPermission('ROLE_ADMIN')
                 ->linkToUrl(static fn (array $row): string => '/books/'.$row['id']),
             $granted,
         );
@@ -129,7 +129,7 @@ final class AbstractDataTableResetTest extends TestCase
 
         $table = $this->tableWithAction(
             Action::detail()
-                ->permission('BOOK_VIEW', static fn (array $row): array => $row)
+                ->setPermission('BOOK_VIEW', static fn (array $row): array => $row)
                 ->linkToUrl(static fn (array $row): string => '/books/'.$row['id']),
             $granted,
         );

--- a/tests/Unit/Model/ActionTest.php
+++ b/tests/Unit/Model/ActionTest.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\ExpressionLanguage\Expression;
 
 /**
  * @internal
@@ -276,7 +277,7 @@ final class ActionTest extends TestCase
     #[DataProvider('permissionProvider')]
     public function it_distinguishes_static_from_per_row_permissions(?\Closure $subjectResolver, bool $static, bool $perRow): void
     {
-        $action = Action::delete()->permission('ROLE_ADMIN', $subjectResolver);
+        $action = Action::delete()->setPermission('ROLE_ADMIN', $subjectResolver);
 
         $this->assertSame('ROLE_ADMIN', $action->getPermission());
         $this->assertSame($subjectResolver, $action->getPermissionSubjectResolver());
@@ -287,6 +288,17 @@ final class ActionTest extends TestCase
 
         $this->assertArrayNotHasKey('permission', $json);
         $this->assertArrayNotHasKey('permissionSubjectResolver', $json);
+    }
+
+    #[Test]
+    public function it_stores_expression_permissions_without_serializing_them(): void
+    {
+        $expression = new Expression('"ROLE_ADMIN" in role_names');
+        $action     = Action::delete()->setPermission($expression);
+
+        $this->assertSame($expression, $action->getPermission());
+        $this->assertTrue($action->hasStaticPermission());
+        $this->assertArrayNotHasKey('permission', $action->jsonSerialize());
     }
 
     #[Test]

--- a/tests/Unit/Model/ActionsTest.php
+++ b/tests/Unit/Model/ActionsTest.php
@@ -130,8 +130,8 @@ final class ActionsTest extends TestCase
     public function it_removes_actions_whose_static_permission_is_denied(): void
     {
         $actions = (new Actions())
-            ->add(Action::delete()->permission('ROLE_ADMIN'))
-            ->add(Action::edit()->permission('ROLE_EDITOR'))
+            ->add(Action::delete()->setPermission('ROLE_ADMIN'))
+            ->add(Action::edit()->setPermission('ROLE_EDITOR'))
             ->add(Action::detail());
 
         $checker = $this->createStub(AuthorizationCheckerInterface::class);
@@ -149,7 +149,7 @@ final class ActionsTest extends TestCase
     #[Test]
     public function it_ignores_per_row_permissions_when_filtering(): void
     {
-        $actions = (new Actions())->add(Action::delete()->permission('DELETE', static fn ($row) => $row));
+        $actions = (new Actions())->add(Action::delete()->setPermission('DELETE', static fn ($row) => $row));
 
         $actions->filterStaticPermissions(new PermissionChecker($this->createStub(AuthorizationCheckerInterface::class)));
 
@@ -159,7 +159,7 @@ final class ActionsTest extends TestCase
     #[Test]
     public function it_keeps_every_action_without_an_authorization_checker(): void
     {
-        $actions = (new Actions())->add(Action::delete()->permission('ROLE_ADMIN'));
+        $actions = (new Actions())->add(Action::delete()->setPermission('ROLE_ADMIN'));
 
         $actions->filterStaticPermissions(new PermissionChecker());
 

--- a/tests/Unit/Mutation/BooleanMutationContextResolverTest.php
+++ b/tests/Unit/Mutation/BooleanMutationContextResolverTest.php
@@ -262,7 +262,7 @@ final class PermissionGatedBooleanDataTableFixture extends AbstractDataTable
 {
     public function configureColumns(): iterable
     {
-        yield BooleanColumn::new('enabled')->permission('ROLE_ADMIN')->renderAsSwitch();
+        yield BooleanColumn::new('enabled')->setPermission('ROLE_ADMIN')->renderAsSwitch();
     }
 }
 

--- a/tests/Unit/RowMapper/RowProcessingPipelineTest.php
+++ b/tests/Unit/RowMapper/RowProcessingPipelineTest.php
@@ -60,7 +60,7 @@ final class RowProcessingPipelineTest extends TestCase
         $pipeline = new RowProcessingPipeline(
             baseMapper: static fn (array $row): array => $row,
             columns: [
-                TextColumn::new('salary', 'Salary')->permission('ROLE_HR'),
+                TextColumn::new('salary', 'Salary')->setPermission('ROLE_HR'),
                 TextColumn::new('name', 'Name'),
             ],
             columnResolver: new ColumnResolver(permissionChecker: new PermissionChecker($checker)),
@@ -83,7 +83,7 @@ final class RowProcessingPipelineTest extends TestCase
         $pipeline = new RowProcessingPipeline(
             baseMapper: static fn (array $row): array => $row,
             columns: [
-                TextColumn::new('user.email', 'Email')->permission('ROLE_HR'),
+                TextColumn::new('user.email', 'Email')->setPermission('ROLE_HR'),
                 TextColumn::new('name', 'Name'),
             ],
             columnResolver: new ColumnResolver(permissionChecker: new PermissionChecker($checker)),
@@ -106,7 +106,7 @@ final class RowProcessingPipelineTest extends TestCase
         $pipeline = new RowProcessingPipeline(
             baseMapper: static fn (array $row): array => $row,
             columns: [
-                TextColumn::new('value.name', 'Name')->permission('ROLE_HR'),
+                TextColumn::new('value.name', 'Name')->setPermission('ROLE_HR'),
                 TextColumn::new('name', 'Name'),
             ],
             columnResolver: new ColumnResolver(permissionChecker: new PermissionChecker($checker)),

--- a/tests/Unit/Security/PermissionCheckerTest.php
+++ b/tests/Unit/Security/PermissionCheckerTest.php
@@ -8,6 +8,7 @@ use Pentiminax\UX\DataTables\Security\PermissionChecker;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 
@@ -38,6 +39,20 @@ final class PermissionCheckerTest extends TestCase
             ->willReturn(true);
 
         $this->assertTrue((new PermissionChecker($inner))->isGranted('EDIT', $subject));
+    }
+
+    #[Test]
+    public function delegates_expression_attributes_without_casting_them(): void
+    {
+        $expression = new Expression('"ROLE_ADMIN" in role_names');
+        $inner      = $this->createMock(AuthorizationCheckerInterface::class);
+        $inner
+            ->expects($this->once())
+            ->method('isGranted')
+            ->with($expression, null)
+            ->willReturn(true);
+
+        $this->assertTrue((new PermissionChecker($inner))->isGranted($expression));
     }
 
     #[Test]

--- a/tests/Unit/Twig/DataTablesExtensionTest.php
+++ b/tests/Unit/Twig/DataTablesExtensionTest.php
@@ -267,7 +267,7 @@ final class DataTablesExtensionTest extends TestCase
         $table = $this->inlineTable(
             [
                 TextColumn::new('name'),
-                TextColumn::new('user.email')->permission('ROLE_DENIED'),
+                TextColumn::new('user.email')->setPermission('ROLE_DENIED'),
             ],
             static fn (DataTable $table): DataTable => $table->data([
                 ['name' => 'Ada', 'user' => ['email' => 'secret', 'role' => 'admin']],
@@ -289,7 +289,7 @@ final class DataTablesExtensionTest extends TestCase
         $table = $this->inlineTable(
             [
                 TextColumn::new('name'),
-                TextColumn::new('value.name')->permission('ROLE_DENIED'),
+                TextColumn::new('value.name')->setPermission('ROLE_DENIED'),
             ],
             static fn (DataTable $table): DataTable => $table->data([
                 ['name' => 'Ada', 'value' => (object) ['name' => 'secret', 'role' => 'admin']],
@@ -310,7 +310,7 @@ final class DataTablesExtensionTest extends TestCase
     {
         $actions = (new Actions())->add(
             Action::detail()
-                ->permission('ROLE_DENIED')
+                ->setPermission('ROLE_DENIED')
                 ->linkToUrl(static fn (array $row): string => '/books/'.$row['id'])
         );
 
@@ -345,7 +345,7 @@ final class DataTablesExtensionTest extends TestCase
         $table = new ConfigurableDataTable(
             [
                 TextColumn::new('id'),
-                TextColumn::new('secret')->permission('ROLE_DENIED'),
+                TextColumn::new('secret')->setPermission('ROLE_DENIED'),
             ],
             configureTable: static fn (DataTable $table): DataTable => $table->data([
                 ['id' => 5, 'secret' => 'hidden'],


### PR DESCRIPTION
## Summary

- Replace `permission()` with the strict `setPermission()` API for columns and actions.
- Preserve Symfony `Expression` objects through the existing authorization flow.
- Update documentation, skill references, and tests.
- Add `symfony/expression-language` to `require-dev`.

## Test plan

- `composer validate --no-check-publish`
- PHP syntax lint on all changed PHP files
- `git diff --check`
- PHPUnit not run: Composer dependencies are unavailable because package downloads are blocked by the environment network.

## Notes

The shared `PermissionChecker` path is intentionally affected because it now forwards `Expression` objects without string casts.