### PR TITLE
Skip API Platform properties guarded by an ApiProperty security expression

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -97,6 +97,18 @@ Exports are unaffected: they drop pagination explicitly and still stream every f
 - A failed template rendering request no longer leaves the table spinning: rows are displayed
   unrendered instead.
 
+### Secured API Platform properties are no longer auto-detected
+
+Properties carrying `#[ApiProperty(security: …)]` are never auto-detected; declare them explicitly
+and use `setPermission()`. API Platform evaluates that expression per request in its normalizer, and
+an auto-detected column reads the value outside that check, so a table relying on auto-detection can
+now be missing a column it used to render.
+
+```php
+// The property is skipped by auto-detection; add the column yourself and guard it.
+$table->addColumn(TextColumn::new('salary')->setPermission('ROLE_ADMIN'));
+```
+
 ## v0.84 → v0.85
 
 ### Permission configuration uses `setPermission()`

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -105,8 +105,20 @@ an auto-detected column reads the value outside that check, so a table relying o
 now be missing a column it used to render.
 
 ```php
-// The property is skipped by auto-detection; add the column yourself and guard it.
-$table->addColumn(TextColumn::new('salary')->setPermission('ROLE_ADMIN'));
+use Pentiminax\UX\DataTables\Attribute\AsDataTable;
+use Pentiminax\UX\DataTables\Column\TextColumn;
+use Pentiminax\UX\DataTables\Model\AbstractDataTable;
+
+#[AsDataTable(Employee::class, apiPlatform: true)]
+final class EmployeesDataTable extends AbstractDataTable
+{
+    public function configureColumns(): iterable
+    {
+        // Keep the auto-detected columns, then add the secured property yourself and guard it.
+        yield from parent::configureColumns();
+        yield TextColumn::new('salary')->setPermission('ROLE_ADMIN');
+    }
+}
 ```
 
 ## v0.84 → v0.85

--- a/docs/src/content/docs/integrations/api-platform.mdx
+++ b/docs/src/content/docs/integrations/api-platform.mdx
@@ -126,6 +126,8 @@ Column auto-detection from API Platform property metadata is also gated behind t
 #[AsDataTable(Book::class, serializationGroups: ['book:list'], apiPlatform: true)]
 ```
 
+Properties carrying `#[ApiProperty(security: …)]` are never auto-detected; declare them explicitly and use `setPermission()`.
+
 ## Frequent pitfalls
 
 - Using `#[AsDataTable(Entity::class)]` alone and expecting Ajax or columns to be auto-configured — add `apiPlatform: true`.

--- a/src/ApiPlatform/ColumnAutoDetector.php
+++ b/src/ApiPlatform/ColumnAutoDetector.php
@@ -66,6 +66,13 @@ class ColumnAutoDetector
                 continue;
             }
 
+            // Property-level API Platform security is evaluated per request by API Platform's normalizer;
+            // an auto-detected column would read the value outside that check, so the property is skipped.
+            // Declare the column explicitly with setPermission() to expose it.
+            if (null !== $propertyMetadata->getSecurity()) {
+                continue;
+            }
+
             $type         = $this->resolveType($entityClass, $propertyName);
             $label        = $this->propertyNameHumanizer->humanize($propertyName);
             $isIdentifier = true === $propertyMetadata->isIdentifier();

--- a/tests/Unit/ApiPlatform/ColumnAutoDetectorTest.php
+++ b/tests/Unit/ApiPlatform/ColumnAutoDetectorTest.php
@@ -166,6 +166,31 @@ final class ColumnAutoDetectorTest extends TestCase
     }
 
     #[Test]
+    public function it_skips_properties_protected_by_an_api_property_security_expression(): void
+    {
+        $this->givenProperties(['name', 'salary']);
+
+        $this->propertyMetadataFactory
+            ->method('create')
+            ->willReturnCallback(static function (string $class, string $property): ApiProperty {
+                $metadata = (new ApiProperty())->withReadable(true);
+
+                return 'salary' === $property
+                    ? $metadata->withSecurity("is_granted('ROLE_ADMIN')")
+                    : $metadata;
+            });
+
+        $this->propertyInfoExtractor->setTypeResolver(static fn (): ?Type => Type::string());
+
+        $columns = $this->createDetector()->detectColumns('App\Entity\Employee');
+
+        $this->assertSame(['name'], array_map(
+            static fn (ColumnInterface $column): string => $column->getName(),
+            $columns
+        ));
+    }
+
+    #[Test]
     public function it_humanizes_labels(): void
     {
         $this->givenProperties(['createdAt', 'first_name', 'id', 'userId']);


### PR DESCRIPTION
`ColumnAutoDetector::detectColumns()` filtered on `isReadable()` and, when groups were provided, on serializer groups. It never consulted `$propertyMetadata->getSecurity()`, so a property carrying `#[ApiProperty(security: "is_granted('ROLE_ADMIN')")]` became a column like any other. API Platform evaluates that expression per request inside its normalizer, while the Doctrine auto path reads the value through `PropertyReader` without crossing that check — the guarded value reached every user of the table.

Auto-detection now skips any property whose `getSecurity()` is non-null. An application that wants the column declares it explicitly and guards it with `setPermission()`. No attempt is made to translate the API Platform expression into a column permission: the two evaluation contexts differ (property value vs. table rendering), and a silent, approximate translation would be worse than an absent column. `getSecurityPostDenormalize()` is deliberately not consulted — it only applies to writes.

**Behavior change.** Per the v0.x policy there is no deprecation. A table relying on auto-detection can now be missing a column it used to render, so both `UPGRADE.md` (§ `v0.90 → v1.0`) and the API Platform integration page state it.

**Blast radius.** `detectColumns()` has a single production caller, `ColumnResolver::resolve()`, reached only for `#[AsDataTable(..., apiPlatform: true)]`. Risk low, contained to auto-detection.

**Tested.** `vendor/bin/phpunit` (1482 green, 1481 before), `composer fix` (no changes), `composer audit`, `npm run lint && npm run build` in `docs/`. The new test fails on the parent commit, confirming the finding rather than assuming it.
**Not tested.** No runtime check against a real API Platform application; the `PropertyMetadataFactoryInterface` double stands in for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
