### PR TITLE
Color and iconify CSV/Excel export buttons in the Tailwind theme

### DIFF
--- a/assets/dist/styles/datatables-tailwind-theme.css
+++ b/assets/dist/styles/datatables-tailwind-theme.css
@@ -666,6 +666,58 @@ div.dt-container.dt-container div.dt-layout-end > *:not(:first-child) {
     box-shadow: var(--dt-tw-ring-focus), var(--dt-tw-shadow-sm);
 }
 
+/*
+ * Export buttons keep the format in their class name — DataTables writes
+ * `buttons-csv` / `buttons-excel` on its own HTML5 buttons, and
+ * `Button::jsonSerialize()` writes the same class for server-side exports — so
+ * the theme can tint each format and prefix a glyph without the app pulling in
+ * an icon font. A `className()` set by the app replaces the marker and opts the
+ * button back out of this styling.
+ */
+
+.dt-container.dt-container :is(button, div, a).dt-button:is(.buttons-csv, .buttons-excel) {
+    background: rgb(var(--dt-tw-export) / 0.1);
+    box-shadow:
+        inset 0 0 0 1px rgb(var(--dt-tw-export) / 0.2),
+        var(--dt-tw-shadow-sm);
+    color: rgb(var(--dt-tw-export));
+}
+
+.dt-container.dt-container
+    :is(button, div, a).dt-button:is(.buttons-csv, .buttons-excel):hover:not(.disabled) {
+    background: rgb(var(--dt-tw-export) / 0.18);
+    box-shadow:
+        inset 0 0 0 1px rgb(var(--dt-tw-export) / 0.35),
+        var(--dt-tw-shadow-sm);
+}
+
+.dt-container.dt-container
+    :is(button, div, a).dt-button:is(.buttons-csv, .buttons-excel):active:not(.disabled) {
+    background: rgb(var(--dt-tw-export) / 0.26);
+    box-shadow: inset 0 0 0 1px rgb(var(--dt-tw-export) / 0.35);
+}
+
+.dt-container.dt-container
+    :is(button, div, a).dt-button:is(.buttons-csv, .buttons-excel)::before {
+    content: '';
+    flex-shrink: 0;
+    width: 1rem;
+    height: 1rem;
+    background: currentColor;
+    mask: var(--dt-tw-export-icon) center / contain no-repeat;
+    -webkit-mask: var(--dt-tw-export-icon) center / contain no-repeat;
+}
+
+.dt-container.dt-container :is(button, div, a).dt-button.buttons-csv {
+    --dt-tw-export: var(--dt-tw-info);
+    --dt-tw-export-icon: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='black'%20stroke-width='2'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Cpath%20d='M14%202H6a2%202%200%200%200-2%202v16a2%202%200%200%200%202%202h12a2%202%200%200%200%202-2V8z'/%3E%3Cpath%20d='M14%202v6h6'/%3E%3Cpath%20d='M8%2013h8'/%3E%3Cpath%20d='M8%2017h5'/%3E%3C/svg%3E");
+}
+
+.dt-container.dt-container :is(button, div, a).dt-button.buttons-excel {
+    --dt-tw-export: var(--dt-tw-success);
+    --dt-tw-export-icon: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='black'%20stroke-width='2'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Cpath%20d='M14%202H6a2%202%200%200%200-2%202v16a2%202%200%200%200%202%202h12a2%202%200%200%200%202-2V8z'/%3E%3Cpath%20d='M14%202v6h6'/%3E%3Cpath%20d='M8%2013h8'/%3E%3Cpath%20d='M8%2017h8'/%3E%3Cpath%20d='M12%2012v6'/%3E%3C/svg%3E");
+}
+
 /* ------------------------------------------------------- row actions -- */
 
 /*

--- a/assets/src/styles/datatables-tailwind-theme.css
+++ b/assets/src/styles/datatables-tailwind-theme.css
@@ -666,6 +666,49 @@ div.dt-container.dt-container div.dt-layout-end > *:not(:first-child) {
     box-shadow: var(--dt-tw-ring-focus), var(--dt-tw-shadow-sm);
 }
 
+.dt-container.dt-container :is(button, div, a).dt-button:is(.buttons-csv, .buttons-excel) {
+    background: rgb(var(--dt-tw-export) / 0.1);
+    box-shadow:
+        inset 0 0 0 1px rgb(var(--dt-tw-export) / 0.2),
+        var(--dt-tw-shadow-sm);
+    color: rgb(var(--dt-tw-export));
+}
+
+.dt-container.dt-container
+    :is(button, div, a).dt-button:is(.buttons-csv, .buttons-excel):hover:not(.disabled) {
+    background: rgb(var(--dt-tw-export) / 0.18);
+    box-shadow:
+        inset 0 0 0 1px rgb(var(--dt-tw-export) / 0.35),
+        var(--dt-tw-shadow-sm);
+}
+
+.dt-container.dt-container
+    :is(button, div, a).dt-button:is(.buttons-csv, .buttons-excel):active:not(.disabled) {
+    background: rgb(var(--dt-tw-export) / 0.26);
+    box-shadow: inset 0 0 0 1px rgb(var(--dt-tw-export) / 0.35);
+}
+
+.dt-container.dt-container
+    :is(button, div, a).dt-button:is(.buttons-csv, .buttons-excel)::before {
+    content: '';
+    flex-shrink: 0;
+    width: 1rem;
+    height: 1rem;
+    background: currentColor;
+    mask: var(--dt-tw-export-icon) center / contain no-repeat;
+    -webkit-mask: var(--dt-tw-export-icon) center / contain no-repeat;
+}
+
+.dt-container.dt-container :is(button, div, a).dt-button.buttons-csv {
+    --dt-tw-export: var(--dt-tw-info);
+    --dt-tw-export-icon: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='black'%20stroke-width='2'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Cpath%20d='M14%202H6a2%202%200%200%200-2%202v16a2%202%200%200%200%202%202h12a2%202%200%200%200%202-2V8z'/%3E%3Cpath%20d='M14%202v6h6'/%3E%3Cpath%20d='M8%2013h8'/%3E%3Cpath%20d='M8%2017h5'/%3E%3C/svg%3E");
+}
+
+.dt-container.dt-container :is(button, div, a).dt-button.buttons-excel {
+    --dt-tw-export: var(--dt-tw-success);
+    --dt-tw-export-icon: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='black'%20stroke-width='2'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Cpath%20d='M14%202H6a2%202%200%200%200-2%202v16a2%202%200%200%200%202%202h12a2%202%200%200%200%202-2V8z'/%3E%3Cpath%20d='M14%202v6h6'/%3E%3Cpath%20d='M8%2013h8'/%3E%3Cpath%20d='M8%2017h8'/%3E%3Cpath%20d='M12%2012v6'/%3E%3C/svg%3E");
+}
+
 /* ------------------------------------------------------- row actions -- */
 
 /*

--- a/src/Model/Extensions/Button.php
+++ b/src/Model/Extensions/Button.php
@@ -14,6 +14,13 @@ final class Button implements \JsonSerializable
     private const string DEFAULT_EXPORT_COLUMNS = ':visible:not(.not-exportable)';
 
     /**
+     * A server-side export button carries no `extend`, so DataTables never adds the format class
+     * its own HTML5 buttons get. Writing it here keeps both kinds of export button stylable by the
+     * same selector; an app-provided `className()` wins.
+     */
+    private const string EXPORT_MARKER_CLASS_PREFIX = 'buttons-';
+
+    /**
      * Button types that never export data: no default `exportOptions` is injected for these.
      *
      * @var list<ButtonType>
@@ -261,9 +268,10 @@ final class Button implements \JsonSerializable
         if (null !== $this->exportFormat) {
             $payload = $this->options;
             unset($payload['extend'], $payload['exportOptions']);
-            $payload['action']    = self::SERVER_EXPORT_ACTION;
-            $payload['format']    = $this->exportFormat->value;
-            $payload['exportKey'] = $this->getExportKey();
+            $payload['action']      = self::SERVER_EXPORT_ACTION;
+            $payload['format']      = $this->exportFormat->value;
+            $payload['exportKey']   = $this->getExportKey();
+            $payload['className'] ??= self::EXPORT_MARKER_CLASS_PREFIX.$this->type->value;
 
             return $payload;
         }

--- a/tests/Unit/Model/Extensions/ButtonTest.php
+++ b/tests/Unit/Model/Extensions/ButtonTest.php
@@ -137,6 +137,7 @@ final class ButtonTest extends TestCase
                 'exportKey' => 'csv',
                 'text'      => 'Export CSV',
                 'filename'  => 'users',
+                'className' => 'buttons-csv',
             ],
         ];
     }
@@ -174,6 +175,7 @@ final class ButtonTest extends TestCase
                     'exportKey' => 'csv',
                     'text'      => 'CSV',
                     'filename'  => 'users',
+                    'className' => 'buttons-csv',
                 ],
             ],
             'text' => 'Export',
@@ -194,6 +196,7 @@ final class ButtonTest extends TestCase
             'exportKey' => 'xlsx',
             'text'      => 'Excel',
             'filename'  => 'users',
+            'className' => 'buttons-excel',
         ], json_decode(json_encode($button), true));
     }
 

--- a/tests/Unit/Model/Extensions/ButtonsExtensionTest.php
+++ b/tests/Unit/Model/Extensions/ButtonsExtensionTest.php
@@ -129,6 +129,7 @@ final class ButtonsExtensionTest extends DataTableTestCase
                 'format'    => 'csv',
                 'exportKey' => 'csv',
                 'text'      => 'CSV',
+                'className' => 'buttons-csv',
             ],
         ], $extension);
     }
@@ -144,6 +145,7 @@ final class ButtonsExtensionTest extends DataTableTestCase
                 'format'    => 'xlsx',
                 'exportKey' => 'xlsx',
                 'text'      => 'Excel',
+                'className' => 'buttons-excel',
             ],
         ], $extension);
     }


### PR DESCRIPTION
## Summary

Server-side export buttons (`Button::csv(serverSide: true)`, `Button::excel(serverSide: true)`) never got a stylable class — DataTables' own HTML5 buttons plugin writes `buttons-csv`/`buttons-excel` for the bare `extend` form, but the server-side action button carries no `extend` at all. `Button::jsonSerialize()` now stamps the same `buttons-{format}` marker as a className default; an explicit `className()` call still wins.

The Tailwind theme uses that marker to color each format (CSV → info, Excel → success) and prefix an inline SVG file-icon via `mask-image`, so no icon-font dependency is added.

## Why

Follow-up from a support question: a dev configuring `->buttons([ButtonType::CSV])` wanted CSV/Excel export buttons visually distinct with an icon, without pulling in FontAwesome.

## Testing

Tested:
- `vendor/bin/phpunit` — 1420 tests, 5706 assertions, green
- Verified in the sandbox app: server-side CSV/Excel buttons now carry `buttons-csv`/`buttons-excel` and render colored with the glyph

Not-tested:
- `npm run lint` / `npm run typecheck` in `assets/` — pre-existing Biome/tsc diagnostics unrelated to this change, not re-run after this CSS-only edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)