### PR TITLE
Make server-side text search case-insensitive with a per-column opt-out

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -121,6 +121,24 @@ final class EmployeesDataTable extends AbstractDataTable
 }
 ```
 
+### Case-insensitive server-side text search
+
+Server-side text search (global search, per-column search, and the ColumnControl `contains`,
+`starts`, `ends`, and `notContains` logics) is now case-insensitive on every platform: the
+condition compares `LOWER(field)` against a lowercased term instead of using a bare `LIKE`, which
+was case-sensitive on PostgreSQL and on MySQL binary collations.
+
+Call `->setCaseSensitiveSearch()` on a column to restore the previous behavior — for instance to
+keep a `starts` search sargable on a MySQL prefix index:
+
+```php
+TextColumn::new('reference', 'Reference')
+    ->setCaseSensitiveSearch();
+```
+
+The flag lives on `AbstractColumn`; a column class implementing `ColumnInterface` directly is always
+searched case-insensitively.
+
 ## v0.84 → v0.85
 
 ### Permission configuration uses `setPermission()`

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -128,16 +128,18 @@ Server-side text search (global search, per-column search, and the ColumnControl
 condition compares `LOWER(field)` against a lowercased term instead of using a bare `LIKE`, which
 was case-sensitive on PostgreSQL and on MySQL binary collations.
 
-Call `->setCaseSensitiveSearch()` on a column to restore the previous behavior — for instance to
-keep a `starts` search sargable on a MySQL prefix index:
+Call `->setSearchNormalization(false)` on a column to restore the previous bare `LIKE` — for
+instance to keep a `starts` search sargable on a MySQL prefix index. The comparison then follows
+the column's collation, so it is case-sensitive only where the collation is:
 
 ```php
 TextColumn::new('reference', 'Reference')
-    ->setCaseSensitiveSearch();
+    ->setSearchNormalization(false);
 ```
 
-The flag lives on `AbstractColumn`; a column class implementing `ColumnInterface` directly is always
-searched case-insensitively.
+`AbstractColumn` implements the new `Contracts\NormalizedSearchColumnInterface`. A column class
+implementing `ColumnInterface` directly is normalized unless it implements that interface and
+returns `false` from `isSearchNormalized()`.
 
 ## v0.84 → v0.85
 

--- a/docs/src/content/docs/columns/overview.mdx
+++ b/docs/src/content/docs/columns/overview.mdx
@@ -74,24 +74,26 @@ $column
     ->setOrderable(false)             // Disable sorting
     ->setSearchable(false)            // Disable column search
     ->disableGlobalSearch()           // Exclude from global search
-    ->setCaseSensitiveSearch();       // Compare without LOWER() on either side
+    ->setSearchNormalization(false);  // Bare LIKE on the raw column, no LOWER()
 ```
 
-#### Case sensitivity
+#### Search normalization
 
 Server-side text search lowercases both the column and the search term, so it behaves the same on
-PostgreSQL, on MySQL, and on binary collations. `setCaseSensitiveSearch()` opts a single column out
-of that and compares the raw column instead, which is what keeps a `starts` search usable on a
-MySQL prefix index. It applies to global search, per-column search, and the ColumnControl
-`contains`, `starts`, `ends`, and `notContains` logics.
+PostgreSQL, on MySQL, and on binary collations. `setSearchNormalization(false)` opts a single
+column out of that and compares the raw column with a bare `LIKE` instead, which is what keeps a
+`starts` search usable on a MySQL prefix index. The bare `LIKE` follows the column's collation, so
+it is case-sensitive only where the collation is. It applies to global search, per-column search,
+and the ColumnControl `contains`, `starts`, `ends`, and `notContains` logics.
 
 ```php
 TextColumn::new('reference', 'Reference')
-    ->setCaseSensitiveSearch();
+    ->setSearchNormalization(false);
 ```
 
-Only columns extending `AbstractColumn` carry the flag: a class implementing `ColumnInterface`
-directly is always searched case-insensitively.
+`AbstractColumn` carries the flag. A class implementing `ColumnInterface` directly is normalized
+unless it also implements `NormalizedSearchColumnInterface` and returns `false` from
+`isSearchNormalized()`.
 
 #### Sorting on a custom expression
 

--- a/docs/src/content/docs/columns/overview.mdx
+++ b/docs/src/content/docs/columns/overview.mdx
@@ -73,8 +73,25 @@ $column
 $column
     ->setOrderable(false)             // Disable sorting
     ->setSearchable(false)            // Disable column search
-    ->disableGlobalSearch();          // Exclude from global search
+    ->disableGlobalSearch()           // Exclude from global search
+    ->setCaseSensitiveSearch();       // Compare without LOWER() on either side
 ```
+
+#### Case sensitivity
+
+Server-side text search lowercases both the column and the search term, so it behaves the same on
+PostgreSQL, on MySQL, and on binary collations. `setCaseSensitiveSearch()` opts a single column out
+of that and compares the raw column instead, which is what keeps a `starts` search usable on a
+MySQL prefix index. It applies to global search, per-column search, and the ColumnControl
+`contains`, `starts`, `ends`, and `notContains` logics.
+
+```php
+TextColumn::new('reference', 'Reference')
+    ->setCaseSensitiveSearch();
+```
+
+Only columns extending `AbstractColumn` carry the flag: a class implementing `ColumnInterface`
+directly is always searched case-insensitively.
 
 #### Sorting on a custom expression
 

--- a/docs/src/content/docs/reference/search-strategies.mdx
+++ b/docs/src/content/docs/reference/search-strategies.mdx
@@ -76,6 +76,26 @@ one class per operator: the enum supplies the SQL operator, the parameter wrappi
 whether the logic is expressed with `LIKE`. Constructing it with a logic it cannot express — such as
 `ColumnControlLogic::Empty` — throws an `InvalidArgumentException`.
 
+### Case sensitivity
+
+Every shipped `LIKE` logic — `contains`, `starts`, `ends`, `notContains` — is case-insensitive:
+the condition is built as `LOWER(field) LIKE :param` and the bound term is lowercased with
+`mb_strtolower()`. A bare `LIKE` is case-sensitive on PostgreSQL and on MySQL binary collations,
+so without this the same table answered differently depending on the database.
+
+`LOWER()` on the column also prevents the database from using a plain index on it. When that
+matters — a `starts` search on a large MySQL table with a prefix index, on values whose case is
+already known — opt the column out:
+
+```php
+TextColumn::new('reference', 'Reference')
+    ->setCaseSensitiveSearch();
+```
+
+The flag lives on `AbstractColumn`, so a column class implementing `ColumnInterface` directly is
+always searched case-insensitively. `setSearchPredicate()` stays the escape hatch for anything
+neither mode expresses.
+
 <Aside type="note">
   `ColumnControlLogic::In` has no dedicated strategy. ColumnControl list selections
   (`searchList`) are applied by `ColumnControlSearchFilter` through an explicit `IN` branch, which
@@ -100,10 +120,10 @@ use Pentiminax\UX\DataTables\Query\LikeValueEscaper;
 use Pentiminax\UX\DataTables\Query\RelationFieldResolver;
 
 /**
- * Case-insensitive "starts with": the shipped `starts` logic compares with a plain LIKE, which is
- * case-sensitive on MySQL binary collations and on PostgreSQL.
+ * Word-prefix "starts with": the shipped `starts` logic anchors on the beginning of the value,
+ * so searching "doe" never matches "John Doe". This one also matches the start of any word.
  */
-final class CaseInsensitiveStartsSearchStrategy implements SearchStrategyInterface
+final class WordPrefixStartsSearchStrategy implements SearchStrategyInterface
 {
     public function apply(
         QueryBuilder $qb,
@@ -126,17 +146,27 @@ final class CaseInsensitiveStartsSearchStrategy implements SearchStrategyInterfa
         // for a column without the search contract.
         RelationFieldResolver::applySearchJoins($qb, $column);
 
-        // LOWER() on a uuid or a datetime column is rejected by strict engines.
+        // LOWER() and LIKE on a uuid or a datetime column are rejected by strict engines.
         if (!RelationFieldResolver::supportsTextSearch($qb, $fieldPath)) {
             return;
         }
 
         $field = RelationFieldResolver::resolve($qb, $alias, $fieldPath);
-        $paramName = sprintf('starts_ci_%d', $paramIndex);
+        $prefix = sprintf('word_prefix_%d', $paramIndex);
+        $anywhere = sprintf('word_anywhere_%d', $paramIndex);
+        $escaped = LikeValueEscaper::escape(mb_strtolower($value));
+        $escape = LikeValueEscaper::ESCAPE_CHARACTER;
 
         $qb
-            ->andWhere(sprintf("LOWER(%s) LIKE :%s ESCAPE '%s'", $field, $paramName, LikeValueEscaper::ESCAPE_CHARACTER))
-            ->setParameter($paramName, strtolower(LikeValueEscaper::escape($value)).'%');
+            ->andWhere(sprintf(
+                "(LOWER(%1\$s) LIKE :%2\$s ESCAPE '%4\$s' OR LOWER(%1\$s) LIKE :%3\$s ESCAPE '%4\$s')",
+                $field,
+                $prefix,
+                $anywhere,
+                $escape,
+            ))
+            ->setParameter($prefix, $escaped.'%')
+            ->setParameter($anywhere, '% '.$escaped.'%');
     }
 
     public function getLogic(): string
@@ -153,7 +183,7 @@ use Pentiminax\UX\DataTables\Query\Strategy\SearchStrategyRegistry;
 protected function createSearchStrategyRegistry(): SearchStrategyRegistry
 {
     $registry = new DefaultSearchStrategyRegistry();
-    $registry->register(new CaseInsensitiveStartsSearchStrategy());
+    $registry->register(new WordPrefixStartsSearchStrategy());
 
     return $registry;
 }
@@ -209,7 +239,7 @@ type:
 | numeric (or `$forceNumeric`) | exact match when the term is numeric, `null` otherwise             |
 | date                         | `null` — a partial date term has no meaningful `LIKE`              |
 | native UUID / ULID           | exact match when the term is a well-formed identifier of that type |
-| anything else                | `LIKE %term%` when the field supports text search                  |
+| anything else                | `LOWER(field) LIKE %term%` when the field supports text search      |
 
 `$field` is resolved by the caller through `RelationFieldResolver::resolveSearchField()` before the
 builder is reached, so a `setSearchField()` override and any `addSearchJoin()` are already in

--- a/docs/src/content/docs/reference/search-strategies.mdx
+++ b/docs/src/content/docs/reference/search-strategies.mdx
@@ -76,7 +76,7 @@ one class per operator: the enum supplies the SQL operator, the parameter wrappi
 whether the logic is expressed with `LIKE`. Constructing it with a logic it cannot express — such as
 `ColumnControlLogic::Empty` — throws an `InvalidArgumentException`.
 
-### Case sensitivity
+### Search normalization
 
 Every shipped `LIKE` logic — `contains`, `starts`, `ends`, `notContains` — is case-insensitive:
 the condition is built as `LOWER(field) LIKE :param` and the bound term is lowercased with
@@ -89,16 +89,17 @@ already known — opt the column out:
 
 ```php
 TextColumn::new('reference', 'Reference')
-    ->setCaseSensitiveSearch();
+    ->setSearchNormalization(false);
 ```
 
 Opting out restores a bare `LIKE`, which follows the column's collation: case-sensitive on
 PostgreSQL and on binary collations, still case-insensitive on a `_ci` MySQL collation. The flag
 trades the guaranteed behavior for index usage; it does not force case sensitivity.
 
-The flag lives on `AbstractColumn`, so a column class implementing `ColumnInterface` directly is
-always searched case-insensitively. `setSearchPredicate()` stays the escape hatch for anything
-neither mode expresses.
+`AbstractColumn` implements `NormalizedSearchColumnInterface` and exposes it as
+`setSearchNormalization()`. A column class implementing `ColumnInterface` directly can implement
+that interface to make the same choice; otherwise it is normalized. `setSearchPredicate()` stays
+the escape hatch for anything neither mode expresses.
 
 <Aside type="note">
   `ColumnControlLogic::In` has no dedicated strategy. ColumnControl list selections

--- a/docs/src/content/docs/reference/search-strategies.mdx
+++ b/docs/src/content/docs/reference/search-strategies.mdx
@@ -92,6 +92,10 @@ TextColumn::new('reference', 'Reference')
     ->setCaseSensitiveSearch();
 ```
 
+Opting out restores a bare `LIKE`, which follows the column's collation: case-sensitive on
+PostgreSQL and on binary collations, still case-insensitive on a `_ci` MySQL collation. The flag
+trades the guaranteed behavior for index usage; it does not force case sensitivity.
+
 The flag lives on `AbstractColumn`, so a column class implementing `ColumnInterface` directly is
 always searched case-insensitively. `setSearchPredicate()` stays the escape hatch for anything
 neither mode expresses.

--- a/src/Column/AbstractColumn.php
+++ b/src/Column/AbstractColumn.php
@@ -128,12 +128,14 @@ abstract class AbstractColumn implements SearchableColumnInterface
     }
 
     /**
-     * Make server-side text search on this column case-sensitive.
+     * Let server-side text search on this column follow the database collation.
      *
      * Server-side LIKE searches lowercase both the column and the term by default, which makes
      * them case-insensitive on every platform but prevents the database from using a plain
      * index on the column. Opt out when a "starts with" search must stay sargable on a MySQL
-     * prefix index and the stored values already have a known case.
+     * prefix index and the stored values already have a known case. The bare LIKE is then
+     * case-sensitive on PostgreSQL and binary collations only; a case-insensitive MySQL
+     * collation keeps matching regardless of case.
      *
      * Only columns extending {@see AbstractColumn} carry this flag: a column implementing
      * {@see ColumnInterface} directly is always searched case-insensitively.

--- a/src/Column/AbstractColumn.php
+++ b/src/Column/AbstractColumn.php
@@ -6,6 +6,7 @@ namespace Pentiminax\UX\DataTables\Column;
 
 use Doctrine\ORM\QueryBuilder;
 use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
+use Pentiminax\UX\DataTables\Contracts\NormalizedSearchColumnInterface;
 use Pentiminax\UX\DataTables\Contracts\SearchableColumnInterface;
 use Pentiminax\UX\DataTables\Enum\ColumnType;
 use Symfony\Component\ExpressionLanguage\Expression;
@@ -22,7 +23,7 @@ use Symfony\Component\ExpressionLanguage\Expression;
  * column — see the "Columns" documentation for usage. Only createWithType() below is genuinely
  * internal, restricted to how the bundled column types build themselves.
  */
-abstract class AbstractColumn implements SearchableColumnInterface
+abstract class AbstractColumn implements SearchableColumnInterface, NormalizedSearchColumnInterface
 {
     protected ColumnType $type;
     protected ?string $cellType                  = null;
@@ -45,7 +46,7 @@ abstract class AbstractColumn implements SearchableColumnInterface
     protected array $customOptions               = [];
     protected string|Expression|null $permission = null;
     protected ?int $responsivePriority           = null;
-    protected bool $caseSensitiveSearch          = false;
+    protected bool $searchNormalized             = true;
 
     /** @var list<array{join: string, alias: string, conditionType: ?string, condition: ?string}> */
     protected array $searchJoins = [];
@@ -128,28 +129,24 @@ abstract class AbstractColumn implements SearchableColumnInterface
     }
 
     /**
-     * Let server-side text search on this column follow the database collation.
+     * Whether server-side LIKE searches on this column lowercase both sides.
      *
-     * Server-side LIKE searches lowercase both the column and the term by default, which makes
-     * them case-insensitive on every platform but prevents the database from using a plain
-     * index on the column. Opt out when a "starts with" search must stay sargable on a MySQL
-     * prefix index and the stored values already have a known case. The bare LIKE is then
-     * case-sensitive on PostgreSQL and binary collations only; a case-insensitive MySQL
-     * collation keeps matching regardless of case.
-     *
-     * Only columns extending {@see AbstractColumn} carry this flag: a column implementing
-     * {@see ColumnInterface} directly is always searched case-insensitively.
+     * Normalized (the default), a search behaves the same on every platform, but LOWER() on the
+     * column prevents the database from using a plain index on it. Pass false when a "starts
+     * with" search must stay sargable on a MySQL prefix index and the stored values already have
+     * a known case. The bare LIKE then follows the column's collation: case-sensitive on
+     * PostgreSQL and binary collations, still case-insensitive on a `_ci` MySQL collation.
      */
-    public function setCaseSensitiveSearch(bool $caseSensitive = true): static
+    public function setSearchNormalization(bool $normalized = true): static
     {
-        $this->caseSensitiveSearch = $caseSensitive;
+        $this->searchNormalized = $normalized;
 
         return $this;
     }
 
-    public function isCaseSensitiveSearch(): bool
+    public function isSearchNormalized(): bool
     {
-        return $this->caseSensitiveSearch;
+        return $this->searchNormalized;
     }
 
     public function isGlobalSearchable(): bool

--- a/src/Column/AbstractColumn.php
+++ b/src/Column/AbstractColumn.php
@@ -45,6 +45,7 @@ abstract class AbstractColumn implements SearchableColumnInterface
     protected array $customOptions               = [];
     protected string|Expression|null $permission = null;
     protected ?int $responsivePriority           = null;
+    protected bool $caseSensitiveSearch          = false;
 
     /** @var list<array{join: string, alias: string, conditionType: ?string, condition: ?string}> */
     protected array $searchJoins = [];
@@ -124,6 +125,29 @@ abstract class AbstractColumn implements SearchableColumnInterface
     public function isSearchable(): bool
     {
         return $this->searchable;
+    }
+
+    /**
+     * Make server-side text search on this column case-sensitive.
+     *
+     * Server-side LIKE searches lowercase both the column and the term by default, which makes
+     * them case-insensitive on every platform but prevents the database from using a plain
+     * index on the column. Opt out when a "starts with" search must stay sargable on a MySQL
+     * prefix index and the stored values already have a known case.
+     *
+     * Only columns extending {@see AbstractColumn} carry this flag: a column implementing
+     * {@see ColumnInterface} directly is always searched case-insensitively.
+     */
+    public function setCaseSensitiveSearch(bool $caseSensitive = true): static
+    {
+        $this->caseSensitiveSearch = $caseSensitive;
+
+        return $this;
+    }
+
+    public function isCaseSensitiveSearch(): bool
+    {
+        return $this->caseSensitiveSearch;
     }
 
     public function isGlobalSearchable(): bool

--- a/src/Contracts/NormalizedSearchColumnInterface.php
+++ b/src/Contracts/NormalizedSearchColumnInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Contracts;
+
+/**
+ * A column that decides whether server-side LIKE searches normalize case.
+ *
+ * By default the query pipeline compares LOWER(field) against a lowercased term, so a search
+ * behaves the same on PostgreSQL, on MySQL, and on binary collations. Returning false restores a
+ * bare LIKE on the raw column: the comparison then follows the column's collation, and a plain
+ * or prefix index on the column stays usable.
+ *
+ * {@see \Pentiminax\UX\DataTables\Column\AbstractColumn} implements this and exposes it as
+ * setSearchNormalization(). A column implementing ColumnInterface directly is normalized unless it
+ * implements this interface too.
+ */
+interface NormalizedSearchColumnInterface extends ColumnInterface
+{
+    public function isSearchNormalized(): bool;
+}

--- a/src/Query/DefaultSearchPredicateBuilder.php
+++ b/src/Query/DefaultSearchPredicateBuilder.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Pentiminax\UX\DataTables\Query;
 
 use Doctrine\ORM\QueryBuilder;
-use Pentiminax\UX\DataTables\Column\AbstractColumn;
 use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
+use Pentiminax\UX\DataTables\Contracts\NormalizedSearchColumnInterface;
 use Pentiminax\UX\DataTables\Contracts\SearchableColumnInterface;
 use Pentiminax\UX\DataTables\Contracts\SearchPredicateBuilderInterface;
 
@@ -31,8 +31,8 @@ use Pentiminax\UX\DataTables\Contracts\SearchPredicateBuilderInterface;
  * For native UUID/ULID columns: exact match when the value is a well-formed identifier of
  * that field's type, null otherwise.
  * For other columns: LIKE %value% when the field supports search filtering, null otherwise. That
- * LIKE is case-insensitive unless the column opts out with
- * {@see AbstractColumn::setCaseSensitiveSearch()}.
+ * LIKE is case-insensitive unless the column opts out through
+ * {@see NormalizedSearchColumnInterface}.
  *
  * A column is treated as numeric when {@see ColumnInterface::isNumber()} is true or when
  * the caller forces numeric handling via $forceNumeric (e.g. based on an external type hint).
@@ -80,7 +80,7 @@ final class DefaultSearchPredicateBuilder implements SearchPredicateBuilderInter
             return null;
         }
 
-        return SearchConditionBuilder::text($qb, $alias, $field, $value, $paramName, $column instanceof AbstractColumn && $column->isCaseSensitiveSearch());
+        return SearchConditionBuilder::text($qb, $alias, $field, $value, $paramName, !$column instanceof NormalizedSearchColumnInterface || $column->isSearchNormalized());
     }
 
     /**

--- a/src/Query/DefaultSearchPredicateBuilder.php
+++ b/src/Query/DefaultSearchPredicateBuilder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pentiminax\UX\DataTables\Query;
 
 use Doctrine\ORM\QueryBuilder;
+use Pentiminax\UX\DataTables\Column\AbstractColumn;
 use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
 use Pentiminax\UX\DataTables\Contracts\SearchableColumnInterface;
 use Pentiminax\UX\DataTables\Contracts\SearchPredicateBuilderInterface;
@@ -29,7 +30,9 @@ use Pentiminax\UX\DataTables\Contracts\SearchPredicateBuilderInterface;
  * every other column in a global search — when the term happens to be numeric.
  * For native UUID/ULID columns: exact match when the value is a well-formed identifier of
  * that field's type, null otherwise.
- * For other columns: LIKE %value% when the field supports search filtering, null otherwise.
+ * For other columns: LIKE %value% when the field supports search filtering, null otherwise. That
+ * LIKE is case-insensitive unless the column opts out with
+ * {@see AbstractColumn::setCaseSensitiveSearch()}.
  *
  * A column is treated as numeric when {@see ColumnInterface::isNumber()} is true or when
  * the caller forces numeric handling via $forceNumeric (e.g. based on an external type hint).
@@ -77,7 +80,7 @@ final class DefaultSearchPredicateBuilder implements SearchPredicateBuilderInter
             return null;
         }
 
-        return SearchConditionBuilder::text($qb, $alias, $field, $value, $paramName);
+        return SearchConditionBuilder::text($qb, $alias, $field, $value, $paramName, $column instanceof AbstractColumn && $column->isCaseSensitiveSearch());
     }
 
     /**

--- a/src/Query/SearchConditionBuilder.php
+++ b/src/Query/SearchConditionBuilder.php
@@ -22,8 +22,9 @@ final class SearchConditionBuilder
      *
      * Both sides are lowercased by default, because a bare LIKE is case-sensitive on
      * PostgreSQL and on binary MySQL collations. $caseSensitive keeps the raw column in the
-     * condition so a prefix index stays usable — see
-     * {@see \Pentiminax\UX\DataTables\Column\AbstractColumn::setCaseSensitiveSearch()}.
+     * condition so a prefix index stays usable; the comparison then follows the column's
+     * collation, which on a case-insensitive MySQL collation still matches regardless of case —
+     * see {@see \Pentiminax\UX\DataTables\Column\AbstractColumn::setCaseSensitiveSearch()}.
      */
     public static function text(QueryBuilder $qb, string $alias, string $fieldPath, string $value, string $paramName, bool $caseSensitive = false): string
     {

--- a/src/Query/SearchConditionBuilder.php
+++ b/src/Query/SearchConditionBuilder.php
@@ -19,13 +19,22 @@ final class SearchConditionBuilder
      * $value is escaped so a literal `%` or `_` in the search term is matched literally
      * rather than treated as a wildcard; the ESCAPE clause is what makes the database honor
      * that escaping — see {@see LikeValueEscaper}.
+     *
+     * Both sides are lowercased by default, because a bare LIKE is case-sensitive on
+     * PostgreSQL and on binary MySQL collations. $caseSensitive keeps the raw column in the
+     * condition so a prefix index stays usable — see
+     * {@see \Pentiminax\UX\DataTables\Column\AbstractColumn::setCaseSensitiveSearch()}.
      */
-    public static function text(QueryBuilder $qb, string $alias, string $fieldPath, string $value, string $paramName): string
+    public static function text(QueryBuilder $qb, string $alias, string $fieldPath, string $value, string $paramName, bool $caseSensitive = false): string
     {
-        $field = RelationFieldResolver::resolve($qb, $alias, $fieldPath);
-        $qb->setParameter($paramName, \sprintf('%%%s%%', LikeValueEscaper::escape($value)));
+        $field  = RelationFieldResolver::resolve($qb, $alias, $fieldPath);
+        $needle = $caseSensitive ? $value : mb_strtolower($value);
 
-        return \sprintf("%s LIKE :%s ESCAPE '%s'", $field, $paramName, LikeValueEscaper::ESCAPE_CHARACTER);
+        $qb->setParameter($paramName, \sprintf('%%%s%%', LikeValueEscaper::escape($needle)));
+
+        $expr = $caseSensitive ? $field : \sprintf('LOWER(%s)', $field);
+
+        return \sprintf("%s LIKE :%s ESCAPE '%s'", $expr, $paramName, LikeValueEscaper::ESCAPE_CHARACTER);
     }
 
     /**

--- a/src/Query/SearchConditionBuilder.php
+++ b/src/Query/SearchConditionBuilder.php
@@ -21,19 +21,18 @@ final class SearchConditionBuilder
      * that escaping — see {@see LikeValueEscaper}.
      *
      * Both sides are lowercased by default, because a bare LIKE is case-sensitive on
-     * PostgreSQL and on binary MySQL collations. $caseSensitive keeps the raw column in the
+     * PostgreSQL and on binary MySQL collations. $normalize = false keeps the raw column in the
      * condition so a prefix index stays usable; the comparison then follows the column's
-     * collation, which on a case-insensitive MySQL collation still matches regardless of case —
-     * see {@see \Pentiminax\UX\DataTables\Column\AbstractColumn::setCaseSensitiveSearch()}.
+     * collation — see {@see \Pentiminax\UX\DataTables\Contracts\NormalizedSearchColumnInterface}.
      */
-    public static function text(QueryBuilder $qb, string $alias, string $fieldPath, string $value, string $paramName, bool $caseSensitive = false): string
+    public static function text(QueryBuilder $qb, string $alias, string $fieldPath, string $value, string $paramName, bool $normalize = true): string
     {
         $field  = RelationFieldResolver::resolve($qb, $alias, $fieldPath);
-        $needle = $caseSensitive ? $value : mb_strtolower($value);
+        $needle = $normalize ? mb_strtolower($value) : $value;
 
         $qb->setParameter($paramName, \sprintf('%%%s%%', LikeValueEscaper::escape($needle)));
 
-        $expr = $caseSensitive ? $field : \sprintf('LOWER(%s)', $field);
+        $expr = $normalize ? \sprintf('LOWER(%s)', $field) : $field;
 
         return \sprintf("%s LIKE :%s ESCAPE '%s'", $expr, $paramName, LikeValueEscaper::ESCAPE_CHARACTER);
     }

--- a/src/Query/Strategy/ComparisonSearchStrategy.php
+++ b/src/Query/Strategy/ComparisonSearchStrategy.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Pentiminax\UX\DataTables\Query\Strategy;
 
 use Doctrine\ORM\QueryBuilder;
-use Pentiminax\UX\DataTables\Column\AbstractColumn;
 use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
+use Pentiminax\UX\DataTables\Contracts\NormalizedSearchColumnInterface;
 use Pentiminax\UX\DataTables\Contracts\SearchableColumnInterface;
 use Pentiminax\UX\DataTables\Contracts\SearchStrategyInterface;
 use Pentiminax\UX\DataTables\DataTableRequest\ColumnControlSearch;
@@ -34,7 +34,7 @@ use Pentiminax\UX\DataTables\Query\UuidSearchTerm;
  * that builds its own predicate stays searchable on the Contains logic.
  *
  * The LIKE logics (StartsWith, EndsWith, NotContains) lowercase both the column and the term
- * unless the column opts out with {@see AbstractColumn::setCaseSensitiveSearch()}.
+ * unless the column opts out through {@see NormalizedSearchColumnInterface}.
  */
 final class ComparisonSearchStrategy implements SearchStrategyInterface
 {
@@ -78,9 +78,9 @@ final class ComparisonSearchStrategy implements SearchStrategyInterface
         $field     = RelationFieldResolver::resolve($qb, $alias, $fieldPath);
         $paramName = \sprintf('column_control_param_%d', $paramIndex);
 
-        $caseSensitive = $column instanceof AbstractColumn && $column->isCaseSensitiveSearch();
+        $normalize = !$column instanceof NormalizedSearchColumnInterface || $column->isSearchNormalized();
 
-        if ($usesLike && !$caseSensitive && \is_string($bindValue)) {
+        if ($usesLike && $normalize && \is_string($bindValue)) {
             $field     = \sprintf('LOWER(%s)', $field);
             $bindValue = mb_strtolower($bindValue);
         }

--- a/src/Query/Strategy/ComparisonSearchStrategy.php
+++ b/src/Query/Strategy/ComparisonSearchStrategy.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pentiminax\UX\DataTables\Query\Strategy;
 
 use Doctrine\ORM\QueryBuilder;
+use Pentiminax\UX\DataTables\Column\AbstractColumn;
 use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
 use Pentiminax\UX\DataTables\Contracts\SearchableColumnInterface;
 use Pentiminax\UX\DataTables\Contracts\SearchStrategyInterface;
@@ -31,6 +32,9 @@ use Pentiminax\UX\DataTables\Query\UuidSearchTerm;
  *
  * A field the root entity does not map is skipped here rather than in the filter, so a column
  * that builds its own predicate stays searchable on the Contains logic.
+ *
+ * The LIKE logics (StartsWith, EndsWith, NotContains) lowercase both the column and the term
+ * unless the column opts out with {@see AbstractColumn::setCaseSensitiveSearch()}.
  */
 final class ComparisonSearchStrategy implements SearchStrategyInterface
 {
@@ -73,6 +77,13 @@ final class ComparisonSearchStrategy implements SearchStrategyInterface
 
         $field     = RelationFieldResolver::resolve($qb, $alias, $fieldPath);
         $paramName = \sprintf('column_control_param_%d', $paramIndex);
+
+        $caseSensitive = $column instanceof AbstractColumn && $column->isCaseSensitiveSearch();
+
+        if ($usesLike && !$caseSensitive && \is_string($bindValue)) {
+            $field     = \sprintf('LOWER(%s)', $field);
+            $bindValue = mb_strtolower($bindValue);
+        }
 
         $condition = \sprintf('%s %s :%s', $field, $this->logic->operator(), $paramName);
         if ($usesLike) {

--- a/src/Query/Strategy/ContainsSearchStrategy.php
+++ b/src/Query/Strategy/ContainsSearchStrategy.php
@@ -16,7 +16,9 @@ use Pentiminax\UX\DataTables\Query\RelationFieldResolver;
 /**
  * Strategy for 'contains' search logic.
  *
- * Performs a case-sensitive substring search using SQL LIKE %value%.
+ * Performs a case-insensitive substring search using SQL LIKE %value% (LOWER() on both sides),
+ * unless the column opts out with
+ * {@see \Pentiminax\UX\DataTables\Column\AbstractColumn::setCaseSensitiveSearch()}.
  * For numeric columns, performs exact match if the value is numeric.
  *
  * Predicate construction is delegated to {@see SearchPredicateBuilderInterface} so the

--- a/src/Query/Strategy/ContainsSearchStrategy.php
+++ b/src/Query/Strategy/ContainsSearchStrategy.php
@@ -17,8 +17,8 @@ use Pentiminax\UX\DataTables\Query\RelationFieldResolver;
  * Strategy for 'contains' search logic.
  *
  * Performs a case-insensitive substring search using SQL LIKE %value% (LOWER() on both sides),
- * unless the column opts out with
- * {@see \Pentiminax\UX\DataTables\Column\AbstractColumn::setCaseSensitiveSearch()}.
+ * unless the column opts out through
+ * {@see \Pentiminax\UX\DataTables\Contracts\NormalizedSearchColumnInterface}.
  * For numeric columns, performs exact match if the value is numeric.
  *
  * Predicate construction is delegated to {@see SearchPredicateBuilderInterface} so the

--- a/tests/Unit/Column/AbstractColumnTest.php
+++ b/tests/Unit/Column/AbstractColumnTest.php
@@ -75,6 +75,22 @@ final class AbstractColumnTest extends TestCase
     }
 
     #[Test]
+    public function it_searches_case_insensitively_unless_the_column_opts_out(): void
+    {
+        $column = (new class extends AbstractColumn {})
+            ->setType(ColumnType::STRING)
+            ->setName('name');
+
+        $this->assertFalse($column->isCaseSensitiveSearch());
+
+        $this->assertSame($column, $column->setCaseSensitiveSearch());
+        $this->assertTrue($column->isCaseSensitiveSearch());
+
+        $this->assertSame($column, $column->setCaseSensitiveSearch(false));
+        $this->assertFalse($column->isCaseSensitiveSearch());
+    }
+
+    #[Test]
     public function it_overrides_column_control_content_for_a_single_column(): void
     {
         $column = (new class extends AbstractColumn {})

--- a/tests/Unit/Column/AbstractColumnTest.php
+++ b/tests/Unit/Column/AbstractColumnTest.php
@@ -75,19 +75,19 @@ final class AbstractColumnTest extends TestCase
     }
 
     #[Test]
-    public function it_searches_case_insensitively_unless_the_column_opts_out(): void
+    public function it_normalizes_search_unless_the_column_opts_out(): void
     {
         $column = (new class extends AbstractColumn {})
             ->setType(ColumnType::STRING)
             ->setName('name');
 
-        $this->assertFalse($column->isCaseSensitiveSearch());
+        $this->assertTrue($column->isSearchNormalized());
 
-        $this->assertSame($column, $column->setCaseSensitiveSearch());
-        $this->assertTrue($column->isCaseSensitiveSearch());
+        $this->assertSame($column, $column->setSearchNormalization(false));
+        $this->assertFalse($column->isSearchNormalized());
 
-        $this->assertSame($column, $column->setCaseSensitiveSearch(false));
-        $this->assertFalse($column->isCaseSensitiveSearch());
+        $this->assertSame($column, $column->setSearchNormalization());
+        $this->assertTrue($column->isSearchNormalized());
     }
 
     #[Test]

--- a/tests/Unit/Query/DefaultSearchPredicateBuilderTest.php
+++ b/tests/Unit/Query/DefaultSearchPredicateBuilderTest.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\QueryBuilder;
 use Pentiminax\UX\DataTables\Column\NumberColumn;
 use Pentiminax\UX\DataTables\Column\TextColumn;
 use Pentiminax\UX\DataTables\Contracts\ColumnInterface;
+use Pentiminax\UX\DataTables\Contracts\NormalizedSearchColumnInterface;
 use Pentiminax\UX\DataTables\Query\DefaultSearchPredicateBuilder;
 use Pentiminax\UX\DataTables\Tests\Support\BuildsTypedFieldQueryBuilder;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -55,7 +56,7 @@ final class DefaultSearchPredicateBuilderTest extends TestCase
         ];
 
         yield 'text column opting out of case-insensitive search' => [
-            TextColumn::new('name', 'Name')->setField('name')->setCaseSensitiveSearch(),
+            TextColumn::new('name', 'Name')->setField('name')->setSearchNormalization(false),
             null,
             'Hello',
             false,
@@ -296,6 +297,26 @@ final class DefaultSearchPredicateBuilderTest extends TestCase
         $result = (new DefaultSearchPredicateBuilder())->build($qb, $column, 'e', $field, $value, 'p_0', $forceNumeric);
 
         $this->assertSame($expectedCondition, $result);
+    }
+
+    /**
+     * A column implementing ColumnInterface directly is not an AbstractColumn, so the opt-out has
+     * to be readable through the contract for third-party columns to keep an index-usable LIKE.
+     */
+    #[Test]
+    public function it_lets_a_direct_column_implementation_opt_out_through_the_contract(): void
+    {
+        $column = $this->createMock(NormalizedSearchColumnInterface::class);
+        $column->method('getField')->willReturn('name');
+        $column->method('isNumber')->willReturn(false);
+        $column->method('isSearchNormalized')->willReturn(false);
+
+        $qb = $this->queryBuilderWithFieldType('name', null);
+        $qb->expects($this->once())->method('setParameter')->with('p_0', '%Hello%');
+
+        $result = (new DefaultSearchPredicateBuilder())->build($qb, $column, 'e', 'name', 'Hello', 'p_0', false);
+
+        $this->assertSame("e.name LIKE :p_0 ESCAPE '!'", $result);
     }
 
     #[Test]

--- a/tests/Unit/Query/DefaultSearchPredicateBuilderTest.php
+++ b/tests/Unit/Query/DefaultSearchPredicateBuilderTest.php
@@ -41,7 +41,7 @@ final class DefaultSearchPredicateBuilderTest extends TestCase
             null,
             'hello',
             false,
-            "e.name LIKE :p_0 ESCAPE '!'",
+            "LOWER(e.name) LIKE :p_0 ESCAPE '!'",
             ['p_0', '%hello%'],
         ];
 
@@ -50,8 +50,17 @@ final class DefaultSearchPredicateBuilderTest extends TestCase
             null,
             '50%_off',
             false,
-            "e.name LIKE :p_0 ESCAPE '!'",
+            "LOWER(e.name) LIKE :p_0 ESCAPE '!'",
             ['p_0', '%50!%!_off%'],
+        ];
+
+        yield 'text column opting out of case-insensitive search' => [
+            TextColumn::new('name', 'Name')->setField('name')->setCaseSensitiveSearch(),
+            null,
+            'Hello',
+            false,
+            "e.name LIKE :p_0 ESCAPE '!'",
+            ['p_0', '%Hello%'],
         ];
 
         yield 'numeric column with numeric value' => [
@@ -385,6 +394,6 @@ final class DefaultSearchPredicateBuilderTest extends TestCase
 
         $result = (new DefaultSearchPredicateBuilder())->build($qb, $column, 'e', 'name', 'acme', 'p_0');
 
-        $this->assertSame("e.name LIKE :p_0 ESCAPE '!'", $result);
+        $this->assertSame("LOWER(e.name) LIKE :p_0 ESCAPE '!'", $result);
     }
 }

--- a/tests/Unit/Query/Filter/ColumnSearchFilterTest.php
+++ b/tests/Unit/Query/Filter/ColumnSearchFilterTest.php
@@ -43,7 +43,7 @@ final class ColumnSearchFilterTest extends TestCase
 
         $qb->expects($this->once())
             ->method('andWhere')
-            ->with("e.name LIKE :column_control_param_0 ESCAPE '!'");
+            ->with("LOWER(e.name) LIKE :column_control_param_0 ESCAPE '!'");
 
         $context = $this->singleColumnContext(TextColumn::new('name', 'Name')->setField('name'), new Search('ali', false));
 
@@ -58,7 +58,7 @@ final class ColumnSearchFilterTest extends TestCase
         yield 'text field' => [
             TextColumn::new('name', 'Name')->setField('name'),
             'test',
-            "e.name LIKE :column_control_param_0 ESCAPE '!'",
+            "LOWER(e.name) LIKE :column_control_param_0 ESCAPE '!'",
             '%test%',
             null,
         ];
@@ -66,7 +66,7 @@ final class ColumnSearchFilterTest extends TestCase
         yield 'text field with like wildcards is escaped, not interpreted' => [
             TextColumn::new('name', 'Name')->setField('name'),
             '50%_off',
-            "e.name LIKE :column_control_param_0 ESCAPE '!'",
+            "LOWER(e.name) LIKE :column_control_param_0 ESCAPE '!'",
             '%50!%!_off%',
             null,
         ];
@@ -82,7 +82,7 @@ final class ColumnSearchFilterTest extends TestCase
         yield 'dot notation field' => [
             TextColumn::new('authorName', 'Author')->setField('author.firstName'),
             'john',
-            "author.firstName LIKE :column_control_param_0 ESCAPE '!'",
+            "LOWER(author.firstName) LIKE :column_control_param_0 ESCAPE '!'",
             '%john%',
             ['e.author', 'author'],
         ];
@@ -203,7 +203,7 @@ final class ColumnSearchFilterTest extends TestCase
 
         $qb->expects($this->once())
             ->method('andWhere')
-            ->with("e.name LIKE :column_control_param_0 ESCAPE '!'");
+            ->with("LOWER(e.name) LIKE :column_control_param_0 ESCAPE '!'");
 
         $qb->expects($this->once())
             ->method('setParameter')
@@ -259,8 +259,8 @@ final class ColumnSearchFilterTest extends TestCase
         $this->filter()->apply($qb, $context);
 
         self::assertSame([
-            "e.name LIKE :column_control_param_0 ESCAPE '!'",
-            "e.email LIKE :column_control_param_1 ESCAPE '!'",
+            "LOWER(e.name) LIKE :column_control_param_0 ESCAPE '!'",
+            "LOWER(e.email) LIKE :column_control_param_1 ESCAPE '!'",
         ], $conditions);
 
         self::assertSame([
@@ -304,7 +304,7 @@ final class ColumnSearchFilterTest extends TestCase
 
         $qb->expects($this->once())
             ->method('andWhere')
-            ->with("dp.name LIKE :column_control_param_0 ESCAPE '!'")
+            ->with("LOWER(dp.name) LIKE :column_control_param_0 ESCAPE '!'")
             ->willReturn($qb);
 
         $qb->expects($this->once())

--- a/tests/Unit/Query/Filter/GlobalSearchFilterTest.php
+++ b/tests/Unit/Query/Filter/GlobalSearchFilterTest.php
@@ -66,7 +66,7 @@ final class GlobalSearchFilterTest extends TestCase
         yield 'simple field' => [
             TextColumn::new('name', 'Name')->setField('name'),
             'test',
-            "e.name LIKE :search_param_0 ESCAPE '!'",
+            "LOWER(e.name) LIKE :search_param_0 ESCAPE '!'",
             '%test%',
             null,
         ];
@@ -74,7 +74,7 @@ final class GlobalSearchFilterTest extends TestCase
         yield 'field with like wildcards is escaped, not interpreted' => [
             TextColumn::new('name', 'Name')->setField('name'),
             '50%_off',
-            "e.name LIKE :search_param_0 ESCAPE '!'",
+            "LOWER(e.name) LIKE :search_param_0 ESCAPE '!'",
             '%50!%!_off%',
             null,
         ];
@@ -82,7 +82,7 @@ final class GlobalSearchFilterTest extends TestCase
         yield 'dot notation field' => [
             TextColumn::new('authorName', 'Author')->setField('author.firstName'),
             'john',
-            "author.firstName LIKE :search_param_0 ESCAPE '!'",
+            "LOWER(author.firstName) LIKE :search_param_0 ESCAPE '!'",
             '%john%',
             ['e.author', 'author'],
         ];
@@ -225,8 +225,8 @@ final class GlobalSearchFilterTest extends TestCase
         $expr = $this->createMock(Expr::class);
         $expr->expects($this->once())
             ->method('orX')
-            ->with("e.name LIKE :search_param_0 ESCAPE '!'")
-            ->willReturn(new Expr\Orx(["e.name LIKE :search_param_0 ESCAPE '!'"]));
+            ->with("LOWER(e.name) LIKE :search_param_0 ESCAPE '!'")
+            ->willReturn(new Expr\Orx(["LOWER(e.name) LIKE :search_param_0 ESCAPE '!'"]));
 
         $qb->method('expr')->willReturn($expr);
         $qb->expects($this->once())->method('andWhere')->willReturn($qb);
@@ -255,8 +255,8 @@ final class GlobalSearchFilterTest extends TestCase
         $expr = $this->createMock(Expr::class);
         $expr->expects($this->once())
             ->method('orX')
-            ->with("donorProvider.name LIKE :search_param_0 ESCAPE '!'")
-            ->willReturn(new Expr\Orx(["donorProvider.name LIKE :search_param_0 ESCAPE '!'"]));
+            ->with("LOWER(donorProvider.name) LIKE :search_param_0 ESCAPE '!'")
+            ->willReturn(new Expr\Orx(["LOWER(donorProvider.name) LIKE :search_param_0 ESCAPE '!'"]));
 
         $qb->method('expr')->willReturn($expr);
         $qb->expects($this->once())->method('andWhere')->willReturn($qb);
@@ -275,8 +275,8 @@ final class GlobalSearchFilterTest extends TestCase
         $expr = $this->createMock(Expr::class);
         $expr->expects($this->once())
             ->method('orX')
-            ->with("dp.name LIKE :search_param_0 ESCAPE '!'")
-            ->willReturn(new Expr\Orx(["dp.name LIKE :search_param_0 ESCAPE '!'"]));
+            ->with("LOWER(dp.name) LIKE :search_param_0 ESCAPE '!'")
+            ->willReturn(new Expr\Orx(["LOWER(dp.name) LIKE :search_param_0 ESCAPE '!'"]));
 
         $qb->method('expr')->willReturn($expr);
         $qb->expects($this->once())->method('andWhere')->willReturn($qb);
@@ -328,8 +328,8 @@ final class GlobalSearchFilterTest extends TestCase
         $expr = $this->createMock(Expr::class);
         $expr->expects($this->once())
             ->method('orX')
-            ->with("e.name LIKE :search_param_0 ESCAPE '!'")
-            ->willReturn(new Expr\Orx(["e.name LIKE :search_param_0 ESCAPE '!'"]));
+            ->with("LOWER(e.name) LIKE :search_param_0 ESCAPE '!'")
+            ->willReturn(new Expr\Orx(["LOWER(e.name) LIKE :search_param_0 ESCAPE '!'"]));
 
         $qb->method('expr')->willReturn($expr);
         $qb->expects($this->once())->method('andWhere')->willReturn($qb);

--- a/tests/Unit/Query/SearchConditionBuilderExecutionTest.php
+++ b/tests/Unit/Query/SearchConditionBuilderExecutionTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\DataTables\Tests\Unit\Query;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Pentiminax\UX\DataTables\Query\SearchConditionBuilder;
+use Pentiminax\UX\DataTables\Tests\Fixtures\Count\CountCustomer;
+use Pentiminax\UX\DataTables\Tests\Support\BuildsEntityManager;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Runs the generated LIKE condition against a real database.
+ *
+ * sqlite's LIKE is already case-insensitive for ASCII, so this does not prove the LOWER()
+ * behavior on PostgreSQL; what it does prove is that the generated DQL is valid and that
+ * lowercasing the bound term does not break matching.
+ *
+ * @internal
+ */
+#[CoversClass(SearchConditionBuilder::class)]
+final class SearchConditionBuilderExecutionTest extends TestCase
+{
+    use BuildsEntityManager;
+
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $this->em = $this->createEntityManager(CountCustomer::class);
+
+        $this->em->persist(new CountCustomer(1, 'Alice'));
+        $this->em->persist(new CountCustomer(2, 'Bob'));
+        $this->em->flush();
+        $this->em->clear();
+    }
+
+    #[Test]
+    public function it_matches_regardless_of_case_on_sqlite(): void
+    {
+        $qb = $this->em->createQueryBuilder()->select('e')->from(CountCustomer::class, 'e');
+
+        $qb->andWhere(SearchConditionBuilder::text($qb, 'e', 'name', 'ALI', 'param_0'));
+
+        $names = array_map(static fn (CountCustomer $c): string => $c->name, $qb->getQuery()->getResult());
+
+        $this->assertSame(['Alice'], $names);
+    }
+}

--- a/tests/Unit/Query/SearchConditionBuilderTest.php
+++ b/tests/Unit/Query/SearchConditionBuilderTest.php
@@ -29,7 +29,7 @@ final class SearchConditionBuilderTest extends TestCase
             'text',
             'name',
             'hello',
-            "e.name LIKE :param_0 ESCAPE '!'",
+            "LOWER(e.name) LIKE :param_0 ESCAPE '!'",
             ['param_0', '%hello%'],
             null,
         ];
@@ -38,7 +38,7 @@ final class SearchConditionBuilderTest extends TestCase
             'text',
             'author.firstName',
             'john',
-            "author.firstName LIKE :param_0 ESCAPE '!'",
+            "LOWER(author.firstName) LIKE :param_0 ESCAPE '!'",
             ['param_0', '%john%'],
             ['e.author', 'author'],
         ];
@@ -47,7 +47,7 @@ final class SearchConditionBuilderTest extends TestCase
             'text',
             'name',
             '50%_off',
-            "e.name LIKE :param_0 ESCAPE '!'",
+            "LOWER(e.name) LIKE :param_0 ESCAPE '!'",
             ['param_0', '%50!%!_off%'],
             null,
         ];
@@ -104,6 +104,51 @@ final class SearchConditionBuilderTest extends TestCase
         $result = SearchConditionBuilder::$method($qb, 'e', $fieldPath, $value, 'param_0');
 
         $this->assertSame($expectedCondition, $result);
+    }
+
+    #[Test]
+    public function it_lowercases_both_sides_by_default(): void
+    {
+        $qb = $this->createMock(QueryBuilder::class);
+        $qb->method('getDQLPart')->with('join')->willReturn([]);
+
+        $qb->expects($this->once())
+            ->method('setParameter')
+            ->with('param_0', '%alice%');
+
+        $result = SearchConditionBuilder::text($qb, 'e', 'name', 'ALiCe', 'param_0');
+
+        $this->assertSame("LOWER(e.name) LIKE :param_0 ESCAPE '!'", $result);
+    }
+
+    #[Test]
+    public function it_keeps_the_raw_field_when_the_column_is_case_sensitive(): void
+    {
+        $qb = $this->createMock(QueryBuilder::class);
+        $qb->method('getDQLPart')->with('join')->willReturn([]);
+
+        $qb->expects($this->once())
+            ->method('setParameter')
+            ->with('param_0', '%ALiCe%');
+
+        $result = SearchConditionBuilder::text($qb, 'e', 'name', 'ALiCe', 'param_0', caseSensitive: true);
+
+        $this->assertSame("e.name LIKE :param_0 ESCAPE '!'", $result);
+    }
+
+    #[Test]
+    public function it_escapes_wildcards_after_lowercasing_the_term(): void
+    {
+        $qb = $this->createMock(QueryBuilder::class);
+        $qb->method('getDQLPart')->with('join')->willReturn([]);
+
+        $qb->expects($this->once())
+            ->method('setParameter')
+            ->with('param_0', '%50!%!_off!!%');
+
+        $result = SearchConditionBuilder::text($qb, 'e', 'name', '50%_OFF!', 'param_0');
+
+        $this->assertSame("LOWER(e.name) LIKE :param_0 ESCAPE '!'", $result);
     }
 
     #[Test]

--- a/tests/Unit/Query/SearchConditionBuilderTest.php
+++ b/tests/Unit/Query/SearchConditionBuilderTest.php
@@ -131,7 +131,7 @@ final class SearchConditionBuilderTest extends TestCase
             ->method('setParameter')
             ->with('param_0', '%ALiCe%');
 
-        $result = SearchConditionBuilder::text($qb, 'e', 'name', 'ALiCe', 'param_0', caseSensitive: true);
+        $result = SearchConditionBuilder::text($qb, 'e', 'name', 'ALiCe', 'param_0', normalize: false);
 
         $this->assertSame("e.name LIKE :param_0 ESCAPE '!'", $result);
     }

--- a/tests/Unit/Query/Strategy/ComparisonSearchStrategyTest.php
+++ b/tests/Unit/Query/Strategy/ComparisonSearchStrategyTest.php
@@ -77,7 +77,7 @@ final class ComparisonSearchStrategyTest extends TestCase
         string $expectedParameter,
     ): void {
         $strategy = new ComparisonSearchStrategy($logic);
-        $column   = TextColumn::new('name')->setCaseSensitiveSearch();
+        $column   = TextColumn::new('name')->setSearchNormalization(false);
 
         $qb = $this->createMock(QueryBuilder::class);
 

--- a/tests/Unit/Query/Strategy/ComparisonSearchStrategyTest.php
+++ b/tests/Unit/Query/Strategy/ComparisonSearchStrategyTest.php
@@ -69,6 +69,29 @@ final class ComparisonSearchStrategyTest extends TestCase
         $strategy->apply($qb, $column, $search, 3, 'e');
     }
 
+    #[Test]
+    #[DataProvider('case_sensitive_cases')]
+    public function it_keeps_the_raw_column_when_the_column_opts_out_of_case_insensitive_search(
+        ColumnControlLogic $logic,
+        string $expectedExpression,
+        string $expectedParameter,
+    ): void {
+        $strategy = new ComparisonSearchStrategy($logic);
+        $column   = TextColumn::new('name')->setCaseSensitiveSearch();
+
+        $qb = $this->createMock(QueryBuilder::class);
+
+        $qb->expects($this->once())
+            ->method('andWhere')
+            ->with($expectedExpression);
+
+        $qb->expects($this->once())
+            ->method('setParameter')
+            ->with('column_control_param_3', $expectedParameter, null);
+
+        $strategy->apply($qb, $column, new ColumnControlSearch('Ali', $logic, 'text'), 3, 'e');
+    }
+
     /**
      * Two independent guards, both observable as "the query builder is never touched":
      * a LIKE against a uuid-typed column crashes on PostgreSQL and SQL Server, and a
@@ -345,29 +368,53 @@ final class ComparisonSearchStrategyTest extends TestCase
         yield 'starts' => [
             ColumnControlLogic::Starts,
             'Ali',
+            "LOWER(e.name) LIKE :column_control_param_3 ESCAPE '!'",
+            'ali%',
+        ];
+
+        yield 'ends' => [
+            ColumnControlLogic::Ends,
+            'Ice',
+            "LOWER(e.name) LIKE :column_control_param_3 ESCAPE '!'",
+            '%ice',
+        ];
+
+        yield 'notContains' => [
+            ColumnControlLogic::NotContains,
+            'ALI',
+            "LOWER(e.name) NOT LIKE :column_control_param_3 ESCAPE '!'",
+            '%ali%',
+        ];
+
+        yield 'starts with like wildcards is escaped, not interpreted' => [
+            ColumnControlLogic::Starts,
+            '50%_OFF',
+            "LOWER(e.name) LIKE :column_control_param_3 ESCAPE '!'",
+            '50!%!_off%',
+        ];
+    }
+
+    /**
+     * @return iterable<string, array{ColumnControlLogic, string, string}>
+     */
+    public static function case_sensitive_cases(): iterable
+    {
+        yield 'starts' => [
+            ColumnControlLogic::Starts,
             "e.name LIKE :column_control_param_3 ESCAPE '!'",
             'Ali%',
         ];
 
         yield 'ends' => [
             ColumnControlLogic::Ends,
-            'ice',
             "e.name LIKE :column_control_param_3 ESCAPE '!'",
-            '%ice',
+            '%Ali',
         ];
 
         yield 'notContains' => [
             ColumnControlLogic::NotContains,
-            'ali',
             "e.name NOT LIKE :column_control_param_3 ESCAPE '!'",
-            '%ali%',
-        ];
-
-        yield 'starts with like wildcards is escaped, not interpreted' => [
-            ColumnControlLogic::Starts,
-            '50%_off',
-            "e.name LIKE :column_control_param_3 ESCAPE '!'",
-            '50!%!_off%',
+            '%Ali%',
         ];
     }
 

--- a/tests/Unit/Query/Strategy/ContainsSearchStrategyTest.php
+++ b/tests/Unit/Query/Strategy/ContainsSearchStrategyTest.php
@@ -94,7 +94,7 @@ final class ContainsSearchStrategyTest extends TestCase
         ];
 
         yield 'text column opting out of case-insensitive search' => [
-            TextColumn::new('name')->setField('name')->setCaseSensitiveSearch(),
+            TextColumn::new('name')->setField('name')->setSearchNormalization(false),
             'text',
             3,
             'Foo',

--- a/tests/Unit/Query/Strategy/ContainsSearchStrategyTest.php
+++ b/tests/Unit/Query/Strategy/ContainsSearchStrategyTest.php
@@ -80,7 +80,7 @@ final class ContainsSearchStrategyTest extends TestCase
             'text',
             3,
             'foo',
-            "e.name LIKE :column_control_param_3 ESCAPE '!'",
+            "LOWER(e.name) LIKE :column_control_param_3 ESCAPE '!'",
             ['column_control_param_3', '%foo%'],
         ];
 
@@ -89,8 +89,17 @@ final class ContainsSearchStrategyTest extends TestCase
             'text',
             3,
             '50%_off',
-            "e.name LIKE :column_control_param_3 ESCAPE '!'",
+            "LOWER(e.name) LIKE :column_control_param_3 ESCAPE '!'",
             ['column_control_param_3', '%50!%!_off%'],
+        ];
+
+        yield 'text column opting out of case-insensitive search' => [
+            TextColumn::new('name')->setField('name')->setCaseSensitiveSearch(),
+            'text',
+            3,
+            'Foo',
+            "e.name LIKE :column_control_param_3 ESCAPE '!'",
+            ['column_control_param_3', '%Foo%'],
         ];
 
         yield 'numeric column uses exact match' => [


### PR DESCRIPTION
Closes #395.

## Problem

`SearchConditionBuilder::text()` emitted a bare `field LIKE :p ESCAPE '!'`, and `ComparisonSearchStrategy` did the same for its `starts` / `ends` / `notContains` logics. A bare `LIKE` is case-sensitive on PostgreSQL and on MySQL binary collations, so the same table answered differently depending on the database: searching `ali` found `Alice` on a MySQL `_ci` collation and nothing on PostgreSQL. `Filter\TextFilter` already compared `LOWER(field)` against an `mb_strtolower()`'d term — this aligns the rest of the server-side search on that model.

## Change

- `SearchConditionBuilder::text()` takes a new `bool $caseSensitive = false` and emits `LOWER(field) LIKE :p ESCAPE '!'` with a lowercased needle. Wildcard escaping is applied **after** lowercasing, so `50%_OFF` still binds as `%50!%!_off%`.
- `ComparisonSearchStrategy` applies the same treatment inside its `$usesLike` branch only. Comparison operators (`=`, `!=`, `<`, …) and the `DateTimeImmutable` / bool / numeric bind values are untouched.
- New opt-out `AbstractColumn::setCaseSensitiveSearch(bool $caseSensitive = true): static` with `isCaseSensitiveSearch()`, default `false`. It exists because `LOWER()` on the column prevents the database from using a plain index — the opt-out is what keeps a `starts` search sargable on a MySQL prefix index.

`SearchableColumnInterface` was deliberately **not** extended: it is a public contract, and adding a method there breaks every external implementation for the sake of one boolean. The flag is read as `$column instanceof AbstractColumn && $column->isCaseSensitiveSearch()`; columns implementing `ColumnInterface` directly are always case-insensitive, as documented on the setter. Not serialized to the frontend — the client never reads it.

Rejected alternatives: a custom DQL function (forces the host to register it and to prepend the `doctrine` config), `CAST`-based normalization, and a `UX_DATATABLES_SEARCH` configuration knob. `setSearchPredicate()` remains the escape hatch for what neither mode expresses.

## Blast radius

`SearchConditionBuilder::text()` has a single caller, `DefaultSearchPredicateBuilder::build()` — `GlobalSearchFilter`, `ColumnSearchFilter` and `ContainsSearchStrategy` all route through it, so the flag is read in one place. `ComparisonSearchStrategy` is the only other LIKE-building site. `Filter\TextFilter` was already compliant and is unchanged. In-memory search (`ArrayDataProvider`) and the non-LIKE `ColumnControlSearchFilter` branches are out of scope.

## Docs

- `UPGRADE.md` § `v0.90 → v1.0`: new "Case-insensitive server-side text search" subsection.
- `reference/search-strategies.mdx`: new "Case sensitivity" section; the predicate dispatch table now reads `LOWER(field) LIKE %term%`. The custom-strategy example demonstrated a case-insensitive `starts` — now the shipped behavior — so it was re-framed as a word-prefix search.
- `columns/overview.mdx`: `setCaseSensitiveSearch()` documented under "Sorting & Searching".

## Tests

`vendor/bin/phpunit` — 1491 tests, 5891 assertions, green.

- `SearchConditionBuilderTest`: `it_lowercases_both_sides_by_default`, `it_keeps_the_raw_field_when_the_column_is_case_sensitive`, `it_escapes_wildcards_after_lowercasing_the_term`.
- `SearchConditionBuilderExecutionTest` (new): runs the generated DQL against in-memory SQLite. SQLite's `LIKE` is already ASCII case-insensitive, so this proves the DQL is valid and the lowercased binding still matches — not the PostgreSQL behavior. Noted in the class docblock.
- `ComparisonSearchStrategyTest`: expectations adapted, plus an opt-out case per LIKE logic (`starts`, `ends`, `notContains`).
- `ContainsSearchStrategyTest`, `DefaultSearchPredicateBuilderTest`, `GlobalSearchFilterTest`, `ColumnSearchFilterTest`: DQL expectations adapted, opt-out cases added.
- `AbstractColumnTest`: setter/getter.

**Tested:** `composer fix`, `composer audit`, `vendor/bin/phpunit`, `npm run lint` and `npm run build` in `docs/`.
**Not tested:** PostgreSQL and MySQL binary collations — no integration environment in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
