### PR TITLE
Bound Ajax pagination so a crafted length cannot exhaust memory

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -45,6 +45,34 @@ bundle's `SecurityVoter` is not registered either, so there is nothing to vote o
 application with no firewall keeps rendering its tables. An empty or `null` attribute — meaning
 no permission is configured — is also still granted.
 
+### Ajax pagination is bounded
+
+Affects server-side tables whose Ajax requests relied on an unbounded page size. Table
+configuration, columns, Twig templates, the Ajax routes, and every JSON payload on the wire are
+unchanged.
+
+The `length` parameter of an Ajax request is now capped at the `data_tables.max_page_length`
+parameter (1000 by default), and a negative `start` is clamped to `0`.
+
+DataTables' "show all" (`length=-1`, or a missing `length`) is honored only when the table declares
+`-1` in its `lengthMenu()`. A table that relied on an implicit unbounded page must declare it, or
+raise the bound:
+
+```php
+// before: any length was served, including "show all"
+$table->lengthMenu([10, 25, 50]);
+
+// after: declare "show all" to keep serving an unbounded page
+$table->lengthMenu([[10, 25, 50, -1], ['10', '25', '50', 'All']]);
+```
+
+```yaml
+# config/packages/data_tables.yaml
+data_tables:
+  max_page_length: 5000
+```
+
+Exports are unaffected: they drop pagination explicitly and still stream every filtered row.
 
 ## v0.84 → v0.85
 

--- a/config/services.php
+++ b/config/services.php
@@ -308,6 +308,7 @@ return static function (ContainerConfigurator $container): void {
         ->arg(2, service('datatables.column.action_row_data_resolver'))
         ->arg(3, service(UrlColumnDataResolver::class)->nullOnInvalid())
         ->arg(4, service('datatables.security.authorization_checker'))
+        ->arg(5, param('datatables.max_page_length'))
         ->private();
 
     $services->alias(DataTableRuntimeFactory::class, 'datatables.runtime.factory')

--- a/docs/src/content/docs/guide/configuration.mdx
+++ b/docs/src/content/docs/guide/configuration.mdx
@@ -10,6 +10,7 @@ Configure bundle-wide defaults in `config/packages/data_tables.yaml`.
 
 ```yaml
 data_tables:
+  max_page_length: 1000
   options:
     language: en-GB
     layout:
@@ -32,6 +33,30 @@ data_tables:
     select:
       style: single
 ```
+
+## max_page_length
+
+Upper bound applied to the `length` parameter of every server-side Ajax request, so a crafted
+`length=999999` cannot make a table hydrate its whole dataset.
+
+```yaml
+data_tables:
+  max_page_length: 1000
+```
+
+DataTables sends `length=-1` for its "show all" entry. That is honored only when the table offers
+it, that is when `lengthMenu()` declares `-1`; otherwise the request is served with
+`max_page_length` rows. A negative `start` is clamped to `0`.
+
+```php
+// Show all is honored: this table offers it.
+$table->lengthMenu([10, 25, -1]);
+
+// Show all is capped to max_page_length: this table never offers it.
+$table->lengthMenu([10, 25]);
+```
+
+Exports are not affected: they read every filtered row by design.
 
 ## Options
 
@@ -122,6 +147,9 @@ $table->lengthMenu([
     [10, 25, 50, 'All']
 ]);
 ```
+
+Declaring `-1` also tells the bundle that an unbounded Ajax page is intentional for this table.
+See [`max_page_length`](#max_page_length).
 
 ### pageLength
 

--- a/docs/src/content/docs/guide/security.mdx
+++ b/docs/src/content/docs/guide/security.mdx
@@ -252,6 +252,19 @@ same rule: secure those API routes with API Platform and Symfony Security. PHP r
 bundle can only protect rows processed by the bundle backend; they cannot protect rows returned
 directly by API Platform or another controller.
 
+## Request bounds
+
+Ajax pagination parameters come from the browser, so the bundle does not trust them. A negative
+`start` is clamped to `0` instead of reaching the database as a negative offset, and `length` is
+capped at the `data_tables.max_page_length` parameter (1000 by default).
+
+DataTables' "show all" (`length=-1`) is honored only when the table declares `-1` in its
+`lengthMenu()`. Without that declaration a crafted `length=-1` or `length=999999` is served with
+`max_page_length` rows rather than hydrating the whole dataset, which is what protects the process
+from running out of memory on a large table.
+
+See [`max_page_length`](/guide/configuration/#max_page_length) to change the bound.
+
 ## Migrating from the legacy permission API
 
 UX DataTables no longer ships `PermissionChecker` and no longer falls back to the old implicit row

--- a/docs/src/content/docs/reference/abstract-datatable.mdx
+++ b/docs/src/content/docs/reference/abstract-datatable.mdx
@@ -129,7 +129,6 @@ When you configure the table to use the same route as its Ajax endpoint, handle 
 
 ```php
 use App\DataTables\UsersDataTable;
-use Pentiminax\UX\DataTables\DataTableRequest\DataTableRequest;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -145,11 +144,6 @@ class UsersController extends AbstractController
 
         if ($table->isRequestHandled()) {
             return $table->getResponse();
-        }
-
-        // For client-side tables, fetch data before rendering
-        if (!$table->getDataTable()->isServerSide()) {
-            $table->fetchData(DataTableRequest::fromRequest($request));
         }
 
         return $this->render('users/index.html.twig', [

--- a/src/DataProvider/DoctrineDataProvider.php
+++ b/src/DataProvider/DoctrineDataProvider.php
@@ -70,7 +70,7 @@ class DoctrineDataProvider implements DataProviderInterface, StreamingDataProvid
 
         $filteredCount = $this->count($qb, $alias);
 
-        if ($request->start) {
+        if ($request->start > 0) {
             $qb->setFirstResult($request->start);
         }
 

--- a/src/DataTableRequest/DataTableRequest.php
+++ b/src/DataTableRequest/DataTableRequest.php
@@ -36,7 +36,7 @@ final readonly class DataTableRequest
         return new self(
             draw: $bag->getInt('draw'),
             columns: $columns,
-            start: $bag->getInt('start'),
+            start: max(0, $bag->getInt('start')),
             length: $bag->getInt('length'),
             search: Search::fromRequest($request),
             order: $orders,
@@ -51,6 +51,37 @@ final readonly class DataTableRequest
     public function pageLength(int $default = 25): int
     {
         return $this->length > 0 ? $this->length : $default;
+    }
+
+    /**
+     * Caps the requested page size so a crafted "length" cannot make a provider hydrate the
+     * whole table.
+     *
+     * DataTables sends 0 or -1 for "show all". That is honored only when $allowShowAll -- the
+     * table declares -1 in its lengthMenu -- and is otherwise narrowed to $maxLength rather
+     * than to a single row, so an unexpected length still returns a usable page.
+     */
+    public function withBoundedLength(int $maxLength, bool $allowShowAll): self
+    {
+        if ($this->length <= 0) {
+            $length = $allowShowAll ? -1 : $maxLength;
+        } else {
+            $length = min($this->length, $maxLength);
+        }
+
+        if ($length === $this->length) {
+            return $this;
+        }
+
+        return new self(
+            draw: $this->draw,
+            columns: $this->columns,
+            start: $this->start,
+            length: $length,
+            search: $this->search,
+            order: $this->order,
+            filters: $this->filters,
+        );
     }
 
     /**

--- a/src/DataTablesBundle.php
+++ b/src/DataTablesBundle.php
@@ -32,6 +32,11 @@ class DataTablesBundle extends AbstractBundle
     {
         $definition->rootNode()
             ->children()
+                ->integerNode('max_page_length')
+                    ->min(1)
+                    ->defaultValue(1000)
+                    ->info('Upper bound applied to the DataTables "length" parameter on Ajax requests. "length=-1" (show all) is honored only when the table declares -1 in lengthMenu(); otherwise it is capped to this value.')
+                ->end()
                 ->arrayNode('options')
                     ->children()
                         ->scalarNode('language')->defaultValue('en-GB')->end()
@@ -105,7 +110,8 @@ class DataTablesBundle extends AbstractBundle
             ->set('datatables.extensions', $config['extensions'] ?? [])
             ->set('datatables.edit_modal.template', $config['edit_modal']['template'])
             ->set('datatables.edit_modal.body_template', $config['edit_modal']['body_template'])
-            ->set('datatables.edit_modal.default_title', $config['edit_modal']['default_title']);
+            ->set('datatables.edit_modal.default_title', $config['edit_modal']['default_title'])
+            ->set('datatables.max_page_length', $config['max_page_length']);
 
         $container->import('../config/services.php');
 

--- a/src/Runtime/DataTableRuntime.php
+++ b/src/Runtime/DataTableRuntime.php
@@ -24,6 +24,7 @@ final class DataTableRuntime
     public function __construct(
         private readonly DataTable $table,
         private readonly \Closure $dataProviderFactory,
+        private readonly int $maxPageLength = 1000,
     ) {
     }
 
@@ -40,7 +41,28 @@ final class DataTableRuntime
     public function handleRequest(Request $request): void
     {
         $this->httpRequest = $request;
-        $this->request     = DataTableRequest::fromRequest($request);
+        $this->request     = DataTableRequest::fromRequest($request)
+            ->withBoundedLength($this->maxPageLength, $this->allowsShowAll());
+    }
+
+    /**
+     * Whether the table offers DataTables' "show all" entry, the only case where an
+     * unbounded page size is what the developer asked for.
+     *
+     * lengthMenu() accepts both `[10, 25, -1]` and the two-dimensional
+     * `[[10, 25, -1], ['10', '25', 'All']]` form, whose first entry holds the values.
+     */
+    private function allowsShowAll(): bool
+    {
+        $menu = $this->table->getOption('lengthMenu');
+
+        if (!\is_array($menu)) {
+            return false;
+        }
+
+        $values = isset($menu[0]) && \is_array($menu[0]) ? $menu[0] : $menu;
+
+        return \in_array(-1, $values, true);
     }
 
     public function isRequestHandled(): bool

--- a/src/Runtime/DataTableRuntimeFactory.php
+++ b/src/Runtime/DataTableRuntimeFactory.php
@@ -32,6 +32,7 @@ final class DataTableRuntimeFactory
         private readonly ?ActionRowDataResolver $actionRowDataResolver = null,
         private readonly ?UrlColumnDataResolver $urlColumnDataResolver = null,
         private readonly ?AuthorizationChecker $permissionChecker = null,
+        private readonly int $maxPageLength = 1000,
     ) {
     }
 
@@ -105,6 +106,7 @@ final class DataTableRuntimeFactory
                 pageProjector: $pageProjector,
                 configureBaseQueryBuilder: $configureBaseQueryBuilder,
             ),
+            maxPageLength: $this->maxPageLength,
         );
     }
 

--- a/tests/Kernel/ConfigDefaultsAppKernel.php
+++ b/tests/Kernel/ConfigDefaultsAppKernel.php
@@ -46,7 +46,8 @@ final class ConfigDefaultsAppKernel extends Kernel
             ]);
 
             $container->loadFromExtension('data_tables', [
-                'options' => [
+                'max_page_length' => 50,
+                'options'         => [
                     'pageLength' => 25,
                     'paging'     => [
                         'buttons'   => 5,

--- a/tests/Unit/DataProvider/DoctrineDataProviderPaginationTest.php
+++ b/tests/Unit/DataProvider/DoctrineDataProviderPaginationTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Unit\DataProvider;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Pentiminax\UX\DataTables\Contracts\DataProviderInterface;
+use Pentiminax\UX\DataTables\Contracts\RowMapperInterface;
+use Pentiminax\UX\DataTables\DataProvider\DoctrineDataProvider;
+use Pentiminax\UX\DataTables\DataTableRequest\Columns;
+use Pentiminax\UX\DataTables\DataTableRequest\DataTableRequest;
+use Pentiminax\UX\DataTables\Model\DataTable;
+use Pentiminax\UX\DataTables\Runtime\DataTableRuntime;
+use Pentiminax\UX\DataTables\Tests\Fixtures\Count\CountCustomer;
+use Pentiminax\UX\DataTables\Tests\Fixtures\Count\CountTag;
+use Pentiminax\UX\DataTables\Tests\Support\BuildsEntityManager;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+#[CoversClass(DoctrineDataProvider::class)]
+final class DoctrineDataProviderPaginationTest extends TestCase
+{
+    use BuildsEntityManager;
+
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $this->em = $this->createEntityManager(CountCustomer::class, CountTag::class);
+
+        foreach (range(1, 12) as $id) {
+            $this->em->persist(new CountCustomer($id, 'Customer '.$id));
+        }
+
+        $this->em->flush();
+        $this->em->clear();
+    }
+
+    /**
+     * A negative offset made DBAL throw before the query even ran, turning a crafted
+     * `start=-5` into an HTTP 500.
+     */
+    #[Test]
+    public function it_ignores_a_negative_start_instead_of_failing(): void
+    {
+        $result = $this->provider()->fetchData(
+            new DataTableRequest(draw: 1, columns: new Columns([]), start: -5, length: 3)
+        );
+
+        $this->assertSame([1, 2, 3], $this->ids($result->data));
+    }
+
+    /**
+     * "Show all" on a table whose lengthMenu never offers it used to dump every row,
+     * whatever the table size.
+     */
+    #[Test]
+    public function it_caps_show_all_to_the_maximum_page_length_when_the_table_forbids_it(): void
+    {
+        $runtime = new DataTableRuntime(
+            table: (new DataTable('customers'))->lengthMenu([10, 25]),
+            dataProviderFactory: fn (): ?DataProviderInterface => $this->provider(),
+            maxPageLength: 5,
+        );
+
+        $runtime->handleRequest(new Request(query: ['draw' => 1, 'start' => -5, 'length' => -1]));
+
+        $payload = json_decode((string) $runtime->getResponse()->getContent(), true);
+
+        $this->assertCount(5, $payload['data']);
+        $this->assertSame([1, 2, 3, 4, 5], array_column($payload['data'], 'id'));
+    }
+
+    private function provider(): DoctrineDataProvider
+    {
+        return new DoctrineDataProvider(
+            em: $this->em,
+            entityClass: CountCustomer::class,
+            rowMapper: new class implements RowMapperInterface {
+                public function map(mixed $row): array
+                {
+                    return ['id' => $row->id];
+                }
+            },
+        );
+    }
+
+    /**
+     * @param iterable<array<string, mixed>> $rows
+     *
+     * @return list<int>
+     */
+    private function ids(iterable $rows): array
+    {
+        return array_column(iterator_to_array($rows), 'id');
+    }
+}

--- a/tests/Unit/DataTableRequest/DataTableRequestTest.php
+++ b/tests/Unit/DataTableRequest/DataTableRequestTest.php
@@ -197,6 +197,57 @@ final class DataTableRequestTest extends TestCase
     }
 
     #[Test]
+    public function it_clamps_a_negative_start_to_zero(): void
+    {
+        $dataTableRequest = DataTableRequest::fromRequest(self::createRequest(['start' => -5]));
+
+        $this->assertSame(0, $dataTableRequest->start);
+    }
+
+    #[Test]
+    public function it_caps_length_to_the_maximum(): void
+    {
+        $dataTableRequest = DataTableRequest::fromRequest(self::createRequest(['length' => 999999]))
+            ->withBoundedLength(1000, false);
+
+        $this->assertSame(1000, $dataTableRequest->length);
+    }
+
+    #[Test]
+    public function it_maps_show_all_to_the_maximum_when_not_allowed(): void
+    {
+        $dataTableRequest = DataTableRequest::fromRequest(self::createRequest(['length' => -1]))
+            ->withBoundedLength(1000, false);
+
+        $this->assertSame(1000, $dataTableRequest->length);
+    }
+
+    #[Test]
+    public function it_keeps_show_all_when_allowed(): void
+    {
+        $dataTableRequest = DataTableRequest::fromRequest(self::createRequest(['length' => -1]))
+            ->withBoundedLength(1000, true);
+
+        $this->assertSame(-1, $dataTableRequest->length);
+    }
+
+    #[Test]
+    public function it_keeps_a_length_within_bounds(): void
+    {
+        $dataTableRequest = DataTableRequest::fromRequest(self::createRequest([
+            'draw'   => 5,
+            'start'  => 20,
+            'length' => 25,
+            'search' => ['value' => 'test', 'regex' => false],
+        ]))->withBoundedLength(1000, false);
+
+        $this->assertSame(25, $dataTableRequest->length);
+        $this->assertSame(5, $dataTableRequest->draw);
+        $this->assertSame(20, $dataTableRequest->start);
+        $this->assertSame('test', $dataTableRequest->search->value);
+    }
+
+    #[Test]
     #[DataProvider('provideSearchTerms')]
     public function it_resolves_search_term(?string $rawSearch, ?string $expected): void
     {

--- a/tests/Unit/DataTablesBundleTest.php
+++ b/tests/Unit/DataTablesBundleTest.php
@@ -15,6 +15,7 @@ use Pentiminax\UX\DataTables\Query\Intent\DefaultDataTableQueryIntentFactory;
 use Pentiminax\UX\DataTables\Runtime\DataTableInfrastructure;
 use Pentiminax\UX\DataTables\Security\AuthorizationChecker;
 use Pentiminax\UX\DataTables\Security\SecurityVoter;
+use Pentiminax\UX\DataTables\Tests\Kernel\ConfigDefaultsAppKernel;
 use Pentiminax\UX\DataTables\Tests\Support\BootsTwigKernel;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -75,6 +76,25 @@ final class DataTablesBundleTest extends TestCase
         self::assertInstanceOf(ExporterRegistry::class, $registry);
         self::assertInstanceOf(CsvExporter::class, $registry->get(ExportFormat::CSV));
         self::assertInstanceOf(XlsxExporter::class, $registry->get(ExportFormat::XLSX));
+    }
+
+    #[Test]
+    public function it_defines_the_maximum_page_length_parameter(): void
+    {
+        self::assertSame(1000, $this->kernel->getContainer()->getParameter('datatables.max_page_length'));
+    }
+
+    #[Test]
+    public function it_lets_the_application_override_the_maximum_page_length(): void
+    {
+        $kernel = new ConfigDefaultsAppKernel('test', true);
+        $kernel->boot();
+
+        try {
+            self::assertSame(50, $kernel->getContainer()->getParameter('datatables.max_page_length'));
+        } finally {
+            $kernel->shutdown();
+        }
     }
 
     #[Test]

--- a/tests/Unit/Runtime/DataTableRuntimeTest.php
+++ b/tests/Unit/Runtime/DataTableRuntimeTest.php
@@ -122,6 +122,60 @@ final class DataTableRuntimeTest extends TestCase
         $this->assertSame(1, $factoryCalls);
     }
 
+    #[Test]
+    #[DataProvider('showAllLengthMenus')]
+    public function it_bounds_the_request_length_from_the_table_length_menu(array $lengthMenu): void
+    {
+        $table = (new DataTable('movies'))->lengthMenu($lengthMenu);
+
+        $runtime = new DataTableRuntime(
+            table: $table,
+            dataProviderFactory: static fn (): ?DataProviderInterface => null,
+            maxPageLength: 100,
+        );
+
+        $runtime->handleRequest(new Request(query: ['draw' => 1, 'start' => -5, 'length' => -1]));
+
+        $this->assertSame(-1, $runtime->getRequest()?->length);
+        $this->assertSame(0, $runtime->getRequest()?->start);
+    }
+
+    /**
+     * @return iterable<string, array{0: array<mixed>}>
+     */
+    public static function showAllLengthMenus(): iterable
+    {
+        yield 'flat menu' => [[10, 25, -1]];
+        yield 'menu with its own labels' => [[[10, 25, -1], ['10', '25', 'All']]];
+    }
+
+    #[Test]
+    #[DataProvider('cappedLengths')]
+    public function it_caps_length_when_the_length_menu_has_no_show_all(int $length, int $expected): void
+    {
+        $table = (new DataTable('movies'))->lengthMenu([10, 25]);
+
+        $runtime = new DataTableRuntime(
+            table: $table,
+            dataProviderFactory: static fn (): ?DataProviderInterface => null,
+            maxPageLength: 100,
+        );
+
+        $runtime->handleRequest(new Request(query: ['draw' => 1, 'length' => $length]));
+
+        $this->assertSame($expected, $runtime->getRequest()?->length);
+    }
+
+    /**
+     * @return iterable<string, array{0: int, 1: int}>
+     */
+    public static function cappedLengths(): iterable
+    {
+        yield 'show all is capped' => [-1, 100];
+        yield 'an oversized length is capped' => [999999, 100];
+        yield 'a length within bounds is kept' => [25, 25];
+    }
+
     private function createRuntime(?DataProviderInterface $provider = null): DataTableRuntime
     {
         return new DataTableRuntime(


### PR DESCRIPTION
## Why
`start` and `length` reached the data providers unfiltered: `start=-5` made DBAL throw (HTTP 500), `length=999999` hydrated the whole table, and `length=-1` skipped `setMaxResults()` even on tables whose `lengthMenu` never offered "show all".

## What
- `DataTableRequest::fromRequest()` clamps `start` to 0.
- New `DataTableRequest::withBoundedLength()`, applied in `DataTableRuntime::handleRequest()` (its only caller).
- New bundle parameter `datatables.max_page_length` (default 1000). `length <= 0` ("show all") stays unbounded only when the table declares `-1` in `lengthMenu()` (simple or two-dimensional form); otherwise it is narrowed to the cap.
- Exports keep their explicit `withoutPagination()` path.
- Docs: `guide/configuration.mdx`, `guide/security.mdx`. `UPGRADE.md` entry.

## Behavior change to note
A request **without** a `length` parameter used to mean "no LIMIT"; it is now bounded to `max_page_length`.

## Tests
`vendor/bin/phpunit`: 1455 tests (+14), including a sqlite regression on `start=-5` and `length=-1`. `composer fix`, `composer audit`, docs lint/build green.

---
Part of the pre-1.0 security lot (A). Each PR of the lot adds its own entry under `## v0.90 → v1.0` in `UPGRADE.md`; expect a trivial rebase on that file after the previous lot PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)