### PR TITLE
Align ArrayDataProvider global search eligibility with the Doctrine filter

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -168,7 +168,7 @@ returns `false` from `isSearchNormalized()`.
 
 - Global search now reads the **source** value of each item (the property named by the column's
   field path) instead of every scalar cell of the mapped row, matching the Doctrine semantics. It
-  honors `isSearchable()` and `isGlobalSearchable()`, trims the term, and is case-insensitive. A
+  honors `isGlobalSearchable()`, trims the term, and is case-insensitive. A
   column with no matching source property — an `ActionColumn`, a `TemplateColumn`, or a column whose
   value only exists after mapping — is no longer searchable in memory.
 - Ordering compares the source value: strings with `strnatcasecmp()`, other values with `<=>`, rows

--- a/docs/src/content/docs/reference/data-providers-row-mappers.mdx
+++ b/docs/src/content/docs/reference/data-providers-row-mappers.mdx
@@ -71,7 +71,7 @@ the request are ignored, as the Doctrine provider ignores values for unconfigure
     ],
     [
       'Global search',
-      'Honored on columns that are both searchable and globally searchable. The term is trimmed and matching is case-insensitive.',
+      'Honored on globally searchable columns, as the Doctrine provider does. The term is trimmed and matching is case-insensitive.',
     ],
     ['Per-column search', 'Honored, cumulatively: a row must match every active column search.'],
     ['ColumnControl searches', 'Not supported — throws a `LogicException`.'],

--- a/src/DataProvider/ArrayDataProvider.php
+++ b/src/DataProvider/ArrayDataProvider.php
@@ -119,14 +119,17 @@ final class ArrayDataProvider implements DataProviderInterface, StreamingDataPro
             return $items;
         }
 
+        // Same eligibility as the Doctrine GlobalSearchFilter: isSearchable() only governs the
+        // per-column search box, and a term no column can carry filters nothing rather than
+        // everything.
         $globalColumns = array_values(array_filter(
             $intent->columns,
-            static fn (ColumnReadReference $column): bool => $column->searchable && $column->globalSearchable,
+            static fn (ColumnReadReference $column): bool => $column->globalSearchable,
         ));
 
         $matched = [];
         foreach ($items as $item) {
-            if (null !== $globalSearch && !$this->matchesAny($item, $globalColumns, $globalSearch)) {
+            if (null !== $globalSearch && [] !== $globalColumns && !$this->matchesAny($item, $globalColumns, $globalSearch)) {
                 continue;
             }
 

--- a/tests/Unit/DataProvider/ArrayDataProviderTest.php
+++ b/tests/Unit/DataProvider/ArrayDataProviderTest.php
@@ -179,6 +179,23 @@ final class ArrayDataProviderTest extends TestCase
         $this->assertSame([], iterator_to_array($result->data));
     }
 
+    /**
+     * The Doctrine GlobalSearchFilter reads isGlobalSearchable() only: setSearchable(false) turns
+     * off the per-column search box, not the global one.
+     */
+    #[Test]
+    public function it_applies_the_global_search_to_a_column_whose_column_search_is_disabled(): void
+    {
+        $columns    = self::columns();
+        $columns[1] = TextColumn::new('name')->setSearchable(false);
+
+        $result = (new ArrayDataProvider(self::people(), new CountingRowMapper(), $columns))->fetchData(
+            self::request(start: 0, length: 10, search: new Search('ali', false)),
+        );
+
+        $this->assertSame(2, $result->recordsFiltered);
+    }
+
     #[Test]
     public function it_applies_column_searches_cumulatively(): void
     {
@@ -216,16 +233,20 @@ final class ArrayDataProviderTest extends TestCase
     }
 
     #[Test]
-    public function it_does_not_search_non_searchable_columns(): void
+    public function it_ignores_a_column_search_on_a_non_searchable_column(): void
     {
         $columns    = self::columns();
         $columns[1] = TextColumn::new('name')->setSearchable(false);
 
         $result = (new ArrayDataProvider(self::people(), new CountingRowMapper(), $columns))->fetchData(
-            self::request(start: 0, length: 10, search: new Search('ali', false)),
+            self::request(
+                start: 0,
+                length: 10,
+                requestColumns: [self::requestColumn('name', new Search('alicia', false))],
+            ),
         );
 
-        $this->assertSame(0, $result->recordsFiltered);
+        $this->assertSame(4, $result->recordsFiltered);
     }
 
     /**


### PR DESCRIPTION
## Summary

Follow-up to #428, surfaced by Greptile while re-reviewing #429 against a stale base.

- `GlobalSearchFilter` (Doctrine) applies the global search to every column whose `isGlobalSearchable()` is true. `ArrayDataProvider` additionally required `isSearchable()`, so a column with `setSearchable(false)` was excluded from the in-memory global search while the Doctrine path searched it.
- Once no eligible column was left, `ArrayDataProvider` rejected every row of a global search. It now skips the global match instead, as the Doctrine filter emits no condition in that case.
- The previous test asserting the divergent behavior is rewritten to cover what `setSearchable(false)` actually governs: the per-column search box.
- Docs table and `UPGRADE.md` bullet updated.

## Test plan

- [x] `composer fix`
- [x] `vendor/bin/phpunit` (1504 tests)
- [x] `npm run lint` in `docs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
