### PR TITLE
Guard the edit-form submit flush so conflicts return 409, not 500

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -3,6 +3,33 @@
 Each section covers one version bump. When you skip versions, apply every section between your
 current version and the target, oldest first.
 
+## v0.90 → v1.0
+
+### `EntityMutator` and `EditFormService` take a `MutationFlusher`
+
+The guarded flush that maps a rejected write to a 409 response lives in the new
+`Mutation\MutationFlusher`. `EntityMutator` no longer owns it privately, and the edit-form submit
+path now shares it, so a unique constraint violation on submit returns the same 409 JSON as delete
+and inline edit instead of a 500.
+
+| Changed | New signature |
+| --- | --- |
+| `Mutation\EntityMutator::__construct()` | a `Mutation\MutationFlusher` is appended after `$topicResolver` |
+| `Form\EditFormService::__construct()` | a `Mutation\MutationFlusher` is inserted after `$topicResolver`, before the optional `$permissionChecker` |
+
+Both services are wired by the bundle, so nothing changes for DI users. Only code that instantiates
+either class by hand — typically a test — has to pass the collaborator:
+
+```php
+// before
+$mutator = new EntityMutator($locator, $propertyAccessor, $publisher, $checker, $topicResolver);
+
+// after
+$mutator = new EntityMutator($locator, $propertyAccessor, $publisher, $checker, $topicResolver, new MutationFlusher());
+```
+
+`MutationFlusher` is stateless and has no constructor arguments.
+
 ## v0.84 → v0.85
 
 ### Permission configuration uses `setPermission()`

--- a/config/form.php
+++ b/config/form.php
@@ -45,7 +45,8 @@ return static function (ContainerConfigurator $container): void {
         ->arg(3, service('datatables.form.edit_modal_template_resolver'))
         ->arg(4, service(MercurePublisherInterface::class))
         ->arg(5, service('datatables.mercure.topic_resolver'))
-        ->arg(6, service('datatables.security.authorization_checker'))
+        ->arg(6, service('datatables.mutation.flusher'))
+        ->arg(7, service('datatables.security.authorization_checker'))
         ->private();
 
     $services->set('datatables.controller.ajax_edit_form', AjaxEditFormController::class)

--- a/config/services.php
+++ b/config/services.php
@@ -33,6 +33,7 @@ use Pentiminax\UX\DataTables\Mercure\NullMercurePublisher;
 use Pentiminax\UX\DataTables\Mutation\BooleanMutationContextResolver;
 use Pentiminax\UX\DataTables\Mutation\EntityLocator;
 use Pentiminax\UX\DataTables\Mutation\EntityMutator;
+use Pentiminax\UX\DataTables\Mutation\MutationFlusher;
 use Pentiminax\UX\DataTables\Query\Builder\QueryFilterPipeline;
 use Pentiminax\UX\DataTables\Query\Intent\DefaultDataTableQueryIntentFactory;
 use Pentiminax\UX\DataTables\Ajax\RowIdentifierExtractor;
@@ -152,12 +153,16 @@ return static function (ContainerConfigurator $container): void {
     $services->alias(MercureTopicResolver::class, 'datatables.mercure.topic_resolver')
         ->private();
 
+    $services->set('datatables.mutation.flusher', MutationFlusher::class)
+        ->private();
+
     $services->set('datatables.mutation.mutator', EntityMutator::class)
         ->arg(0, service('datatables.mutation.locator'))
         ->arg(1, service('property_accessor'))
         ->arg(2, service(MercurePublisherInterface::class))
         ->arg(3, service('datatables.security.authorization_checker'))
         ->arg(4, service('datatables.mercure.topic_resolver'))
+        ->arg(5, service('datatables.mutation.flusher'))
         ->private();
 
     $services->set('datatables.mutation.boolean_context_resolver', BooleanMutationContextResolver::class)

--- a/src/Form/EditFormService.php
+++ b/src/Form/EditFormService.php
@@ -10,10 +10,12 @@ use Pentiminax\UX\DataTables\Column\ColumnResolver;
 use Pentiminax\UX\DataTables\Contracts\MercurePublisherInterface;
 use Pentiminax\UX\DataTables\Enum\ActionType;
 use Pentiminax\UX\DataTables\Exception\EntityNotFoundException;
+use Pentiminax\UX\DataTables\Exception\MutationPersistenceException;
 use Pentiminax\UX\DataTables\Mercure\MercureTopicResolver;
 use Pentiminax\UX\DataTables\Model\Action;
 use Pentiminax\UX\DataTables\Mutation\EntityLocator;
 use Pentiminax\UX\DataTables\Mutation\MutationContext;
+use Pentiminax\UX\DataTables\Mutation\MutationFlusher;
 use Pentiminax\UX\DataTables\Security\ActionPermissionContext;
 use Pentiminax\UX\DataTables\Security\AuthorizationChecker;
 use Pentiminax\UX\DataTables\Security\Permission;
@@ -30,6 +32,7 @@ final class EditFormService
         private readonly EditModalTemplateResolver $templateResolver,
         private readonly MercurePublisherInterface $publisher,
         private readonly MercureTopicResolver $topicResolver,
+        private readonly MutationFlusher $flusher,
         ?AuthorizationChecker $permissionChecker = null,
     ) {
         $this->permissionChecker = $permissionChecker ?? new AuthorizationChecker();
@@ -61,6 +64,8 @@ final class EditFormService
 
     /**
      * @param array<string, mixed> $formData
+     *
+     * @throws MutationPersistenceException when the persistence layer rejects the flush
      */
     public function handleSubmit(ResolvedDataTable $dataTable, int|string $id, array $formData): AjaxActionResult
     {
@@ -95,7 +100,7 @@ final class EditFormService
             return AjaxActionResult::invalid($html);
         }
 
-        $context->manager->flush();
+        $this->flusher->flush($context->manager);
 
         $this->publisher->publish($this->topicResolver->resolve($dataTable->requireEntityClass(), $dataTable->dataTableClass), [
             'type' => 'edit',

--- a/src/Mutation/EntityMutator.php
+++ b/src/Mutation/EntityMutator.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Pentiminax\UX\DataTables\Mutation;
 
-use Doctrine\DBAL\Exception as DBALException;
-use Doctrine\ORM\OptimisticLockException;
-use Doctrine\Persistence\ObjectManager;
 use Pentiminax\UX\DataTables\Contracts\MercurePublisherInterface;
 use Pentiminax\UX\DataTables\Exception\EntityNotFoundException;
 use Pentiminax\UX\DataTables\Exception\FieldNotToggleableException;
@@ -28,6 +25,7 @@ final class EntityMutator
         private readonly MercurePublisherInterface $publisher,
         private readonly AuthorizationChecker $permissionChecker,
         private readonly MercureTopicResolver $topicResolver,
+        private readonly MutationFlusher $flusher,
     ) {
     }
 
@@ -54,7 +52,7 @@ final class EntityMutator
         }
 
         $context->manager->remove($context->entity);
-        $this->flush($context->manager);
+        $this->flusher->flush($context->manager);
 
         $this->publisher->publish($this->topicResolver->resolve($entityClass, $dataTableClass), [
             'type' => 'delete',
@@ -90,28 +88,12 @@ final class EntityMutator
         }
 
         $this->propertyAccessor->setValue($context->entity, $field, $value);
-        $this->flush($context->manager);
+        $this->flusher->flush($context->manager);
 
         $this->publisher->publish($this->topicResolver->resolve($entityClass, $dataTableClass), [
             'type'  => 'edit',
             'id'    => $id,
             'field' => $field,
         ]);
-    }
-
-    /**
-     * @throws MutationPersistenceException when the underlying persistence layer rejects the flush
-     */
-    private function flush(ObjectManager $manager): void
-    {
-        try {
-            $manager->flush();
-        } catch (DBALException|OptimisticLockException $exception) {
-            // The 409 primarily targets constraint/conflict cases — a unique
-            // violation or an optimistic-lock version mismatch. Broader DBAL
-            // failures (e.g. a lost connection) are deliberately mapped here
-            // too rather than leaking as a raw 500.
-            throw new MutationPersistenceException(previous: $exception);
-        }
     }
 }

--- a/src/Mutation/MutationFlusher.php
+++ b/src/Mutation/MutationFlusher.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Mutation;
+
+use Doctrine\DBAL\Exception as DBALException;
+use Doctrine\ORM\OptimisticLockException;
+use Doctrine\Persistence\ObjectManager;
+use Pentiminax\UX\DataTables\Exception\MutationPersistenceException;
+
+/**
+ * Single source of the guarded flush shared by the mutation and edit-form write paths.
+ */
+final class MutationFlusher
+{
+    /**
+     * @throws MutationPersistenceException when the underlying persistence layer rejects the flush
+     */
+    public function flush(ObjectManager $manager): void
+    {
+        try {
+            $manager->flush();
+        } catch (DBALException|OptimisticLockException $exception) {
+            // The 409 primarily targets constraint/conflict cases — a unique
+            // violation or an optimistic-lock version mismatch. Broader DBAL
+            // failures (e.g. a lost connection) are deliberately mapped here
+            // too rather than leaking as a raw 500.
+            throw new MutationPersistenceException(previous: $exception);
+        }
+    }
+}

--- a/tests/Unit/Controller/AjaxDeleteControllerTest.php
+++ b/tests/Unit/Controller/AjaxDeleteControllerTest.php
@@ -29,6 +29,7 @@ use Pentiminax\UX\DataTables\Model\Actions;
 use Pentiminax\UX\DataTables\Model\DataTable;
 use Pentiminax\UX\DataTables\Mutation\EntityLocator;
 use Pentiminax\UX\DataTables\Mutation\EntityMutator;
+use Pentiminax\UX\DataTables\Mutation\MutationFlusher;
 use Pentiminax\UX\DataTables\Runtime\DataTableInfrastructure;
 use Pentiminax\UX\DataTables\Runtime\RenderingPreparer;
 use Pentiminax\UX\DataTables\Security\ActionPermissionContext;
@@ -75,7 +76,7 @@ final class AjaxDeleteControllerTest extends TestCase
         $topicResolver = $this->createStub(MercureTopicResolver::class);
         $topicResolver->method('resolve')->willReturn(['/server/deletable-entity-fixtures/{id}']);
 
-        $mutator = new EntityMutator(new EntityLocator($registry), $this->createMock(PropertyAccessorInterface::class), $publisher, new AuthorizationChecker(), $topicResolver);
+        $mutator = new EntityMutator(new EntityLocator($registry), $this->createMock(PropertyAccessorInterface::class), $publisher, new AuthorizationChecker(), $topicResolver, new MutationFlusher());
 
         $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
         $csrfTokenManager->method('isTokenValid')
@@ -124,6 +125,7 @@ final class AjaxDeleteControllerTest extends TestCase
             $publisher,
             new AuthorizationChecker(),
             new MercureTopicResolver($resolver, $dataTables),
+            new MutationFlusher(),
         );
 
         $csrfTokenManager = $this->createStub(CsrfTokenManagerInterface::class);
@@ -227,6 +229,7 @@ final class AjaxDeleteControllerTest extends TestCase
                 new NullMercurePublisher(),
                 new AuthorizationChecker(),
                 new MercureTopicResolver(),
+                new MutationFlusher(),
             ),
             new MutationTokenValidator($this->createStub(CsrfTokenManagerInterface::class)),
             $this->registry(new StaticDeniedDeleteActionDataTable()),
@@ -331,6 +334,7 @@ final class AjaxDeleteControllerTest extends TestCase
                 new NullMercurePublisher(),
                 $permissionChecker ?? new AuthorizationChecker(),
                 new MercureTopicResolver(),
+                new MutationFlusher(),
             ),
             new MutationTokenValidator($csrfTokenManager),
             $this->registry($dataTable),

--- a/tests/Unit/Controller/AjaxEditControllerTest.php
+++ b/tests/Unit/Controller/AjaxEditControllerTest.php
@@ -29,6 +29,7 @@ use Pentiminax\UX\DataTables\Model\DataTable;
 use Pentiminax\UX\DataTables\Mutation\BooleanMutationContextResolver;
 use Pentiminax\UX\DataTables\Mutation\EntityLocator;
 use Pentiminax\UX\DataTables\Mutation\EntityMutator;
+use Pentiminax\UX\DataTables\Mutation\MutationFlusher;
 use Pentiminax\UX\DataTables\Runtime\DataTableInfrastructure;
 use Pentiminax\UX\DataTables\Runtime\RenderingPreparer;
 use Pentiminax\UX\DataTables\Security\AuthorizationChecker;
@@ -185,6 +186,7 @@ final class AjaxEditControllerTest extends TestCase
             $publisher,
             new AuthorizationChecker(),
             new MercureTopicResolver($resolver, $dataTables),
+            new MutationFlusher(),
         );
 
         $controller = new AjaxEditController(
@@ -209,6 +211,7 @@ final class AjaxEditControllerTest extends TestCase
             new NullMercurePublisher(),
             new AuthorizationChecker(),
             new MercureTopicResolver(),
+            new MutationFlusher(),
         );
 
         return new AjaxEditController(

--- a/tests/Unit/Controller/AjaxEditFormControllerTest.php
+++ b/tests/Unit/Controller/AjaxEditFormControllerTest.php
@@ -25,6 +25,7 @@ use Pentiminax\UX\DataTables\Model\AbstractDataTable;
 use Pentiminax\UX\DataTables\Model\Action;
 use Pentiminax\UX\DataTables\Model\Actions;
 use Pentiminax\UX\DataTables\Mutation\EntityLocator;
+use Pentiminax\UX\DataTables\Mutation\MutationFlusher;
 use Pentiminax\UX\DataTables\Runtime\DataTableInfrastructure;
 use Pentiminax\UX\DataTables\Security\AuthorizationChecker;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -161,6 +162,7 @@ final class AjaxEditFormControllerTest extends TestCase
                 $templateResolver,
                 new NullMercurePublisher(),
                 new MercureTopicResolver(dataTables: $dataTables),
+                new MutationFlusher(),
                 new AuthorizationChecker($authorizationChecker),
             ),
             $this->tableRegistry(),

--- a/tests/Unit/Controller/AjaxEditFormSubmitControllerTest.php
+++ b/tests/Unit/Controller/AjaxEditFormSubmitControllerTest.php
@@ -29,6 +29,7 @@ use Pentiminax\UX\DataTables\Model\AbstractDataTable;
 use Pentiminax\UX\DataTables\Model\Action;
 use Pentiminax\UX\DataTables\Model\Actions;
 use Pentiminax\UX\DataTables\Mutation\EntityLocator;
+use Pentiminax\UX\DataTables\Mutation\MutationFlusher;
 use Pentiminax\UX\DataTables\Runtime\DataTableInfrastructure;
 use Pentiminax\UX\DataTables\Security\AuthorizationChecker;
 use Pentiminax\UX\DataTables\Security\MutationTokenValidator;
@@ -78,6 +79,7 @@ final class AjaxEditFormSubmitControllerTest extends TestCase
             $templateResolver,
             new NullMercurePublisher(),
             new MercureTopicResolver(dataTables: $this->registeredDataTables()),
+            new MutationFlusher(),
             $this->permissionCheckerGranting(true),
         ));
 
@@ -127,6 +129,7 @@ final class AjaxEditFormSubmitControllerTest extends TestCase
             $templateResolver,
             new NullMercurePublisher(),
             new MercureTopicResolver(),
+            new MutationFlusher(),
             new AuthorizationChecker($authorizationChecker),
         ));
 
@@ -185,6 +188,7 @@ final class AjaxEditFormSubmitControllerTest extends TestCase
             $templateResolver,
             new MercureUpdatePublisher($hub),
             new MercureTopicResolver($resolver, $this->registeredDataTables()),
+            new MutationFlusher(),
             $this->permissionCheckerGranting(true),
         ));
 
@@ -222,6 +226,7 @@ final class AjaxEditFormSubmitControllerTest extends TestCase
                 $this->createMock(EditModalTemplateResolver::class),
                 new NullMercurePublisher(),
                 new MercureTopicResolver(),
+                new MutationFlusher(),
                 $this->permissionCheckerGranting(true),
             ),
             $csrfTokenManager,

--- a/tests/Unit/Form/EditFormServiceTest.php
+++ b/tests/Unit/Form/EditFormServiceTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Pentiminax\UX\DataTables\Tests\Unit\Form;
 
+use Doctrine\DBAL\Driver\Exception as DriverException;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -13,6 +15,7 @@ use Pentiminax\UX\DataTables\Ajax\ResolvedDataTable;
 use Pentiminax\UX\DataTables\Attribute\AsDataTable;
 use Pentiminax\UX\DataTables\Column\TextColumn;
 use Pentiminax\UX\DataTables\Contracts\MercurePublisherInterface;
+use Pentiminax\UX\DataTables\Exception\MutationPersistenceException;
 use Pentiminax\UX\DataTables\Form\ColumnToFormTypeMapper;
 use Pentiminax\UX\DataTables\Form\EditFormBuilder;
 use Pentiminax\UX\DataTables\Form\EditFormService;
@@ -26,6 +29,7 @@ use Pentiminax\UX\DataTables\Model\AbstractDataTable;
 use Pentiminax\UX\DataTables\Model\Action;
 use Pentiminax\UX\DataTables\Model\Actions;
 use Pentiminax\UX\DataTables\Mutation\EntityLocator;
+use Pentiminax\UX\DataTables\Mutation\MutationFlusher;
 use Pentiminax\UX\DataTables\Runtime\DataTableInfrastructure;
 use Pentiminax\UX\DataTables\Security\ActionPermissionContext;
 use Pentiminax\UX\DataTables\Security\AuthorizationChecker;
@@ -99,6 +103,7 @@ final class EditFormServiceTest extends TestCase
             $this->createRenderingTemplateResolver(EditFormServiceFixtureDataTable::class),
             new NullMercurePublisher(),
             new MercureTopicResolver(),
+            new MutationFlusher(),
         );
 
         $result = $service->handleView($this->resolved(new EditFormServiceFixtureDataTable()), '42');
@@ -134,6 +139,7 @@ final class EditFormServiceTest extends TestCase
             $this->createRenderingTemplateResolver(EditFormServiceFixtureDataTable::class),
             new NullMercurePublisher(),
             new MercureTopicResolver(),
+            new MutationFlusher(),
         );
 
         $result = $service->handleSubmit($this->resolved(new EditFormServiceFixtureDataTable()), 42, ['name' => 'Alice']);
@@ -179,6 +185,35 @@ final class EditFormServiceTest extends TestCase
         $this->assertTrue($result->success);
         $this->assertNull($result->html);
         $this->assertSame('', $result->message);
+    }
+
+    /**
+     * Regression: the submit flush used to be unguarded, so a unique constraint
+     * violation surfaced as a 500 leaking SQL instead of the 409 the delete and
+     * inline-edit paths already return.
+     */
+    #[Test]
+    public function it_maps_a_unique_constraint_violation_on_submit_to_a_persistence_exception(): void
+    {
+        $driverException = new class('constraint violation') extends \RuntimeException implements DriverException {
+            public function getSQLState(): ?string
+            {
+                return '23505';
+            }
+        };
+        $previous = new UniqueConstraintViolationException($driverException, null);
+
+        $caught = null;
+
+        try {
+            $this->handleValidSubmit(new NullMercurePublisher(), $previous);
+        } catch (MutationPersistenceException $exception) {
+            $caught = $exception;
+        }
+
+        $this->assertInstanceOf(MutationPersistenceException::class, $caught);
+        $this->assertSame(409, $caught->getStatusCode());
+        $this->assertSame($previous, $caught->getPrevious());
     }
 
     #[Test]
@@ -289,6 +324,7 @@ final class EditFormServiceTest extends TestCase
             $templateResolver,
             new NullMercurePublisher(),
             new MercureTopicResolver(),
+            new MutationFlusher(),
             $permissionChecker,
         );
 
@@ -308,14 +344,20 @@ final class EditFormServiceTest extends TestCase
 
     /**
      * Submits a valid form and returns the result; the modal must never be re-rendered.
+     *
+     * When $flushFailure is given, the persistence layer rejects the flush instead.
      */
-    private function handleValidSubmit(MercurePublisherInterface $publisher): AjaxActionResult
+    private function handleValidSubmit(MercurePublisherInterface $publisher, ?\Throwable $flushFailure = null): AjaxActionResult
     {
         $dataTable      = new EditFormServiceFixtureDataTable();
         $dataTableClass = $dataTable::class;
         $entity         = new EditFormServiceFixture();
         $entityManager  = $this->createEntityManagerWithEntity($entity, 42);
-        $entityManager->expects($this->once())->method('flush');
+        $flush          = $entityManager->expects($this->once())->method('flush');
+
+        if (null !== $flushFailure) {
+            $flush->willThrowException($flushFailure);
+        }
 
         $form = $this->createMock(FormInterface::class);
         $form->expects($this->once())->method('submit')->with(['name' => 'Alice']);
@@ -341,6 +383,7 @@ final class EditFormServiceTest extends TestCase
             $templateResolver,
             $publisher,
             $this->topicResolverReturning(self::TOPICS),
+            new MutationFlusher(),
         );
 
         return $service->handleSubmit($this->resolved($dataTable), 42, ['name' => 'Alice']);

--- a/tests/Unit/Mutation/EntityMutatorTest.php
+++ b/tests/Unit/Mutation/EntityMutatorTest.php
@@ -22,6 +22,7 @@ use Pentiminax\UX\DataTables\Mercure\MercureTopicResolver;
 use Pentiminax\UX\DataTables\Model\Action;
 use Pentiminax\UX\DataTables\Mutation\EntityLocator;
 use Pentiminax\UX\DataTables\Mutation\EntityMutator;
+use Pentiminax\UX\DataTables\Mutation\MutationFlusher;
 use Pentiminax\UX\DataTables\Security\AuthorizationChecker;
 use Pentiminax\UX\DataTables\Security\Permission;
 use Pentiminax\UX\DataTables\Security\SecurityVoter;
@@ -409,6 +410,7 @@ final class EntityMutatorTest extends TestCase
             $publisher,
             $permissionChecker ?? new AuthorizationChecker(),
             $topicResolver     ?? new MercureTopicResolver(),
+            new MutationFlusher(),
         );
     }
 

--- a/tests/Unit/Mutation/MutationExceptionHandlingTest.php
+++ b/tests/Unit/Mutation/MutationExceptionHandlingTest.php
@@ -26,6 +26,7 @@ use Pentiminax\UX\DataTables\Model\Actions;
 use Pentiminax\UX\DataTables\Mutation\BooleanMutationContextResolver;
 use Pentiminax\UX\DataTables\Mutation\EntityLocator;
 use Pentiminax\UX\DataTables\Mutation\EntityMutator;
+use Pentiminax\UX\DataTables\Mutation\MutationFlusher;
 use Pentiminax\UX\DataTables\Security\AuthorizationChecker;
 use Pentiminax\UX\DataTables\Security\MutationTokenValidator;
 use PHPUnit\Framework\Attributes\Test;
@@ -78,6 +79,7 @@ final class MutationExceptionHandlingTest extends TestCase
             new NullMercurePublisher(),
             new AuthorizationChecker(),
             new MercureTopicResolver(),
+            new MutationFlusher(),
         ));
 
         $response = $this->handleControllerException(
@@ -161,6 +163,7 @@ final class MutationExceptionHandlingTest extends TestCase
             new NullMercurePublisher(),
             new AuthorizationChecker(),
             new MercureTopicResolver(),
+            new MutationFlusher(),
         );
     }
 

--- a/tests/Unit/Mutation/MutationFlusherTest.php
+++ b/tests/Unit/Mutation/MutationFlusherTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Unit\Mutation;
+
+use Doctrine\DBAL\Driver\Exception as DriverException;
+use Doctrine\DBAL\Exception as DBALException;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\ORM\OptimisticLockException;
+use Doctrine\Persistence\ObjectManager;
+use Pentiminax\UX\DataTables\Exception\MutationPersistenceException;
+use Pentiminax\UX\DataTables\Mutation\MutationFlusher;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+final class MutationFlusherTest extends TestCase
+{
+    #[Test]
+    public function it_flushes_the_manager_when_the_persistence_layer_accepts_it(): void
+    {
+        $manager = $this->createMock(ObjectManager::class);
+        $manager->expects($this->once())->method('flush');
+
+        (new MutationFlusher())->flush($manager);
+    }
+
+    #[Test]
+    public function it_wraps_dbal_exceptions_into_a_mutation_persistence_exception(): void
+    {
+        $previous = self::dbalException();
+
+        $this->assertMapsToPersistenceException($this->managerFailingWith($previous), $previous);
+    }
+
+    #[Test]
+    public function it_wraps_optimistic_lock_exceptions(): void
+    {
+        $previous = OptimisticLockException::lockFailed(new \stdClass());
+
+        $this->assertMapsToPersistenceException($this->managerFailingWith($previous), $previous);
+    }
+
+    #[Test]
+    public function it_lets_other_exceptions_through(): void
+    {
+        $previous = new \RuntimeException('Unrelated failure.');
+
+        $this->expectExceptionObject($previous);
+
+        (new MutationFlusher())->flush($this->managerFailingWith($previous));
+    }
+
+    private static function dbalException(): DBALException
+    {
+        // A genuine Doctrine\DBAL\Exception subtype in both DBAL 3 and 4.
+        $driverException = new class('constraint violation') extends \RuntimeException implements DriverException {
+            public function getSQLState(): ?string
+            {
+                return '23505';
+            }
+        };
+
+        return new UniqueConstraintViolationException($driverException, null);
+    }
+
+    private function managerFailingWith(\Throwable $failure): ObjectManager
+    {
+        $manager = $this->createMock(ObjectManager::class);
+        $manager->method('flush')->willThrowException($failure);
+
+        return $manager;
+    }
+
+    private function assertMapsToPersistenceException(ObjectManager $manager, \Throwable $expectedPrevious): void
+    {
+        $caught = null;
+
+        try {
+            (new MutationFlusher())->flush($manager);
+        } catch (MutationPersistenceException $exception) {
+            $caught = $exception;
+        }
+
+        $this->assertInstanceOf(MutationPersistenceException::class, $caught);
+        $this->assertSame(409, $caught->getStatusCode());
+        $this->assertSame('The operation could not be completed due to a data conflict.', $caught->getClientMessage());
+        $this->assertSame($expectedPrevious, $caught->getPrevious());
+    }
+}


### PR DESCRIPTION
## Why
`EditFormService::handleSubmit()` called `flush()` bare. A unique-constraint or optimistic-lock failure escaped as a 500 with the SQL and index name in the debug response and logs, while delete and inline edit already answered 409 through `EntityMutator`'s private `flush()`.

## What
- New `Mutation\MutationFlusher` owns the guarded flush (`DBALException|OptimisticLockException` → `MutationPersistenceException`).
- Injected into both `EntityMutator` (private `flush()` removed) and `EditFormService`; wired in `config/services.php` and `config/form.php`.
- `MutationExceptionListener` needed no change: it is type-based on `kernel.exception`, so the submit route was covered as soon as the exception is thrown.
- Constructor signature change on both classes (DI users unaffected). `UPGRADE.md` entry.

## Tests
New `MutationFlusherTest` and an `EditFormServiceTest` regression that fails on main. `vendor/bin/phpunit`: 1446 tests. `composer fix`, `composer audit` green.

## Note
Conflicts with the A6 PR on two test files (`EditFormServiceTest`, `AjaxDeleteControllerTest`); whichever merges second gets rebased.

---
Part of the pre-1.0 security lot (A). Each PR of the lot adds its own entry under `## v0.90 → v1.0` in `UPGRADE.md`; expect a trivial rebase on that file after the previous lot PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)