### PR TITLE
Drop malformed ColumnControl payloads instead of returning a 500

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -74,6 +74,12 @@ data_tables:
 
 Exports are unaffected: they drop pagination explicitly and still stream every filtered row.
 
+### Malformed column control payloads are dropped
+
+| Change | Impact |
+| --- | --- |
+| `ColumnControlSearch::fromArray()` returns `null` on malformed input | A column control search with an unknown or missing logic, a non-scalar value, or a missing type is dropped instead of raising an error. Malformed `search` and `list` payloads are dropped by `ColumnControl::fromArray()` the same way. |
+
 ## v0.84 → v0.85
 
 ### Permission configuration uses `setPermission()`

--- a/src/DataTableRequest/ColumnControl.php
+++ b/src/DataTableRequest/ColumnControl.php
@@ -12,11 +12,19 @@ final readonly class ColumnControl
     ) {
     }
 
-    public static function fromArray(array $data): ColumnControl
+    /**
+     * Transport-level input: a client controls both the shape and the types here, so
+     * anything that is not a well-formed search or a list of scalars is dropped rather
+     * than aborting the whole Ajax request.
+     */
+    public static function fromArray(array $data): self
     {
+        $search = $data['search'] ?? null;
+        $list   = $data['list']   ?? [];
+
         return new self(
-            search: isset($data['search']) ? ColumnControlSearch::fromArray($data['search']) : null,
-            list: $data['list'] ?? []
+            search: \is_array($search) ? ColumnControlSearch::fromArray($search) : null,
+            list: \is_array($list) ? array_values(array_filter($list, \is_scalar(...))) : [],
         );
     }
 }

--- a/src/DataTableRequest/ColumnControlSearch.php
+++ b/src/DataTableRequest/ColumnControlSearch.php
@@ -15,12 +15,24 @@ final readonly class ColumnControlSearch
     ) {
     }
 
-    public static function fromArray(array $data): self
+    /**
+     * Returns null when the payload cannot describe a search: an unknown or missing logic,
+     * a non-scalar value, or a missing column type, all of which a client can send.
+     */
+    public static function fromArray(array $data): ?self
     {
+        $logic = ColumnControlLogic::tryFrom(\is_string($data['logic'] ?? null) ? $data['logic'] : '');
+        $value = $data['value'] ?? null;
+        $type  = $data['type']  ?? null;
+
+        if (null === $logic || !\is_scalar($value) || !\is_string($type)) {
+            return null;
+        }
+
         return new self(
-            value: $data['value'],
-            logic: ColumnControlLogic::from($data['logic']),
-            type: $data['type']
+            value: (string) $value,
+            logic: $logic,
+            type: $type,
         );
     }
 }

--- a/src/DataTableRequest/Search.php
+++ b/src/DataTableRequest/Search.php
@@ -16,9 +16,11 @@ final readonly class Search
 
     public static function fromArray(array $data): self
     {
+        $value = $data['value'] ?? null;
+
         return new self(
-            value: $data['value'],
-            regex: 'true' === $data['regex'],
+            value: \is_scalar($value) ? (string) $value : null,
+            regex: 'true' === ($data['regex'] ?? null),
         );
     }
 

--- a/src/Profiler/DataTableProfiler.php
+++ b/src/Profiler/DataTableProfiler.php
@@ -270,11 +270,10 @@ final class DataTableProfiler
     }
 
     /**
-     * ColumnControl::$list is unvalidated request input (ColumnControl::fromArray() reads
-     * $data['list'] ?? [] verbatim) -- a client can submit a nested array for one entry (e.g.
-     * columns[0][columnControl][list][0][x]=y), which the panel's join() filter cannot render
-     * as a string. Reduce every entry to a safe scalar here so the template never has to
-     * account for what a request happened to send.
+     * ColumnControl::fromArray() drops non-scalar list entries, but the constructor accepts any
+     * array, so a request built in code can still carry one (e.g. a nested array), which the
+     * panel's join() filter cannot render as a string. Reduce every entry to a safe scalar here
+     * so the template never has to account for what it was handed.
      *
      * @param list<mixed> $list
      *

--- a/tests/Unit/DataTableRequest/ColumnControlTest.php
+++ b/tests/Unit/DataTableRequest/ColumnControlTest.php
@@ -46,6 +46,10 @@ final class ColumnControlTest extends TestCase
         yield 'non-array search' => [['search' => 'oops']];
         yield 'non-array list' => [['list' => 'oops']];
         yield 'search without logic' => [['search' => ['value' => 'x']]];
+        yield 'search without value' => [['search' => ['logic' => 'equal', 'type' => 'text']]];
+        yield 'search with array value' => [['search' => ['logic' => 'equal', 'value' => ['x'], 'type' => 'text']]];
+        yield 'search without type' => [['search' => ['logic' => 'equal', 'value' => 'x']]];
+        yield 'search with non-string type' => [['search' => ['logic' => 'equal', 'value' => 'x', 'type' => ['text']]]];
     }
 
     #[Test]

--- a/tests/Unit/DataTableRequest/ColumnControlTest.php
+++ b/tests/Unit/DataTableRequest/ColumnControlTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Unit\DataTableRequest;
+
+use Pentiminax\UX\DataTables\DataTableRequest\ColumnControl;
+use Pentiminax\UX\DataTables\DataTableRequest\ColumnControlSearch;
+use Pentiminax\UX\DataTables\DataTableRequest\DataTableRequest;
+use Pentiminax\UX\DataTables\Enum\ColumnControlLogic;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+#[CoversClass(ColumnControl::class)]
+#[CoversClass(ColumnControlSearch::class)]
+final class ColumnControlTest extends TestCase
+{
+    /**
+     * Each of these payloads used to abort the Ajax request with a 500 (ValueError on the
+     * logic enum, TypeError on a non-array search or list, warning plus TypeError on a
+     * missing logic). Transport-level parsing drops them instead, which is the contract
+     * the query intent factory documents.
+     *
+     * @param array<string, mixed> $columnControl
+     */
+    #[Test]
+    #[DataProvider('provideMalformedColumnControls')]
+    public function it_drops_a_malformed_column_control(array $columnControl): void
+    {
+        $control = self::parse($columnControl)->columns->getColumnByName('department')?->columnControl;
+
+        $this->assertInstanceOf(ColumnControl::class, $control);
+        $this->assertNull($control->search);
+        $this->assertSame([], $control->list);
+    }
+
+    public static function provideMalformedColumnControls(): iterable
+    {
+        yield 'unknown search logic' => [['search' => ['logic' => 'bogus', 'value' => 'x', 'type' => 'text']]];
+        yield 'non-array search' => [['search' => 'oops']];
+        yield 'non-array list' => [['list' => 'oops']];
+        yield 'search without logic' => [['search' => ['value' => 'x']]];
+    }
+
+    #[Test]
+    public function it_parses_a_well_formed_column_control(): void
+    {
+        $search = self::parse(['search' => ['logic' => 'equal', 'value' => 'active', 'type' => 'text']])
+            ->columns->getColumnByName('department')?->columnControl?->search;
+
+        $this->assertInstanceOf(ColumnControlSearch::class, $search);
+        $this->assertSame('active', $search->value);
+        $this->assertSame(ColumnControlLogic::Equal, $search->logic);
+        $this->assertSame('text', $search->type);
+    }
+
+    #[Test]
+    public function it_drops_non_scalar_list_entries(): void
+    {
+        $control = self::parse(['list' => ['Sales', ['nested' => 'value'], '']])
+            ->columns->getColumnByName('department')?->columnControl;
+
+        $this->assertSame(['Sales', ''], $control?->list);
+    }
+
+    /**
+     * @param array<string, mixed> $columnControl
+     */
+    private static function parse(array $columnControl): DataTableRequest
+    {
+        return DataTableRequest::fromRequest(Request::create('/datatables', 'GET', [
+            'draw'    => '1',
+            'columns' => [
+                [
+                    'data'          => '0',
+                    'name'          => 'department',
+                    'searchable'    => 'true',
+                    'orderable'     => 'true',
+                    'columnControl' => $columnControl,
+                ],
+            ],
+        ]));
+    }
+}

--- a/tests/Unit/DataTableRequest/SearchTest.php
+++ b/tests/Unit/DataTableRequest/SearchTest.php
@@ -35,6 +35,15 @@ final class SearchTest extends TestCase
     }
 
     #[Test]
+    public function it_drops_a_non_scalar_search_value(): void
+    {
+        $search = Search::fromArray(['value' => ['oops']]);
+
+        $this->assertNull($search->value);
+        $this->assertFalse($search->regex);
+    }
+
+    #[Test]
     public function it_parses_from_a_post_request_body(): void
     {
         $request = Request::create('/ajax', 'POST', [

--- a/tests/Unit/Profiler/DataTablePanelRenderTest.php
+++ b/tests/Unit/Profiler/DataTablePanelRenderTest.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Pentiminax\UX\DataTables\Tests\Unit\Profiler;
 
 use Pentiminax\UX\DataTables\Column\TextColumn;
+use Pentiminax\UX\DataTables\DataTableRequest\Column;
+use Pentiminax\UX\DataTables\DataTableRequest\ColumnControl;
+use Pentiminax\UX\DataTables\DataTableRequest\Columns;
 use Pentiminax\UX\DataTables\DataTableRequest\DataTableRequest;
 use Pentiminax\UX\DataTables\Enum\ButtonType;
 use Pentiminax\UX\DataTables\Filter\TextFilter;
@@ -125,8 +128,9 @@ final class DataTablePanelRenderTest extends TestCase
     }
 
     /**
-     * Regression test: ColumnControl::$list is unvalidated request input, so a client can
-     * submit a nested array for one entry. The panel used to forward it unchanged into a
+     * Regression test: ColumnControl::$list accepts any array, so a nested entry can reach
+     * the panel from a request built in code even though ColumnControl::fromArray() now
+     * drops non-scalar entries. The panel used to forward it unchanged into a
      * `|join(', ')` filter, which cannot render an array as a string and threw a
      * Twig\Error\RuntimeError ("Array to string conversion"), crashing the entire panel --
      * not just that one row.
@@ -143,15 +147,16 @@ final class DataTablePanelRenderTest extends TestCase
         $profiler->collectAjaxQuery(
             class: 'App\\ProductDataTable',
             token: 'token',
-            request: DataTableRequest::fromRequest(Request::create('/datatables', 'GET', [
-                'draw'    => '1',
-                'columns' => [
-                    [
-                        'data'          => '0', 'name' => 'department', 'searchable' => 'true', 'orderable' => 'true',
-                        'columnControl' => ['list' => ['Sales', ['nested' => 'value']]],
-                    ],
-                ],
-            ])),
+            request: new DataTableRequest(
+                draw: 1,
+                columns: new Columns(['department' => new Column(
+                    data: '0',
+                    name: 'department',
+                    searchable: true,
+                    orderable: true,
+                    columnControl: new ColumnControl(list: ['Sales', ['nested' => 'value']]),
+                )]),
+            ),
             recordsTotal: 1,
             recordsFiltered: 1,
             durationMs: 0.5,

--- a/tests/Unit/Profiler/DataTableProfilerTest.php
+++ b/tests/Unit/Profiler/DataTableProfilerTest.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Pentiminax\UX\DataTables\Tests\Unit\Profiler;
 
 use Pentiminax\UX\DataTables\Column\TextColumn;
+use Pentiminax\UX\DataTables\DataTableRequest\Column;
+use Pentiminax\UX\DataTables\DataTableRequest\ColumnControl;
+use Pentiminax\UX\DataTables\DataTableRequest\Columns;
 use Pentiminax\UX\DataTables\DataTableRequest\DataTableRequest;
 use Pentiminax\UX\DataTables\Enum\ButtonType;
 use Pentiminax\UX\DataTables\Filter\TextFilter;
@@ -230,23 +233,24 @@ final class DataTableProfilerTest extends TestCase
     }
 
     /**
-     * ColumnControl::$list is unvalidated request input -- ColumnControl::fromArray() reads
-     * $data['list'] ?? [] verbatim, so a client can submit a nested array for one entry. The
-     * panel's join() filter cannot render an array as a string and used to crash the whole
-     * profiler panel; every entry must reduce to a safe scalar before it ever reaches Twig.
+     * ColumnControl::$list accepts any array, so a nested entry can still reach the profiler
+     * from a request built in code even though ColumnControl::fromArray() now drops non-scalar
+     * entries. The panel's join() filter cannot render an array as a string and used to crash
+     * the whole profiler panel; every entry must reduce to a safe scalar before it reaches Twig.
      */
     #[Test]
     public function it_normalizes_a_non_scalar_search_list_entry_instead_of_forwarding_it_unchanged(): void
     {
-        $request = DataTableRequest::fromRequest(Request::create('/datatables', 'GET', [
-            'draw'    => '1',
-            'columns' => [
-                [
-                    'data'          => '0', 'name' => 'department', 'searchable' => 'true', 'orderable' => 'true',
-                    'columnControl' => ['list' => ['Sales', ['nested' => 'value']]],
-                ],
-            ],
-        ]));
+        $request = new DataTableRequest(
+            draw: 1,
+            columns: new Columns(['department' => new Column(
+                data: '0',
+                name: 'department',
+                searchable: true,
+                orderable: true,
+                columnControl: new ColumnControl(list: ['Sales', ['nested' => 'value']]),
+            )]),
+        );
 
         $profiler = new DataTableProfiler();
         $profiler->collectAjaxQuery('App\\ProductDataTable', 'token', $request, 10, 10, 1.0);


### PR DESCRIPTION
## Why
Four client-controlled `columns[i][columnControl]` shapes aborted the whole Ajax request with an uncaught `ValueError`/`TypeError`: unknown `search.logic`, scalar `search`, scalar `list`, and a `search` without `logic`. `Search::fromArray()` also read `value`/`regex` without a null coalesce.

## What
- `ColumnControl::fromArray()` / `ColumnControlSearch::fromArray()` (now `?self`) / `Search::fromArray()` drop malformed input silently, matching the documented contract of `DefaultDataTableQueryIntentFactory` and the existing `Column::stringField()` convention. No 400.
- Non-scalar `list` entries are filtered at the same boundary (they otherwise reach the IN branch of `ColumnControlSearchFilter` as parameters).
- Two profiler regression tests now build the request in PHP since the malformed shapes no longer survive parsing.

## Tests
New `ColumnControlTest` with a data provider reproducing the four payloads (all red before the fix). `vendor/bin/phpunit`: 1448 tests (+7). `composer fix`, `composer audit` green.

---
Part of the pre-1.0 security lot (A). Each PR of the lot adds its own entry under `## v0.90 → v1.0` in `UPGRADE.md`; expect a trivial rebase on that file after the previous lot PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)