### PR TITLE
Fail closed when an application permission is checked without a Symfony authorization checker

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -30,6 +30,22 @@ $mutator = new EntityMutator($locator, $propertyAccessor, $publisher, $checker, 
 
 `MutationFlusher` is stateless and has no constructor arguments.
 
+### Changed
+
+| Behavior | Before | After |
+| --- | --- | --- |
+| Permission check without a Symfony authorization checker | Silently granted | Throws a `LogicException` |
+
+Configuring `setPermission()` without the Symfony authorization checker now throws a
+`LogicException` instead of silently granting access. Enable `symfony/security-bundle` with a
+firewall, or drop the permission.
+
+The bundle's own `Permission::DT_*` attributes are unaffected: without the SecurityBundle the
+bundle's `SecurityVoter` is not registered either, so there is nothing to vote on and an
+application with no firewall keeps rendering its tables. An empty or `null` attribute — meaning
+no permission is configured — is also still granted.
+
+
 ## v0.84 → v0.85
 
 ### Permission configuration uses `setPermission()`

--- a/docs/src/content/docs/guide/security.mdx
+++ b/docs/src/content/docs/guide/security.mdx
@@ -37,15 +37,27 @@ Permission::DT_VIEW_ROW_DETAILS;   // always required for collapsible detail row
   no voter grants. Register voters for the row permissions your tables use.
 </Aside>
 
-### Why nothing gets denied without a security firewall
+### What happens without a security firewall
 
-The check is performed through a small internal wrapper, `AuthorizationChecker`, which grants
-everything automatically only when **no security stack is configured at all** — for example in the
-CLI, in a unit test, or in an application that never installed `symfony/security-bundle`. As soon as
-a real `AuthorizationCheckerInterface` is available (i.e. your application has a firewall), the
-wrapper defers entirely to Symfony's normal voting process. With a firewall active but no voter
-registered for the required `Permission::DT_*` attribute on your entity, access is denied by
-default. Registering a voter is what makes the feature usable for legitimate users.
+The check is performed through a small internal wrapper, `AuthorizationChecker`. When a real
+`AuthorizationCheckerInterface` is available (i.e. your application has a firewall), the wrapper
+defers entirely to Symfony's normal voting process. With a firewall active but no voter registered
+for the required `Permission::DT_*` attribute on your entity, access is denied by default.
+Registering a voter is what makes the feature usable for legitimate users.
+
+When **no security stack is configured at all** — for example in an application that never
+enabled `symfony/security-bundle` or that has no firewall — the wrapper fails closed on the
+permissions your application configures. Asking for one throws a `LogicException` instead of
+silently granting access:
+
+```
+A permission "ROLE_HR" is configured but no Symfony authorization checker is available.
+Enable the SecurityBundle (a firewall must be configured) or remove the permission.
+```
+
+The bundle's own `Permission::DT_*` attributes stay granted in that situation: without the
+SecurityBundle the bundle's `SecurityVoter` is not registered either, so there is nothing to vote
+on, and an application with no firewall must keep rendering its tables.
 
 ## Table-level permissions
 

--- a/src/Security/AuthorizationChecker.php
+++ b/src/Security/AuthorizationChecker.php
@@ -36,7 +36,7 @@ final class AuthorizationChecker implements AuthorizationCheckerInterface
         }
 
         if (null === $this->checker) {
-            throw new \LogicException(\sprintf('A permission "%s" is configured but no Symfony authorization checker is available. Enable the SecurityBundle (a firewall must be configured) or remove the permission.', \is_string($attribute) ? $attribute : get_debug_type($attribute)));
+            throw new \LogicException(\sprintf('A permission "%s" is configured but no Symfony authorization checker is available. Enable the SecurityBundle (a firewall must be configured) or remove the permission.', \is_string($attribute) || $attribute instanceof \Stringable ? (string) $attribute : get_debug_type($attribute)));
         }
 
         try {

--- a/src/Security/AuthorizationChecker.php
+++ b/src/Security/AuthorizationChecker.php
@@ -9,10 +9,11 @@ use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 
 /**
- * Thin wrapper around Symfony's AuthorizationChecker so the bundle keeps working
- * when the security stack is unavailable (CLI, missing firewall, tests).
+ * Thin wrapper around Symfony's AuthorizationChecker.
  *
- * If no checker is provided, every permission is granted (no-op fallback).
+ * If no checker is provided, an empty or null attribute (no permission configured) and the
+ * bundle's own Permission::DT_* attributes are granted; an application permission fails
+ * closed with a LogicException rather than silently granting access.
  */
 final class AuthorizationChecker implements AuthorizationCheckerInterface
 {
@@ -27,8 +28,15 @@ final class AuthorizationChecker implements AuthorizationCheckerInterface
             return true;
         }
 
-        if (null === $this->checker) {
+        if (null === $this->checker && \in_array($attribute, Permission::all(), true)) {
+            // Without the SecurityBundle the bundle's own SecurityVoter is not registered
+            // either: there is nothing to vote on, and an application with no firewall must
+            // keep rendering its tables. Application permissions still fail closed below.
             return true;
+        }
+
+        if (null === $this->checker) {
+            throw new \LogicException(\sprintf('A permission "%s" is configured but no Symfony authorization checker is available. Enable the SecurityBundle (a firewall must be configured) or remove the permission.', \is_string($attribute) ? $attribute : get_debug_type($attribute)));
         }
 
         try {

--- a/src/Security/Permission.php
+++ b/src/Security/Permission.php
@@ -15,4 +15,18 @@ final class Permission
     private function __construct()
     {
     }
+
+    /**
+     * @return list<string>
+     */
+    public static function all(): array
+    {
+        return [
+            self::DT_ACCESS_TABLE,
+            self::DT_EXECUTE_ACTION,
+            self::DT_EDIT_ROW,
+            self::DT_DELETE_ROW,
+            self::DT_VIEW_ROW_DETAILS,
+        ];
+    }
 }

--- a/tests/Kernel/ProfilerAppKernel.php
+++ b/tests/Kernel/ProfilerAppKernel.php
@@ -56,9 +56,13 @@ class ProfilerAppKernel extends Kernel
         });
     }
 
+    /**
+     * Keyed on the project dir so parallel checkouts never reuse each other's
+     * compiled container.
+     */
     public function getCacheDir(): string
     {
-        return sys_get_temp_dir().'/ux_datatables/profiler_cache/'.$this->environment;
+        return sys_get_temp_dir().'/ux_datatables/profiler_cache/'.substr(md5($this->getProjectDir()), 0, 8).'/'.$this->environment;
     }
 
     public function getLogDir(): string

--- a/tests/Unit/Ajax/DetailRowServiceTest.php
+++ b/tests/Unit/Ajax/DetailRowServiceTest.php
@@ -19,6 +19,7 @@ use Pentiminax\UX\DataTables\Security\ActionPermissionContext;
 use Pentiminax\UX\DataTables\Security\AuthorizationChecker;
 use Pentiminax\UX\DataTables\Security\Permission;
 use Pentiminax\UX\DataTables\Tests\Fixtures\Security\RowContextDenyingAuthorizationChecker;
+use Pentiminax\UX\DataTables\Tests\Fixtures\Security\TestAuthorizationChecker;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -184,7 +185,7 @@ final class DetailRowServiceTest extends TestCase
         ?Environment $twig,
         ?AuthorizationChecker $permissionChecker = null,
     ): DetailRowService {
-        return new DetailRowService($locator, $twig, $permissionChecker ?? new AuthorizationChecker());
+        return new DetailRowService($locator, $twig, $permissionChecker ?? new AuthorizationChecker(new TestAuthorizationChecker()));
     }
 
     private function resolved(AbstractDataTable $dataTable): ResolvedDataTable

--- a/tests/Unit/Column/ColumnResolverTest.php
+++ b/tests/Unit/Column/ColumnResolverTest.php
@@ -367,8 +367,15 @@ final class ColumnResolverTest extends TestCase
      */
     public static function provideColumnsKeptWithoutPermissionCheck(): iterable
     {
-        yield 'permission granted by the default checker' => [TextColumn::new('salary', 'Salary')->setPermission('ROLE_HR')];
         yield 'custom column implementing ColumnInterface with no permission' => [self::createStub(ColumnInterface::class)];
+    }
+
+    #[Test]
+    public function filter_static_permissions_throws_without_an_authorization_checker(): void
+    {
+        $this->expectException(\LogicException::class);
+
+        (new ColumnResolver())->filterStaticPermissions([TextColumn::new('salary', 'Salary')->setPermission('ROLE_HR')]);
     }
 
     /**

--- a/tests/Unit/Column/Rendering/ActionRowDataResolverTest.php
+++ b/tests/Unit/Column/Rendering/ActionRowDataResolverTest.php
@@ -103,7 +103,7 @@ final class ActionRowDataResolverTest extends TestCase
             ['DELETE' => ['id' => 9]],
         ];
 
-        // An AuthorizationChecker without inner checker grants everything.
+        // An AuthorizationChecker without inner checker grants the bundle's own attributes.
         yield 'per row permission without authorization checker' => [
             [
                 Action::edit()

--- a/tests/Unit/Controller/AjaxDeleteControllerTest.php
+++ b/tests/Unit/Controller/AjaxDeleteControllerTest.php
@@ -36,6 +36,7 @@ use Pentiminax\UX\DataTables\Security\ActionPermissionContext;
 use Pentiminax\UX\DataTables\Security\AuthorizationChecker;
 use Pentiminax\UX\DataTables\Security\MutationTokenValidator;
 use Pentiminax\UX\DataTables\Security\Permission;
+use Pentiminax\UX\DataTables\Tests\Fixtures\Security\TestAuthorizationChecker;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -76,14 +77,14 @@ final class AjaxDeleteControllerTest extends TestCase
         $topicResolver = $this->createStub(MercureTopicResolver::class);
         $topicResolver->method('resolve')->willReturn(['/server/deletable-entity-fixtures/{id}']);
 
-        $mutator = new EntityMutator(new EntityLocator($registry), $this->createMock(PropertyAccessorInterface::class), $publisher, new AuthorizationChecker(), $topicResolver, new MutationFlusher());
+        $mutator = new EntityMutator(new EntityLocator($registry), $this->createMock(PropertyAccessorInterface::class), $publisher, new AuthorizationChecker(new TestAuthorizationChecker()), $topicResolver, new MutationFlusher());
 
         $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
         $csrfTokenManager->method('isTokenValid')
             ->with(new CsrfToken(MutationTokenValidator::TOKEN_ID, 'valid-token'))
             ->willReturn(true);
 
-        $controller = new AjaxDeleteController($mutator, new MutationTokenValidator($csrfTokenManager), $this->registry());
+        $controller = new AjaxDeleteController($mutator, new MutationTokenValidator($csrfTokenManager), $this->registry(), new AuthorizationChecker(new TestAuthorizationChecker()));
 
         $response = $controller($this->createRequest(), new AjaxEntityQueryDto(
             dataTable: $this->dataTableToken(),
@@ -123,7 +124,7 @@ final class AjaxDeleteControllerTest extends TestCase
             new EntityLocator($registry),
             $this->createMock(PropertyAccessorInterface::class),
             $publisher,
-            new AuthorizationChecker(),
+            new AuthorizationChecker(new TestAuthorizationChecker()),
             new MercureTopicResolver($resolver, $dataTables),
             new MutationFlusher(),
         );
@@ -131,7 +132,7 @@ final class AjaxDeleteControllerTest extends TestCase
         $csrfTokenManager = $this->createStub(CsrfTokenManagerInterface::class);
         $csrfTokenManager->method('isTokenValid')->willReturn(true);
 
-        $controller = new AjaxDeleteController($mutator, new MutationTokenValidator($csrfTokenManager), $this->registry($dataTable));
+        $controller = new AjaxDeleteController($mutator, new MutationTokenValidator($csrfTokenManager), $this->registry($dataTable), new AuthorizationChecker(new TestAuthorizationChecker()));
 
         $controller($this->createRequest(), new AjaxEntityQueryDto(
             dataTable: $this->dataTableToken(),
@@ -227,7 +228,7 @@ final class AjaxDeleteControllerTest extends TestCase
                 new EntityLocator($this->createMock(ManagerRegistry::class)),
                 $this->createMock(PropertyAccessorInterface::class),
                 new NullMercurePublisher(),
-                new AuthorizationChecker(),
+                new AuthorizationChecker(new TestAuthorizationChecker()),
                 new MercureTopicResolver(),
                 new MutationFlusher(),
             ),
@@ -327,12 +328,14 @@ final class AjaxDeleteControllerTest extends TestCase
         ?AbstractDataTable $dataTable = null,
         ?AuthorizationChecker $permissionChecker = null,
     ): AjaxDeleteController {
+        $permissionChecker ??= new AuthorizationChecker(new TestAuthorizationChecker());
+
         return new AjaxDeleteController(
             new EntityMutator(
                 new EntityLocator($registry),
                 $this->createMock(PropertyAccessorInterface::class),
                 new NullMercurePublisher(),
-                $permissionChecker ?? new AuthorizationChecker(),
+                $permissionChecker,
                 new MercureTopicResolver(),
                 new MutationFlusher(),
             ),

--- a/tests/Unit/Controller/AjaxEditControllerTest.php
+++ b/tests/Unit/Controller/AjaxEditControllerTest.php
@@ -34,6 +34,7 @@ use Pentiminax\UX\DataTables\Runtime\DataTableInfrastructure;
 use Pentiminax\UX\DataTables\Runtime\RenderingPreparer;
 use Pentiminax\UX\DataTables\Security\AuthorizationChecker;
 use Pentiminax\UX\DataTables\Security\MutationTokenValidator;
+use Pentiminax\UX\DataTables\Tests\Fixtures\Security\TestAuthorizationChecker;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -184,7 +185,7 @@ final class AjaxEditControllerTest extends TestCase
             new EntityLocator($this->managerRegistry($entity, 799, expectFlush: true)),
             $this->writableAccessor($entity, true),
             $publisher,
-            new AuthorizationChecker(),
+            new AuthorizationChecker(new TestAuthorizationChecker()),
             new MercureTopicResolver($resolver, $dataTables),
             new MutationFlusher(),
         );
@@ -209,7 +210,7 @@ final class AjaxEditControllerTest extends TestCase
             new EntityLocator($this->managerRegistry($entity, $id, $expectFlush)),
             $accessor,
             new NullMercurePublisher(),
-            new AuthorizationChecker(),
+            new AuthorizationChecker(new TestAuthorizationChecker()),
             new MercureTopicResolver(),
             new MutationFlusher(),
         );

--- a/tests/Unit/Form/EditFormServiceTest.php
+++ b/tests/Unit/Form/EditFormServiceTest.php
@@ -35,6 +35,7 @@ use Pentiminax\UX\DataTables\Security\ActionPermissionContext;
 use Pentiminax\UX\DataTables\Security\AuthorizationChecker;
 use Pentiminax\UX\DataTables\Security\Permission;
 use Pentiminax\UX\DataTables\Tests\Fixtures\Security\RowContextDenyingAuthorizationChecker;
+use Pentiminax\UX\DataTables\Tests\Fixtures\Security\TestAuthorizationChecker;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\TestWith;
@@ -104,6 +105,7 @@ final class EditFormServiceTest extends TestCase
             new NullMercurePublisher(),
             new MercureTopicResolver(),
             new MutationFlusher(),
+            new AuthorizationChecker(new TestAuthorizationChecker()),
         );
 
         $result = $service->handleView($this->resolved(new EditFormServiceFixtureDataTable()), '42');
@@ -140,6 +142,7 @@ final class EditFormServiceTest extends TestCase
             new NullMercurePublisher(),
             new MercureTopicResolver(),
             new MutationFlusher(),
+            new AuthorizationChecker(new TestAuthorizationChecker()),
         );
 
         $result = $service->handleSubmit($this->resolved(new EditFormServiceFixtureDataTable()), 42, ['name' => 'Alice']);
@@ -325,7 +328,7 @@ final class EditFormServiceTest extends TestCase
             new NullMercurePublisher(),
             new MercureTopicResolver(),
             new MutationFlusher(),
-            $permissionChecker,
+            $permissionChecker ?? new AuthorizationChecker(new TestAuthorizationChecker()),
         );
 
         $dataTable = $this->resolved($dataTable ?? new EditFormServiceFixtureDataTable());
@@ -384,6 +387,7 @@ final class EditFormServiceTest extends TestCase
             $publisher,
             $this->topicResolverReturning(self::TOPICS),
             new MutationFlusher(),
+            new AuthorizationChecker(new TestAuthorizationChecker()),
         );
 
         return $service->handleSubmit($this->resolved($dataTable), 42, ['name' => 'Alice']);

--- a/tests/Unit/Mutation/EntityMutatorTest.php
+++ b/tests/Unit/Mutation/EntityMutatorTest.php
@@ -27,6 +27,7 @@ use Pentiminax\UX\DataTables\Security\AuthorizationChecker;
 use Pentiminax\UX\DataTables\Security\Permission;
 use Pentiminax\UX\DataTables\Security\SecurityVoter;
 use Pentiminax\UX\DataTables\Tests\Fixtures\Security\RowContextDenyingAuthorizationChecker;
+use Pentiminax\UX\DataTables\Tests\Fixtures\Security\TestAuthorizationChecker;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -408,7 +409,7 @@ final class EntityMutatorTest extends TestCase
             new EntityLocator($this->registry($manager)),
             $accessor ?? $this->createStub(PropertyAccessorInterface::class),
             $publisher,
-            $permissionChecker ?? new AuthorizationChecker(),
+            $permissionChecker ?? new AuthorizationChecker(new TestAuthorizationChecker()),
             $topicResolver     ?? new MercureTopicResolver(),
             new MutationFlusher(),
         );

--- a/tests/Unit/Mutation/MutationExceptionHandlingTest.php
+++ b/tests/Unit/Mutation/MutationExceptionHandlingTest.php
@@ -29,6 +29,7 @@ use Pentiminax\UX\DataTables\Mutation\EntityMutator;
 use Pentiminax\UX\DataTables\Mutation\MutationFlusher;
 use Pentiminax\UX\DataTables\Security\AuthorizationChecker;
 use Pentiminax\UX\DataTables\Security\MutationTokenValidator;
+use Pentiminax\UX\DataTables\Tests\Fixtures\Security\TestAuthorizationChecker;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -53,6 +54,7 @@ final class MutationExceptionHandlingTest extends TestCase
             $this->mutatorReturning(null),
             new MutationTokenValidator($this->validCsrfTokenManager()),
             $this->dataTableRegistry(),
+            new AuthorizationChecker(new TestAuthorizationChecker()),
         );
 
         $response = $this->handleControllerException(
@@ -77,7 +79,7 @@ final class MutationExceptionHandlingTest extends TestCase
             new EntityLocator($this->registryReturning($entity)),
             $accessor,
             new NullMercurePublisher(),
-            new AuthorizationChecker(),
+            new AuthorizationChecker(new TestAuthorizationChecker()),
             new MercureTopicResolver(),
             new MutationFlusher(),
         ));
@@ -161,7 +163,7 @@ final class MutationExceptionHandlingTest extends TestCase
             new EntityLocator($this->registryReturning($entity)),
             $this->createMock(PropertyAccessorInterface::class),
             new NullMercurePublisher(),
-            new AuthorizationChecker(),
+            new AuthorizationChecker(new TestAuthorizationChecker()),
             new MercureTopicResolver(),
             new MutationFlusher(),
         );

--- a/tests/Unit/Security/AuthorizationCheckerTest.php
+++ b/tests/Unit/Security/AuthorizationCheckerTest.php
@@ -64,7 +64,7 @@ final class AuthorizationCheckerTest extends TestCase
     public function it_throws_without_casting_an_expression_permission(): void
     {
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage(\sprintf('A permission "%s" is configured', Expression::class));
+        $this->expectExceptionMessage('A permission ""ROLE_ADMIN" in role_names" is configured');
 
         (new AuthorizationChecker())->isGranted(new Expression('"ROLE_ADMIN" in role_names'));
     }

--- a/tests/Unit/Security/AuthorizationCheckerTest.php
+++ b/tests/Unit/Security/AuthorizationCheckerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pentiminax\UX\DataTables\Tests\Unit\Security;
 
 use Pentiminax\UX\DataTables\Security\AuthorizationChecker;
+use Pentiminax\UX\DataTables\Security\Permission;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -32,12 +33,40 @@ final class AuthorizationCheckerTest extends TestCase
     }
 
     #[Test]
-    public function grants_everything_when_no_checker_is_provided(): void
+    public function it_grants_empty_and_null_attributes_without_a_checker(): void
     {
         $checker = new AuthorizationChecker();
 
-        $this->assertTrue($checker->isGranted('ROLE_ADMIN'));
-        $this->assertTrue($checker->isGranted('EDIT', new \stdClass()));
+        $this->assertTrue($checker->isGranted(null));
+        $this->assertTrue($checker->isGranted(''));
+    }
+
+    #[Test]
+    public function it_grants_bundle_permissions_without_a_checker(): void
+    {
+        $checker = new AuthorizationChecker();
+
+        foreach (Permission::all() as $permission) {
+            $this->assertTrue($checker->isGranted($permission, new \stdClass()));
+        }
+    }
+
+    #[Test]
+    public function it_throws_when_a_permission_is_configured_without_a_symfony_checker(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('A permission "ROLE_ADMIN" is configured but no Symfony authorization checker is available.');
+
+        (new AuthorizationChecker())->isGranted('ROLE_ADMIN');
+    }
+
+    #[Test]
+    public function it_throws_without_casting_an_expression_permission(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage(\sprintf('A permission "%s" is configured', Expression::class));
+
+        (new AuthorizationChecker())->isGranted(new Expression('"ROLE_ADMIN" in role_names'));
     }
 
     #[Test]


### PR DESCRIPTION
## Why
`AuthorizationChecker` returned `true` for every permission when the Symfony `AuthorizationCheckerInterface` service was missing (`nullOnInvalid()` wiring). `symfony/security-bundle` is a hard requirement, so a missing checker is a misconfiguration; silently granting `setPermission()` is the wrong default.

## What
- A non-empty **application** attribute (string or `Expression`) checked without a Symfony checker now throws `LogicException` with a message naming the permission and the fix.
- Still granted without a checker: null/empty attributes (no permission configured) and the bundle's own `Permission::DT_*` attributes, exposed via new `Permission::all()`. Without the SecurityBundle the bundle's `SecurityVoter` is not registered either, so there is nothing to vote on and an application with no firewall keeps rendering its tables.
- 8 tests realigned on the existing `TestAuthorizationChecker` fixture; `ProfilerAppKernel` cache dir keyed on the project dir (parallel checkouts were reusing each other's compiled container).
- Docs: `guide/security.mdx`. `UPGRADE.md` entry.

## Scope note for reviewers
Only `AbstractColumn::setPermission()` reaches the wrapper with a raw application attribute. Table (`DT_ACCESS_TABLE`) and action (`DT_EXECUTE_ACTION`) permissions travel inside the voter subject and keep their current behavior without a firewall. Closing those needs a separate change.

## Tests
`vendor/bin/phpunit`: 1444 tests. `composer fix`, `composer audit`, docs lint/build green.

---
Part of the pre-1.0 security lot (A). Each PR of the lot adds its own entry under `## v0.90 → v1.0` in `UPGRADE.md`; expect a trivial rebase on that file after the previous lot PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)